### PR TITLE
Issue 711 landing url

### DIFF
--- a/components/collector/src/source_collectors/gitlab.py
+++ b/components/collector/src/source_collectors/gitlab.py
@@ -119,6 +119,9 @@ class GitlabUnmergedBranches(GitlabBase, UnmergedBranchesSourceCollector):
     def _api_url(self) -> URL:
         return self._gitlab_api_url("repository/branches")
 
+    def _landing_url(self, responses: Responses) -> URL:
+        return URL(f"{str(super()._landing_url(responses))}/{self._parameter('project')}/-/branches")
+
     def _unmerged_branches(self, responses: Responses) -> List:
         return [branch for branch in responses[0].json() if not branch["default"] and not branch["merged"] and
                 self._commit_age(branch).days > int(cast(str, self._parameter("inactive_days")))]

--- a/components/collector/tests/unittests/source_collectors_tests/test_gitlab.py
+++ b/components/collector/tests/unittests/source_collectors_tests/test_gitlab.py
@@ -14,7 +14,8 @@ class GitLabTestCase(SourceCollectorTestCase):
             source_id=dict(
                 type="gitlab",
                 parameters=dict(
-                    url="https://gitlab/", project="project", file_path="file", branch="branch", inactive_days="7")))
+                    url="https://gitlab/", project="namespace/project", file_path="file", branch="branch",
+                    inactive_days="7")))
 
 
 class GitLabFailedJobsTest(GitLabTestCase):
@@ -47,7 +48,8 @@ class GitLabFailedJobsTest(GitLabTestCase):
         self.sources["source_id"]["parameters"]["private_token"] = "token"
         response = self.collect(self.metric)
         self.assert_measurement(
-            response, api_url="https://gitlab/api/v4/projects/project/jobs?per_page=100&private_token=token",
+            response,
+            api_url="https://gitlab/api/v4/projects/namespace%2Fproject/jobs?per_page=100&private_token=token",
             parse_error="Traceback")
 
 
@@ -101,4 +103,5 @@ class GitlabUnmergedBranchesTest(GitLabTestCase):
         expected_age = str((datetime.now(timezone.utc) - datetime(2019, 4, 2, 9, 33, 4, tzinfo=timezone.utc)).days)
         expected_entities = [
             dict(key="unmerged_branch", name="unmerged_branch", commit_age=expected_age, commit_date="2019-04-02")]
-        self.assert_measurement(response, value="1", entities=expected_entities)
+        self.assert_measurement(
+            response, value="1", entities=expected_entities, landing_url="https://gitlab/namespace/project/-/branches")

--- a/components/server/src/data/datamodel.json
+++ b/components/server/src/data/datamodel.json
@@ -797,10 +797,12 @@
                 "repository": {
                     "name": "Repository (name or id)",
                     "type": "string",
-                    "mandatory": true,
+                    "placeholder": "default repository",
+                    "mandatory": false,
                     "default_value": "",
                     "metrics": [
-                        "source_up_to_dateness"
+                        "source_up_to_dateness",
+                        "unmerged_branches"
                     ]
                 },
                 "branch": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Added
+
+- When measuring unmerged branches, have the metric landing url point to the list of branches in GitLab or Azure DevOps. When measuring the source up-to-dateness of a folder or file in GitLab or Azure DevOps, have the metric landing url point to the folder or file. Closes [#711](https://github.com/ICTU/quality-time/issues/711). 
+
 ## [0.13.0] - [2019-10-20]
 
 ### Added


### PR DESCRIPTION
When measuring unmerged branches, have the metric landing url point to the list of branches in GitLab or Azure DevOps. When measuring the source up-to-dateness of a folder or file in GitLab or Azure DevOps, have the metric landing url point to the folder or file. Closes #711.
