### PR TITLE
Center the status column so that the trend graphs and the status icon…

### DIFF
--- a/components/frontend/src/metric/Measurement.js
+++ b/components/frontend/src/metric/Measurement.js
@@ -53,7 +53,7 @@ export function Measurement(props) {
     <TableRowWithDetails id={props.metric_uuid} positive={status === "target_met"} negative={status === "target_not_met"} warning={status === "near_target_met"} active={status === "debt_target_met"} details={details}>
       <Table.Cell>{metric_name}</Table.Cell>
       <Table.Cell><TrendSparkline measurements={latest_measurements} scale={metric_scale} /></Table.Cell>
-      <Table.Cell><StatusIcon status={status} /></Table.Cell>
+      <Table.Cell textAlign='center'><StatusIcon status={status} /></Table.Cell>
       <Table.Cell><MeasurementValue /></Table.Cell>
       <Table.Cell>{measurement_target()}</Table.Cell>
       <Table.Cell>{measurement_sources()}</Table.Cell>

--- a/components/frontend/src/subject/Subject.js
+++ b/components/frontend/src/subject/Subject.js
@@ -108,10 +108,10 @@ export function Subject(props) {
       metric_components.reverse()
     }
   }
-  function SortableHeader({ column, label }) {
+  function SortableHeader({ column, label, textAlign }) {
     const sorted = sortColumn === column ? sortDirection : null;
     return (
-      <Table.HeaderCell onClick={() => handleSort(column)} sorted={sorted}>
+      <Table.HeaderCell onClick={() => handleSort(column)} sorted={sorted} textAlign={textAlign || 'left'}>
         {label}
       </Table.HeaderCell>
     )
@@ -138,7 +138,7 @@ export function Subject(props) {
           <FilterHeader/>
           <SortableHeader column='name' label='Metric' />
           <Table.HeaderCell width="2">Trend (7 days)</Table.HeaderCell>
-          <SortableHeader column='status' label='Status' />
+          <SortableHeader column='status' label='Status' textAlign='center' />
           <SortableHeader column='measurement' label='Measurement' />
           <SortableHeader column='target' label='Target' />
           <SortableHeader column='source' label='Source' />

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Sorting of metrics by measurement value, target value, and status did not work. Fixes [#981](https://github.com/ICTU/quality-time/issues/981).
 
+### Changed
+
+- Center the status column so that the trend graphs and the status icons have a bit more space between them. Closes [#985](https://github.com/ICTU/quality-time/issues/985). 
+
 ## [1.4.0] - [2020-01-31]
 
 ### Added


### PR DESCRIPTION
…s have a bit more space between them. Closes #985.