### PR TITLE
Show the five most recent changes in the change log table initially s…

### DIFF
--- a/components/frontend/src/changelog/ChangeLog.js
+++ b/components/frontend/src/changelog/ChangeLog.js
@@ -25,7 +25,7 @@ export function ChangeLog(props) {
     if (props.source_uuid) {
         scope = "Changes to this source";
     }
-    const [nrChanges, setNrChanges] = useState(10);
+    const [nrChanges, setNrChanges] = useState(5);
     const [changes, setChanges] = useState([]);
     useEffect(() => {
         let uuids = {};

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added a button (expand a report title to access it) to download a PDF version of a report. The PDF report can also be downloaded via the API: `http://www.quality-time.example.org/api/v1/report/<report_uuid>/pdf`.
 Closes [#828](https://github.com/ICTU/quality-time/issues/828).
 
+### Changed
+
+- Show the five most recent changes in the change log table initially so that the buttons below the change log table don't disappear off screen. Each click on the "load more changes" button still loads ten more changes. Closes [#836](https://github.com/ICTU/quality-time/issues/836).
 ## [1.0.0] - [2019-11-28]
 
 ### Fixed


### PR DESCRIPTION
…o that the buttons below the change log table don't disappear off screen. Each click on the 'load more changes' button still loads ten more changes. Closes #836.