### PR TITLE
Allow for specifying which test results (skipped, failed, errored, an…

### DIFF
--- a/components/collector/tests/unittests/source_collectors_tests/test_sonarqube.py
+++ b/components/collector/tests/unittests/source_collectors_tests/test_sonarqube.py
@@ -129,7 +129,26 @@ class SonarQubeTest(SourceCollectorTestCase):
         metric = dict(type="tests", addition="sum", sources=self.sources)
         response = self.collect(metric, get_request_json_return_value=json)
         self.assert_value("123", response)
-        self.assert_total("100", response)
+        self.assert_total("123", response)
+
+    def test_nr_of_skipped_tests(self):
+        """Test that the number of skipped tests is returned."""
+        json = dict(
+            component=dict(measures=[dict(metric="tests", value="123"), dict(metric="skipped_tests", value="4")]))
+        self.sources["source_id"]["parameters"]["test_result"] = ["skipped"]
+        metric = dict(type="tests", addition="sum", sources=self.sources)
+        response = self.collect(metric, get_request_json_return_value=json)
+        self.assert_value("4", response)
+        self.assert_total("123", response)
+
+    def test_nr_of_tests_without_tests(self):
+        """Test that the collector throws an exception if there are no tests."""
+        json = dict(component=dict(measures=[]))
+        metric = dict(type="tests", addition="sum", sources=self.sources)
+        response = self.collect(metric, get_request_json_return_value=json)
+        self.assert_value(None, response)
+        self.assert_total(None, response)
+        self.assert_parse_error_contains("KeyError", response)
 
     def test_failed_tests(self):
         """Test that the number of failed tests is returned."""

--- a/components/server/src/data/datamodel.json
+++ b/components/server/src/data/datamodel.json
@@ -2656,6 +2656,21 @@
                         "violations"
                     ]
                 },
+                "test_result": {
+                    "name": "Test result",
+                    "type": "multiple_choice",
+                    "mandatory": false,
+                    "default_value": "",
+                    "values": [
+                        "errored",
+                        "failed",
+                        "passed",
+                        "skipped"
+                    ],
+                    "metrics": [
+                        "tests"
+                    ]
+                },
                 "commented_out_rules": {
                     "name": "Rules",
                     "type": "multiple_choice_with_addition",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- Allow for specifying which test results (skipped, failed, errored, and/or passed) to count when using SonarQube as source for the "Tests" metric. Fixes [#634](https://github.com/ICTU/quality-time/issues/634).  
+
 ## [0.10.2] - [2019-09-26]
 
 ### Fixed


### PR DESCRIPTION
…d/or passed) to count when using SonarQube as source for the Tests metric. Fixes #634.