### PR TITLE
OJAudit XML files may contain duplicate violations 

### DIFF
--- a/components/server/src/data/datamodel.json
+++ b/components/server/src/data/datamodel.json
@@ -1517,6 +1517,10 @@
                         {
                             "name": "Component",
                             "key": "component"
+                        },
+                        {
+                            "name": "Number of occurrences",
+                            "key": "count"
                         }
                     ]
                 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - When using OWASP ZAP reports as source for the security warnings metric, report on the number of "instances" instead of "alert items". Fixes [#467](https://github.com/ICTU/quality-time/issues/467).
 - Don't wait 15 minutes before trying to access a requested Checkmarx SAST XML report, but try again after one minute. Partial fix for [#468](https://github.com/ICTU/quality-time/issues/468).
 - The performancetest-runner now uses "scalability" instead of "ramp-up" as name for the scalability measurement. Closes [#480](https://github.com/ICTU/quality-time/issues/480).
+- OJAudit XML files may contain duplicate violations (i.e. same message, same severity, same model, same location, same everything) which led to problems in the user interface. Fixed by merging multiple duplication violations and adding a count field to the violations. Fixes [515](https://github.com/ICTU/quality-time/issues/515).
 - Stop sorting metrics when the user adds a new metric to prevent it from jumping around due to the sorting. Fixes [518](https://github.com/ICTU/quality-time/issues/518).
 
 ## [0.5.1] - [2019-07-18]


### PR DESCRIPTION
(i.e. same message, same severity, same model, same location, same everything) which led to problems in the user interface. Fixed by merging multiple duplication violations and adding a count field to the violations. Fixes #515.