### PR TITLE
When using OWASP ZAP reports as source for the security warnings metr…

### DIFF
--- a/components/server/src/data/datamodel.json
+++ b/components/server/src/data/datamodel.json
@@ -1710,6 +1710,11 @@
                         {
                             "name": "Description",
                             "key": "description"
+                        },
+                        {
+                            "name": "Location",
+                            "key": "location",
+                            "url": "uri"
                         }
                     ]
                 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- The performancetest-runner now uses "scalability" instead of "ramp-up" as name for the scalability measurement. Closes [#480](https://github.com/ICTU/quality-time/issues/471).
+- When using OWASP ZAP reports as source for the security warnings metric, report on the number of "instances" instead of "alert items". Fixes [#467](https://github.com/ICTU/quality-time/issues/467).
+- The performancetest-runner now uses "scalability" instead of "ramp-up" as name for the scalability measurement. Closes [#480](https://github.com/ICTU/quality-time/issues/480).
 
 ## [0.5.1] - [2019-07-18]
 


### PR DESCRIPTION
…ic, report on the number of "instances" instead of "alert items". Fixes #467.