### PR TITLE
Allow for specifying the repository when using Azure DevOps as source…

### DIFF
--- a/components/collector/src/source_collectors/azure_devops.py
+++ b/components/collector/src/source_collectors/azure_devops.py
@@ -90,12 +90,12 @@ class AzureDevopsSourceUpToDateness(SourceCollector):
 
     def _api_url(self) -> URL:
         url = super()._api_url()
-        project = str(url).split("/")[-1]
+        repository = self._parameter("repository", quote=True)
         path = self._parameter("file_path", quote=True)
         branch = self._parameter("branch", quote=True)
         search_criteria = \
             f"searchCriteria.itemPath={path}&searchCriteria.itemVersion.version={branch}&searchCriteria.$top=1"
-        return URL(f"{url}/_apis/git/repositories/{project}/commits?{search_criteria}&api-version=4.1")
+        return URL(f"{url}/_apis/git/repositories/{repository}/commits?{search_criteria}&api-version=4.1")
 
     def _parse_source_responses_value(self, responses: Responses) -> Value:
         return str(days_ago(parse(responses[0].json()["value"][0]["committer"]["date"])))

--- a/components/collector/tests/unittests/source_collectors_tests/test_ncover.py
+++ b/components/collector/tests/unittests/source_collectors_tests/test_ncover.py
@@ -56,5 +56,6 @@ class NCoverTest(SourceCollectorTestCase):
             ncover.serverRoot = 'http://127.0.0.1:11235';
             ncover.createDateTime = '1440425155042';
         </script>""")
-        expected_age = (datetime.utcnow() - datetime.fromtimestamp(1440425155042 / 1000.)).days
+        report_datetime = datetime.fromtimestamp(1440425155042 / 1000.)
+        expected_age = (datetime.now(tz=report_datetime.tzinfo) - report_datetime).days
         self.assert_value(str(expected_age), response)

--- a/components/server/src/data/datamodel.json
+++ b/components/server/src/data/datamodel.json
@@ -794,6 +794,15 @@
                         "source_up_to_dateness"
                     ]
                 },
+                "repository": {
+                    "name": "Repository (id or name)",
+                    "type": "string",
+                    "mandatory": true,
+                    "default_value": "",
+                    "metrics": [
+                        "source_up_to_dateness"
+                    ]
+                },
                 "branch": {
                     "name": "Branch",
                     "type": "string",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- Allow for specifying the repository when using Azure DevOps as source for the "Source up-to-dateness" metric instead of assuming that the repository has the same name as the project. Fixes [#663](https://github.com/ICTU/quality-time/issues/663).
+
 ## [0.12.0] - [2019-10-11]
 
 ### Fixed


### PR DESCRIPTION
… for the 'Source up-to-dateness' metric instead of assuming that the repository has the same name as the project. Fixes #663.