### PR TITLE
To prevent reporting Checkmarx internal server errors to users when r…

### DIFF
--- a/components/collector/src/source_collectors/cxsast.py
+++ b/components/collector/src/source_collectors/cxsast.py
@@ -114,9 +114,9 @@ class CxSASTSecurityWarnings(CxSASTBase):
             if len(responses) > self.XML_REPORT_RESPONSE else []
 
     def next_collection(self) -> datetime:
-        """If the CxSAST report is in process, try again as soon as possible, otherwise return the regular next
-        collection datetime."""
-        return datetime.min if self.__report_status == "InProcess" else super().next_collection()
+        """If the CxSAST report is deleted or in process, try again as soon as possible, otherwise return the regular
+        next collection datetime."""
+        return datetime.min if self.__report_status in ("Deleted", "InProcess") else super().next_collection()
 
     def __parse_xml_report(self, xml_string: str) -> Entities:
         """Get the entities from the CxSAST XML report."""

--- a/components/collector/tests/unittests/source_collectors_tests/source_collector_test_case.py
+++ b/components/collector/tests/unittests/source_collectors_tests/source_collector_test_case.py
@@ -24,6 +24,7 @@ class SourceCollectorTestCase(unittest.TestCase):
                 get_request_json_return_value=None,
                 get_request_json_side_effect=None,
                 get_request_text="",
+                get_request_raise_for_status_side_effect=None,
                 post_request_side_effect=None,
                 post_request_json_return_value=None,
                 post_request_json_side_effect=None):
@@ -34,6 +35,8 @@ class SourceCollectorTestCase(unittest.TestCase):
         else:
             mock_get_request.json.return_value = get_request_json_return_value
         mock_get_request.text = get_request_text
+        if get_request_raise_for_status_side_effect:
+            mock_get_request.raise_for_status.side_effect = get_request_raise_for_status_side_effect
         mock_post_request = Mock()
         if post_request_json_side_effect:
             mock_post_request.json.side_effect = post_request_json_side_effect

--- a/components/collector/tests/unittests/source_collectors_tests/test_cxsast.py
+++ b/components/collector/tests/unittests/source_collectors_tests/test_cxsast.py
@@ -2,6 +2,8 @@
 
 from datetime import datetime, timezone
 
+from requests import HTTPError
+
 from source_collectors.cxsast import CxSASTSecurityWarnings
 from .source_collector_test_case import SourceCollectorTestCase
 
@@ -97,3 +99,24 @@ class CxSASTSecurityWarningsTest(CxSASTTestCase):
             [dict(key="1", location="file:42:2", name="Name", severity="High", url="http://deeplink")],
             response)
         self.assertNotEqual(datetime.min, self.collector.next_collection())
+
+    def test_report_deleted(self):
+        """Test that a new report will be requested when a previously created report was deleted on the Checkmarx
+        server."""
+        CxSASTSecurityWarnings.CXSAST_SCAN_REPORTS[1000] = 1
+        get_json = [
+            [dict(name="project", id="id")],
+            [dict(id=1000)],
+            dict(status=dict(value="Created")),
+            dict(highSeverity=1, mediumSeverity=2, lowSeverity=3, infoSeverity=4),
+            [dict(name="project", id="id")],
+            [dict(id=1000)],
+            dict(status=dict(value="Created"))]
+        http_errors = [None, None, None, None, HTTPError(500)]
+        post_json = [dict(access_token="token")] * 2
+        response = self.collect(
+            self.metric, get_request_json_side_effect=get_json, get_request_raise_for_status_side_effect=http_errors,
+            post_request_json_side_effect=post_json)
+        self.assert_value("10", response)
+        self.assert_entities([], response)
+        self.assertFalse(1000 in CxSASTSecurityWarnings.CXSAST_SCAN_REPORTS)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- To prevent reporting Checkmarx internal server errors to users when reports are unexpectedly unavailable, don't immediately remove a Checkmarx report after reading it, but silently ignore a removed report and create a new one. Fixes [#468](https://github.com/ICTU/quality-time/issues/468).
 - Prevent locked accounts by not contacting a source again after receiving a 401 (unauthorized) or 403 (forbidden) HTTP status, until the metric's configuration changes. Fixes [#604](https://github.com/ICTU/quality-time/issues/604).
 
 ## [0.9.0] - [2019-09-06]


### PR DESCRIPTION
…eports are unexpectedly unavailable, don't immediately remove a Checkmarx report after reading it, but silently ignore a removed report and create a new one. Fixes #468.