### PR TITLE
Don't assume clocks are exactly equal on client and server

### DIFF
--- a/components/frontend/src/App.js
+++ b/components/frontend/src/App.js
@@ -23,7 +23,7 @@ class App extends Component {
 
   reload(event) {
     if (event) { event.preventDefault(); }
-    const report_date = this.report_date() || new Date();
+    const report_date = this.report_date() || new Date(3000, 12, 31);
     fetch(`${window.server_url}/datamodel?report_date=${report_date.toISOString()}`)
       .then(function (response) {
         return response.json();


### PR DESCRIPTION
When retrieving the latest datamodel and report use a date in the future to prevent problems with out-of-sync clocks between the client and the server.