### PR TITLE
When generating keys for OWASP ZAP security warnings, strip any hashes...

### DIFF
--- a/components/collector/src/source_collectors/owasp_zap.py
+++ b/components/collector/src/source_collectors/owasp_zap.py
@@ -8,7 +8,7 @@ from dateutil.parser import parse
 import requests
 
 from utilities.type import Entities, Value
-from utilities.functions import days_ago, parse_source_response_xml
+from utilities.functions import days_ago, hashless, parse_source_response_xml
 from .source_collector import SourceCollector
 
 
@@ -32,7 +32,7 @@ class OWASPZAPSecurityWarnings(SourceCollector):
             risk = alert.findtext("riskdesc", default="")
             for alert_instance in alert.findall("./instances/instance"):
                 method = alert_instance.findtext("method", default="")
-                uri = alert_instance.findtext("uri", default="")
+                uri = hashless(alert_instance.findtext("uri", default=""))
                 key = f"{alert_key}:{method}:{uri}"
                 entities.append(
                     dict(key=key, name=name, description=description, uri=uri, location=f"{method} {uri}", risk=risk))

--- a/components/collector/tests/unittests/utilities_tests/test_functions.py
+++ b/components/collector/tests/unittests/utilities_tests/test_functions.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timedelta, timezone
 import unittest
 
-from src.utilities.functions import days_ago, stable_traceback
+from src.utilities.functions import days_ago, hashless, stable_traceback
 
 
 class StableTracebackTest(unittest.TestCase):
@@ -40,3 +40,35 @@ class DaysAgoTest(unittest.TestCase):
         self.assertEqual(1, days_ago(datetime.now() - timedelta(hours=24)))
         self.assertEqual(1, days_ago(datetime.now(tz=timezone.utc) - timedelta(hours=47)))
         self.assertEqual(2, days_ago(datetime.now(tz=timezone.utc) - timedelta(hours=48)))
+
+
+class StripHashTest(unittest.TestCase):
+    """Unit tests for the strip hash method."""
+
+    def test_no_hash(self):
+        """Test that an url without hash is returned unchanged."""
+        expected_url = url = "http://www.google.com/"
+        self.assertEqual(expected_url, hashless(url))
+
+    def test_hash(self):
+        """Test that an url with hash is returned without the hash."""
+        url = "http://test.app.example.org:1234/main.58064cb8d36474bd79f9.js"
+        expected_url = "http://test.app.example.org:1234/main.hashremoved.js"
+        self.assertEqual(expected_url, hashless(url))
+
+    def test_uppercase_hash(self):
+        """Test that an url with uppercase hash is returned without the hash."""
+        url = "http://test.app.example.org:1234/main.58064CB8D36474BD79F9.js"
+        expected_url = "http://test.app.example.org:1234/main.hashremoved.js"
+        self.assertEqual(expected_url, hashless(url))
+
+    def test_long_hash(self):
+        """Test that an url with a long hash is returned without the hash."""
+        url = "http://test.app.example.org:1234/main.58064cb8d36474bd79f956dc4ac40404d.js"
+        expected_url = "http://test.app.example.org:1234/main.hashremoved.js"
+        self.assertEqual(expected_url, hashless(url))
+
+    def test_hash_in_host(self):
+        """Test that an url with a host name that matches the hash regular expression is returned unchanged."""
+        expected_url = url = "http://test.app58064cb8d36474bd79f9.example.org:1234/main.js"
+        self.assertEqual(expected_url, hashless(url))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- When generating keys for OWASP ZAP security warnings, strip any hashes from the application urls to ensure the keys are stable. Fixes [#541](https://github.com/ICTU/quality-time/issues/541).
 - In addition to version 2.0 also support version 2.1 and 2.2 of the OWASP Dependency Check XML format. Fixes [#543](https://github.com/ICTU/quality-time/issues/543).
 
 ## [0.7.0] - [2019-08-14]


### PR DESCRIPTION
from the application urls to ensure the keys are stable. Fixes #541.