### PR TITLE
Use Jenkins job timestamp for the source up-to-dateness metric if the…

### DIFF
--- a/components/collector/src/source_collectors/source_collector.py
+++ b/components/collector/src/source_collectors/source_collector.py
@@ -88,7 +88,7 @@ class SourceCollector:
         """Return the basic authentication credentials, if any."""
         token = cast(str, self.parameters.get("private_token", ""))
         if token:
-            return (token, "")
+            return token, ""
         username = cast(str, self.parameters.get("username", ""))
         password = cast(str, self.parameters.get("password", ""))
         return (username, password) if username and password else None

--- a/components/collector/tests/unittests/source_collectors_tests/test_jenkins_test_report.py
+++ b/components/collector/tests/unittests/source_collectors_tests/test_jenkins_test_report.py
@@ -1,6 +1,6 @@
 """Unit tests for the Jenkins test report source."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from .source_collector_test_case import SourceCollectorTestCase
 
@@ -39,3 +39,14 @@ class JenkinsTestReportTest(SourceCollectorTestCase):
             metric, get_request_json_return_value=dict(suites=[dict(timestamp="2019-04-02T08:52:50")]))
         expected_age = (datetime.now() - datetime(2019, 4, 2, 8, 52, 50)).days
         self.assert_value(str(expected_age), response)
+
+    def test_source_up_to_dateness_without_timestamps(self):
+        """Test that the job age in days is returned if the test report doesn't contain timestamps."""
+        metric = dict(type="source_up_to_dateness", addition="max", sources=self.sources)
+        response = self.collect(
+            metric,
+            get_request_json_side_effect=[
+                dict(suites=[dict(timestamp=None)]), dict(timestamp="1565284457173")])
+        expected_age = (datetime.now(timezone.utc) - datetime(2019, 8, 8, 17, 14, 17, 173, tzinfo=timezone.utc)).days
+        self.assert_value(str(expected_age), response)
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,8 +22,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - When using OWASP ZAP reports as source for the security warnings metric, report on the number of "instances" instead of "alert items". Fixes [#467](https://github.com/ICTU/quality-time/issues/467).
 - Don't wait 15 minutes before trying to access a requested Checkmarx SAST XML report, but try again after one minute. Partial fix for [#468](https://github.com/ICTU/quality-time/issues/468).
 - The performancetest-runner now uses "scalability" instead of "ramp-up" as name for the scalability measurement. Closes [#480](https://github.com/ICTU/quality-time/issues/480).
-- OJAudit XML files may contain duplicate violations (i.e. same message, same severity, same model, same location, same everything) which led to problems in the user interface. Fixed by merging multiple duplication violations and adding a count field to the violations. Fixes [515](https://github.com/ICTU/quality-time/issues/515).
-- Stop sorting metrics when the user adds a new metric to prevent it from jumping around due to the sorting. Fixes [518](https://github.com/ICTU/quality-time/issues/518).
+- OJAudit XML files may contain duplicate violations (i.e. same message, same severity, same model, same location, same everything) which led to problems in the user interface. Fixed by merging multiple duplication violations and adding a count field to the violations. Fixes [#515](https://github.com/ICTU/quality-time/issues/515).
+- Use Jenkins job timestamp for the source up-to-dateness metric if the Jenkins test report doesn't contain timestamps in the test report itself. Fixes [#517](https://github.com/ICTU/quality-time/issues/517).
+- Stop sorting metrics when the user adds a new metric to prevent it from jumping around due to the sorting. Fixes [#518](https://github.com/ICTU/quality-time/issues/518).
 
 ## [0.5.1] - [2019-07-18]
 


### PR DESCRIPTION
… Jenkins test report doesn't contain timestamps in the test report itself. Fixes #517.