### PR TITLE
When a user changes a password field, don't show the old password in …

### DIFF
--- a/components/server/src/routes/report.py
+++ b/components/server/src/routes/report.py
@@ -216,10 +216,9 @@ def post_source_parameter(report_uuid: str, source_uuid: str, parameter_key: str
     data = get_data(database, report_uuid, source_uuid=source_uuid)
     parameter_value = dict(bottle.request.json)[parameter_key]
     old_value = data.source["parameters"].get(parameter_key) or ""
-    data.source["parameters"][parameter_key] = parameter_value
-    new_value = "*" * len(parameter_value) \
-        if data.datamodel["sources"][data.source["type"]]["parameters"][parameter_key]["type"] == "password" \
-        else parameter_value
+    new_value = data.source["parameters"][parameter_key] = parameter_value
+    if data.datamodel["sources"][data.source["type"]]["parameters"][parameter_key]["type"] == "password":
+        new_value, old_value = "*" * len(parameter_value), "*" * len(old_value)
     data.report["delta"] = dict(
         report_uuid=report_uuid, subject_uuid=data.subject_uuid, metric_uuid=data.metric_uuid, source_uuid=source_uuid,
         description=f"{sessions.user(database)} changed the {parameter_key} of source '{data.source_name}' of metric "

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-- Nothing yet.
+### Fixed
+
+- When a user changes a password field, don't show the old password in the change log unmasked. Fixes [#565](https://github.com/ICTU/quality-time/issues/565).
 
 ## [0.8.0] - [2019-08-23]
 


### PR DESCRIPTION
…the change log unmasked. Fixes #565.