### PR TITLE
Anchore vulnerability keys are not always valid as JSON key, causing …

### DIFF
--- a/components/collector/src/source_collectors/anchore.py
+++ b/components/collector/src/source_collectors/anchore.py
@@ -5,6 +5,7 @@ from typing import Tuple
 
 from dateutil.parser import parse
 
+from collector_utilities.functions import md5_hash
 from collector_utilities.type import Entities, Response, Responses, Value
 from .source_collector import JSONFileSourceCollector, SourceUpToDatenessCollector
 
@@ -20,7 +21,7 @@ class AnchoreSecurityWarnings(JSONFileSourceCollector):
             vulnerabilities = json.get("vulnerabilities", []) if isinstance(json, dict) else []
             entities.extend([
                 dict(
-                    key=f'{vulnerability["vuln"]}:{vulnerability["package"]}',
+                    key=md5_hash(f'{vulnerability["vuln"]}:{vulnerability["package"]}'),
                     cve=vulnerability["vuln"],
                     package=vulnerability["package"],
                     severity=vulnerability["severity"],

--- a/components/collector/tests/source_collectors/test_anchore.py
+++ b/components/collector/tests/source_collectors/test_anchore.py
@@ -31,7 +31,8 @@ class AnchoreSecurityWarningsTest(AnchoreTestCase):
         self.metric = dict(type="security_warnings", sources=self.sources, addition="sum")
         self.expected_entities = [
             dict(
-                key="CVE-000:package", cve="CVE-000", url="https://cve", fix="None", severity="Low", package="package")]
+                key="1fe53aa1061841cbd9fcdab1179191dc", cve="CVE-000", url="https://cve", fix="None", severity="Low",
+                package="package")]
 
     def test_warnings(self):
         """Test the number of security warnings."""

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Don't refresh the change log when clicking the "Download report as pdf" button. Fixes [#1015](https://github.com/ICTU/quality-time/issues/1015).
 - Make proxy port configurable. Fixes [#1018](https://github.com/ICTU/quality-time/issues/1018).
 - Changes made to violations, issues, warnings, etc., such as marking them as false positive, were only visible in the metric change log and not in the change logs of the report, subject, and source. Note: because a change needed to be made to the database format to fix this, changes made to violations, issues, warnings, etc. before this release are not visible in the change log. Fixes [#1019](https://github.com/ICTU/quality-time/issues/1019).
+- Anchore vulnerability keys are not always valid as JSON key, causing exceptions when the user tries to make changes to vulnerabilities. Hashing the keys prevents this issue. Fixes [#1023](https://github.com/ICTU/quality-time/issues/1023).
 - The too many parameters, complex units, and long unit metrics with SonarQube as source would always report the percentage as zero. Fixes [#1027](https://github.com/ICTU/quality-time/issues/1027). 
 
 ## [1.6.0] - [2020-02-12]


### PR DESCRIPTION
…exceptions when the user tries to make changes to vulnerabilities. Hashing the keys prevents this issue. Fixes #1023.