### PR TITLE
Changes made to violations, issues, warnings, etc., such as marking t…

### DIFF
--- a/components/server/src/database/measurements.py
+++ b/components/server/src/database/measurements.py
@@ -117,8 +117,8 @@ def determine_measurement_status(database: Database, metric, measurement_value: 
     return status
 
 
-def changelog(database: Database, metric_uuid: MetricId, nr_changes: int):
-    """Return the changelog for the measurements of a specific metric."""
+def changelog(database: Database, nr_changes: int, **uuids):
+    """Return the changelog for the measurements belonging the items with the specific uuids."""
     return database.measurements.find(
-        filter={"metric_uuid": metric_uuid, "delta": {"$exists": True}}, sort=[("start", pymongo.DESCENDING)],
+        filter={"delta.uuids": {"$in": list(uuids.values())}}, sort=[("start", pymongo.DESCENDING)],
         limit=nr_changes, projection=["delta", "start"])

--- a/components/server/src/routes/changelog.py
+++ b/components/server/src/routes/changelog.py
@@ -14,7 +14,8 @@ def _get_changelog(database: Database, nr_changes: str, **uuids: str):
         dict(
             delta=item["delta"]["description"], email=item["delta"].get("email", ""),
             timestamp=item.get("timestamp") or item["start"])
-        for item in measurements.changelog(database, limit, **uuids) + reports.changelog(database, limit, **uuids)]
+        for item in
+        list(measurements.changelog(database, limit, **uuids)) + list(reports.changelog(database, limit, **uuids))]
     return dict(changelog=sorted(changes, reverse=True, key=lambda change: change["timestamp"])[:limit])
 
 

--- a/components/server/tests/routes/test_measurement.py
+++ b/components/server/tests/routes/test_measurement.py
@@ -178,7 +178,8 @@ class SetEntityAttributeTest(unittest.TestCase):
         entity = measurement["sources"][0]["entity_user_data"]["entity_key"]
         self.assertEqual(dict(attribute="value"), entity)
         self.assertEqual(
-            dict(description="John changed the attribute of 'entity title' from '' to 'value'.", email=JOHN["email"]),
+            dict(description="John changed the attribute of 'entity title' from '' to 'value'.", email=JOHN["email"],
+                 uuids=[REPORT_ID, SUBJECT_ID, METRIC_ID, SOURCE_ID]),
             measurement["delta"])
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Don't refresh the change log when clicking the "Download report as pdf" button. Fixes [#1015](https://github.com/ICTU/quality-time/issues/1015). 
-- Make proxy port configurable. Fixes [#1018](https://github.com/ICTU/quality-time/issues/1018). 
+- Don't refresh the change log when clicking the "Download report as pdf" button. Fixes [#1015](https://github.com/ICTU/quality-time/issues/1015).
+- Make proxy port configurable. Fixes [#1018](https://github.com/ICTU/quality-time/issues/1018).
+- Changes made to violations, issues, warnings, etc., such as marking them as false positive, were only visible in the metric change log and not in the change logs of the report, subject, and source. Note: because a change needed to be made to the database format to fix this, changes made to violations, issues, warnings, etc. before this release are not visible in the change log. Fixes [#1019](https://github.com/ICTU/quality-time/issues/1019).
 
 ## [1.6.0] - [2020-02-12]
 


### PR DESCRIPTION
…hem as false positive, were only visible in the metric change log and not in the change logs of the report, subject, and source. Note: because a change needed to be made to the database format to fix this, changes made to violations, issues, warnings, etc. before this release are not visible in the change log. Fixes #1019.