### PR TITLE
When using Jira as source for the Issues metric, the URL to Jira in t…

### DIFF
--- a/components/collector/src/source_collectors/jira.py
+++ b/components/collector/src/source_collectors/jira.py
@@ -25,7 +25,7 @@ class JiraIssues(SourceCollector):
     def _landing_url(self, responses: Responses) -> URL:
         url = super()._landing_url(responses)
         jql = str(self._parameter("jql", quote=True))
-        return URL(f"{url}/issues?jql={jql}")
+        return URL(f"{url}/issues/?jql={jql}")
 
     def _parameter(self, parameter_key: str, quote: bool = False) -> Union[str, List[str]]:
         parameter_value = super()._parameter(parameter_key, quote)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Sorting of metrics by measurement value, target value, and status did not work. Fixes [#981](https://github.com/ICTU/quality-time/issues/981).
 - Exporting tag reports to PDF did not work. Fixes [#990](https://github.com/ICTU/quality-time/issues/990). 
+- When using Jira as source for the Issues metric, the URL to Jira in the metrics table would not work properly. Fixes [#991](https://github.com/ICTU/quality-time/issues/991). 
 
 ### Changed
 


### PR DESCRIPTION
…he metrics table would not work properly. Fixes #991.