### PR TITLE
The Trello parameter "lists to ignore" was not being displayed properly.

### DIFF
--- a/components/frontend/src/fields/StringInput.js
+++ b/components/frontend/src/fields/StringInput.js
@@ -27,9 +27,9 @@ function StringInputWithSuggestions(props) {
 }
 
 export function StringInput(props) {
-  const options = props.options || [];
+  const options = [...(props.options || [])].sort().map((value) => ({ key: value, value: value, text: value }));
   return props.readOnly || options.length === 0 ?
     <Input {...props} />
     :
-    <StringInputWithSuggestions {...props} />
+    <StringInputWithSuggestions {...props} options={options} />
 }

--- a/components/frontend/src/source/SourceParameter.js
+++ b/components/frontend/src/source/SourceParameter.js
@@ -17,13 +17,17 @@ export function SourceParameter(props) {
           if (source.type === props.source.type && source.parameters) {
             const value = source.parameters[props.parameter_key];
             if (value) {
-              values.add(value);
+              if (Array.isArray(value)) {
+                value.forEach((item) => values.add(item))
+              } else {
+                values.add(value)
+              }
             }
           }
         })
       })
     });
-    return [...values].sort().map((value) => ({ key: value, value: value, text: value }));
+    return values;
   }
   const label = props.help_url ?
     <label>{props.parameter_name} <a href={props.help_url}><Icon name="help circle" link /></a></label>
@@ -73,7 +77,7 @@ export function SourceParameter(props) {
       <MultipleChoiceInput
         allowAdditions
         label={label}
-        options={props.parameter_values}
+        options={options()}
         placeholder={props.placeholder}
         readOnly={props.readOnly}
         required={props.required}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- The Trello parameter "lists to ignore" wasn't being displayed properly. Fixes [#471](https://github.com/ICTU/quality-time/issues/471).
+
 ## [0.5.0] - [2019-07-16]
 
 ### Added


### PR DESCRIPTION
Fixes #471.