### PR TITLE
Changing the subject type now changes the subject name if the default…

### DIFF
--- a/components/frontend/src/subject/SubjectTitle.js
+++ b/components/frontend/src/subject/SubjectTitle.js
@@ -8,8 +8,9 @@ import { delete_subject, set_subject_attribute } from '../api/subject';
 
 export function SubjectTitle(props) {
     const current_subject_type = props.datamodel.subjects[props.subject.type] || { name: "Unknown subject type", description: "No description" };
+    const subject_name = props.subject.name || current_subject_type.name;
     return (
-        <HeaderWithDetails level="h2" header={props.subject.name} style={{ marginTop: 50 }}>
+        <HeaderWithDetails level="h2" header={subject_name} style={{ marginTop: 50 }}>
             <Segment>
                 <Header>
                     <Header.Content>

--- a/components/server/src/database/datamodels.py
+++ b/components/server/src/database/datamodels.py
@@ -54,4 +54,4 @@ def default_subject_attributes(database: Database, subject_type: str = "") -> Di
     if not subject_type:
         subject_type = list(subject_types.keys())[0]
     defaults = subject_types[subject_type]
-    return dict(type=subject_type, name=defaults["name"], description=defaults["description"], metrics=dict())
+    return dict(type=subject_type, name=None, description=defaults["description"], metrics=dict())

--- a/components/server/tests/unittests/routes/test_datamodel.py
+++ b/components/server/tests/unittests/routes/test_datamodel.py
@@ -44,12 +44,12 @@ class DatamodelTest(unittest.TestCase):
                     parameter=dict(default_value="name", metrics=["metric_type"])))))
         self.assertEqual(dict(parameter="name"), default_source_parameters(database, "metric_type", "source_type"))
 
-    def test_default_subject_attribures(self):
+    def test_default_subject_attributes(self):
         """Test that the default subject attributes can be retrieved from the datamodel."""
         database = Mock()
         database.datamodels.find_one.return_value = dict(
             _id=123,
             subjects=dict(subject_type=dict(name="name", description="description")))
         self.assertEqual(
-            dict(name="name", description="description", type="subject_type", metrics={}),
+            dict(name=None, description="description", type="subject_type", metrics={}),
             default_subject_attributes(database, "subject_type"))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Changing the subject type now changes the subject name if the default subject name has not been overridden. Fixes [#553](https://github.com/ICTU/quality-time/issues/553).
 - When a user changes a password field, don't show the old password in the change log unmasked. Fixes [#565](https://github.com/ICTU/quality-time/issues/565).
 - Use <= and >= for the metric direction in the metric tables instead of < and >. Fixes [#567](https://github.com/ICTU/quality-time/issues/565).
 


### PR DESCRIPTION
… subject name has not been overridden. Fixes #553.