### PR TITLE
Return a parse error if OWASP dependency report XML reports don't con…

### DIFF
--- a/components/collector/src/source_collectors/owasp_dependency_check.py
+++ b/components/collector/src/source_collectors/owasp_dependency_check.py
@@ -15,8 +15,10 @@ from .source_collector import SourceCollector
 class OWASPDependencyCheckSecurityWarnings(SourceCollector):
     """Collector to get security warnings from OWASP Dependency Check."""
 
+    allowed_root_tags = ["{https://jeremylong.github.io/DependencyCheck/dependency-check.2.0.xsd}analysis"]
+
     def parse_source_responses_value(self, responses: List[requests.Response]) -> Value:
-        tree, namespaces = parse_source_response_xml_with_namespace(responses[0])
+        tree, namespaces = parse_source_response_xml_with_namespace(responses[0], self.allowed_root_tags)
         return str(len(self.vulnerable_dependencies(tree, namespaces)))
 
     def vulnerable_dependencies(self, tree: Element, namespaces: Namespaces) -> List[Tuple[int, Element]]:
@@ -25,7 +27,7 @@ class OWASPDependencyCheckSecurityWarnings(SourceCollector):
                 if self.vulnerabilities(dependency, namespaces)]
 
     def parse_source_responses_entities(self, responses: List[requests.Response]) -> Entities:
-        tree, namespaces = parse_source_response_xml_with_namespace(responses[0])
+        tree, namespaces = parse_source_response_xml_with_namespace(responses[0], self.allowed_root_tags)
         landing_url = self.landing_url(responses)
         return [self.parse_entity(dependency, index, namespaces, landing_url) for (index, dependency)
                 in self.vulnerable_dependencies(tree, namespaces)]
@@ -61,7 +63,9 @@ class OWASPDependencyCheckSecurityWarnings(SourceCollector):
 class OWASPDependencyCheckSourceUpToDateness(SourceCollector):
     """Collector to collect the OWASP Dependency Check report age."""
 
+    allowed_root_tags = ["{https://jeremylong.github.io/DependencyCheck/dependency-check.2.0.xsd}analysis"]
+
     def parse_source_responses_value(self, responses: List[requests.Response]) -> Value:
-        tree, namespaces = parse_source_response_xml_with_namespace(responses[0])
+        tree, namespaces = parse_source_response_xml_with_namespace(responses[0], self.allowed_root_tags)
         report_datetime = isoparse(tree.findtext(".//ns:reportDate", default="", namespaces=namespaces))
         return str(days_ago(report_datetime))

--- a/components/collector/tests/unittests/source_collectors_tests/source_collector_test_case.py
+++ b/components/collector/tests/unittests/source_collectors_tests/source_collector_test_case.py
@@ -59,3 +59,7 @@ class SourceCollectorTestCase(unittest.TestCase):
     def assert_landing_url(self, expected_url: str, response: Response, source_index: int = 0) -> None:
         """Assert that the measurement response has the expected landing url."""
         self.assertEqual(expected_url, response["sources"][source_index]["landing_url"])
+
+    def assert_parse_error_contains(self, expected_parse_error: str, response: Response, source_index: int = 0) -> None:
+        """Assert that the measurement response has the expected parse error."""
+        self.assertIn(expected_parse_error, response["sources"][source_index]["parse_error"])

--- a/components/collector/tests/unittests/source_collectors_tests/test_owasp_dependency_check.py
+++ b/components/collector/tests/unittests/source_collectors_tests/test_owasp_dependency_check.py
@@ -70,6 +70,22 @@ class OWASPDependencyCheckTest(SourceCollectorTestCase):
             response)
         self.assert_value("1", response)
 
+    def test_invalid_xml(self):
+        """Test that the number of warnings is returned."""
+        xml = """<?xml version="1.0"?>
+        <analysis xmlns="https://jeremylong.github.io/DependencyCheck/dependency-check.2.1.xsd">
+        </analysis>"""
+        metric = dict(type="security_warnings", addition="sum", sources=self.sources)
+        response = self.collect(metric, get_request_text=xml)
+        self.assert_entities([], response)
+        self.assert_value(None, response)
+        self.maxDiff = None
+        self.assert_parse_error_contains("""
+AssertionError: The XML root element should be one of \
+"['{https://jeremylong.github.io/DependencyCheck/dependency-check.2.0.xsd}analysis']" but is \
+"{https://jeremylong.github.io/DependencyCheck/dependency-check.2.1.xsd}analysis"
+""", response)
+
     def test_source_up_to_dateness(self):
         """Test that the source age in days is returned."""
         xml = """<?xml version="1.0"?>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Break long urls in source error messages to keep the metrics table from becoming very wide. Fixes [#531](https://github.com/ICTU/quality-time/issues/531).
 - Don't try to retrieve more work items from Azure DevOps than allowed. Fixes [#532](https://github.com/ICTU/quality-time/issues/532).
+- Return a parse error if OWASP dependency report XML reports don't contain the expected root tag instead of reporting zero issues. Fixes [#536](https://github.com/ICTU/quality-time/issues/536).
 
 ## [0.6.0] - [2019-08-11]
 


### PR DESCRIPTION
…tain the expected root tag instead of reporting zero issues. Fixes #536.