### PR TITLE
OWASP ZAP warning keys were not always unique, causing trouble with m…

### DIFF
--- a/components/collector/src/source_collectors/owasp_zap.py
+++ b/components/collector/src/source_collectors/owasp_zap.py
@@ -28,7 +28,11 @@ class OWASPZAPSecurityWarnings(XMLFileSourceCollector):
             for alert_instance in alert.findall("./instances/instance"):
                 method = alert_instance.findtext("method", default="")
                 uri = hashless(URL(alert_instance.findtext("uri", default="")))
-                key = md5_hash(f"{alert_key}:{method}:{uri}")
+                # We need to add evidence to the key because apparently alert_key, method, and uri can be the same for
+                # different alert instances. Add evidence, when available, to make keys unique. Add without ":" as not
+                # to change the keys of existing entities that don't have evidence.
+                evidence = alert_instance.findtext("evidence", default="")
+                key = md5_hash(f"{alert_key}:{method}:{uri}{evidence}")
                 entities.append(
                     dict(key=key, name=name, description=description, uri=uri, location=f"{method} {uri}", risk=risk))
         return str(len(entities)), "100", entities

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Use environment variables for both proxy host and port so the renderer uses the right url to get the report. Fixes [#1031](https://github.com/ICTU/quality-time/issues/1031).
+- OWASP ZAP warning keys were not always unique, causing trouble with marking them as false positive. Fixes [#1032](https://github.com/ICTU/quality-time/issues/1032).
 
 ## [1.6.1] - [2020-02-18]
 


### PR DESCRIPTION
…arking them as false positive. Fixes #1032.