### PR TITLE
Add keep-alive messages to the server-sent events stream...

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             cd components/collector
             python -m venv venv
             . venv/bin/activate
-            pip install -r requirements.txt -r requirements-dev.txt
+            pip install --progress-bar off -r requirements.txt -r requirements-dev.txt
             ci/unittest.sh
             ci/quality.sh
 
@@ -26,7 +26,7 @@ jobs:
             cd components/server
             python -m venv venv
             . venv/bin/activate
-            pip install -r requirements.txt -r requirements-dev.txt
+            pip install --progress-bar off -r requirements.txt -r requirements-dev.txt
             ci/unittest.sh
             ci/quality.sh
 

--- a/components/server/src/routes/measurement.py
+++ b/components/server/src/routes/measurement.py
@@ -82,6 +82,8 @@ def stream_nr_measurements(report_uuid: ReportId, database: Database) -> Iterato
             event_id += 1
             logging.info("Updating nr_measurements stream for report %s with %s measurements", report_uuid, data)
             yield sse_pack(event_id, "delta", data)
+        else:
+            yield ": keep-alive\n\n"
 
 
 @bottle.get("/api/v1/measurements/<metric_uuid>")

--- a/components/server/tests/unittests/routes/test_measurement.py
+++ b/components/server/tests/unittests/routes/test_measurement.py
@@ -150,4 +150,5 @@ class StreamNrMeasurementsTest(unittest.TestCase):
         with patch("time.sleep", sleep):
             stream = stream_nr_measurements("report_uuid", database)
             self.assertEqual("retry: 2000\nid: 0\nevent: init\ndata: 42\n\n", next(stream))
+            self.assertEqual(": keep-alive\n\n", next(stream))
             self.assertEqual("retry: 2000\nid: 1\nevent: delta\ndata: 43\n\n", next(stream))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- Add keep-alive messages to the server-sent events stream so it does not time out when there are no new measurements for a while. Fixes [#787](https://github.com/ICTU/quality-time/issues/787).
+
 ## [0.17.0] - [2019-11-10]
 
 ### Fixed


### PR DESCRIPTION
...so it does not time out when there are no new measurements for a while. Fixes #787.