### PR TITLE
Rename 'ramp-up' to 'scalability'.

### DIFF
--- a/components/collector/src/source_collectors/performancetest_runner.py
+++ b/components/collector/src/source_collectors/performancetest_runner.py
@@ -87,7 +87,8 @@ class PerformanceTestRunnerScalability(SourceCollector):
     """Collector for the scalability metric."""
 
     def parse_source_responses_value(self, responses: List[requests.Response]) -> Value:
-        breaking_point = BeautifulSoup(responses[0].text, "html.parser").find(id="trendbreak_rampup").string
+        breaking_point = BeautifulSoup(responses[0].text, "html.parser").find(id="trendbreak_scalability").string
         if breaking_point == "100":
-            raise AssertionError("No performance breaking point occurred (breaking point is at 100%, expected < 100%)")
+            raise AssertionError(
+                "No performance scalability breaking point occurred (breaking point is at 100%, expected < 100%)")
         return breaking_point

--- a/components/collector/tests/unittests/source_collectors/test_performancetest_runner.py
+++ b/components/collector/tests/unittests/source_collectors/test_performancetest_runner.py
@@ -108,7 +108,7 @@ class PerformanceTestRunnerTest(unittest.TestCase):
         """Test that the percentage of the max users of the performancetest at which the ramp-up of throughput breaks is
         returned."""
         self.mock_response.text = '''<html><table class="config">
-            <tr><td class="name">Trendbreak 'ramp-up' (%)</td><td id="trendbreak_rampup">74</td></tr>
+            <tr><td class="name">Trendbreak 'scalability' (%)</td><td id="trendbreak_scalability">74</td></tr>
             </table></html>'''
         metric = dict(type="scalability", sources=self.sources, addition="min")
         with patch("requests.get", return_value=self.mock_response):
@@ -119,7 +119,7 @@ class PerformanceTestRunnerTest(unittest.TestCase):
         """Test that if the percentage of the max users of the performancetest at which the ramp-up of throughput breaks
         is 100%, the metric reports an error (since there is no breaking point)."""
         self.mock_response.text = '''<html><table class="config">
-            <tr><td class="name">Trendbreak 'ramp-up' (%)</td><td id="trendbreak_rampup">100</td></tr>
+            <tr><td class="name">Trendbreak 'scalability' (%)</td><td id="trendbreak_scalability">100</td></tr>
             </table></html>'''
         metric = dict(type="scalability", sources=self.sources, addition="min")
         with patch("requests.get", return_value=self.mock_response):

--- a/components/testdata/performancetest-runner-loadtestreport.html
+++ b/components/testdata/performancetest-runner-loadtestreport.html
@@ -196,7 +196,7 @@
 		Num of transactions exceeding 'red' threshold</td></tr>
 	<tr><td class="name">Baseline warnings<br><td>
 		Num of transactions with 'red' baseline delta% are evaluated</td></tr>
-	<tr><td class="name">Trendbreak 'ramp-up'<br><td>
+	<tr><td class="name">Trendbreak 'scalability'<br><td>
 		Percentage of (max) users at which ramp-up of throughput breaks</td></tr>
 	<tr><td class="name">Trendbreak 'stability'<br><td>
 		Progress of test at which stability of throughput or errorcount breaks</td></tr>
@@ -215,7 +215,7 @@
 	<tr><td class="name">Threshold violations</td><td id="threshold_violations">2</td></tr>
 	<tr><td class="name">Baseline warnings</td><td id="baseline_warnings">1</td></tr>
 	<tr><td>&nbsp</td><td></td></tr>
-	<tr><td class="name">Trendbreak 'ramp-up' (%)</td><td id="trendbreak_rampup">100</td></tr>
+	<tr><td class="name">Trendbreak 'scalability' (%)</td><td id="trendbreak_scalability">100</td></tr>
 	<tr><td class="name">Trendbreak 'stability' (%)</td><td id="trendbreak_stability">100</td></tr>
 	<tr><td>&nbsp</td><td></td></tr>
 	<tr><td class="name">Duration</td><td id="duration">00:34:53</td></tr>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- The performancetest-runner now uses "scalability" instead of "ramp-up" as name for the scalability measurement. Closes [#480](https://github.com/ICTU/quality-time/issues/471).
+
 ## [0.5.1] - [2019-07-18]
 
 ### Fixed


### PR DESCRIPTION
Closes #480.