### PR TITLE
Add Azure DevOps as source for the Tests metric. 

### DIFF
--- a/components/server/src/data/datamodel.json
+++ b/components/server/src/data/datamodel.json
@@ -533,6 +533,7 @@
             "near_target": "0",
             "default_source": "jenkins_test_report",
             "sources": [
+                "azure_devops",
                 "jenkins_test_report",
                 "junit",
                 "manual_number",
@@ -755,6 +756,7 @@
                         "issues",
                         "ready_user_story_points",
                         "source_up_to_dateness",
+                        "tests",
                         "unmerged_branches"
                     ]
                 },
@@ -768,6 +770,7 @@
                         "issues",
                         "ready_user_story_points",
                         "source_up_to_dateness",
+                        "tests",
                         "unmerged_branches"
                     ]
                 },
@@ -809,6 +812,21 @@
                     "default_value": "7",
                     "metrics": [
                         "unmerged_branches"
+                    ]
+                },
+                "test_result": {
+                    "name": "Test result",
+                    "type": "multiple_choice",
+                    "mandatory": false,
+                    "default_value": "",
+                    "values": [
+                        "incomplete",
+                        "failed",
+                        "not applicable",
+                        "passed"
+                    ],
+                    "metrics": [
+                        "tests"
                     ]
                 }
             },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add NCover coverage reports as source for the test coverage metrics. Closes [#635](https://github.com/ICTU/quality-time/issues/635).
+- Add Azure DevOps as source for the "Tests" metric. Requires Azure Devops Server or Service 2019. Closes [#639](https://github.com/ICTU/quality-time/issues/639).
 - Add Azure DevOps as source for the "Source up-to-dateness" metric. Closes [#640](https://github.com/ICTU/quality-time/issues/640).
 - Add Azure DevOps as source for the "Unmerged branches" metric. Closes [#641](https://github.com/ICTU/quality-time/issues/641).
 - Add percentage scale to the "Complex units", "Many parameters", "Long units", and "Suppressed violations" metrics. Closes [#645](https://github.com/ICTU/quality-time/issues/645).


### PR DESCRIPTION
Requires Azure Devops Server or Service 2019. Closes #639.