### PR TITLE
The Jenkins test report source would not correctly get the number of …

### DIFF
--- a/components/collector/tests/source_collectors/test_jenkins_test_report.py
+++ b/components/collector/tests/source_collectors/test_jenkins_test_report.py
@@ -27,6 +27,25 @@ class JenkinsTestReportTest(SourceCollectorTestCase):
                 dict(class_name="c1", key="tc1", name="tc1", test_result="failed"),
                 dict(class_name="c2", key="tc2", name="tc2", test_result="passed")])
 
+    def test_nr_of_tests_with_aggregated_report(self):
+        """Test that the number of tests is returned when the test report is an aggregated report."""
+        jenkins_json = dict(
+            childReports=[
+                dict(
+                    result=dict(
+                        failCount=1, passCount=1,
+                        suites=[dict(
+                            cases=[
+                                dict(status="FAILED", name="tc1", className="c1"),
+                                dict(status="PASSED", name="tc2", className="c2")])]))])
+        metric = dict(type="tests", addition="sum", sources=self.sources)
+        response = self.collect(metric, get_request_json_return_value=jenkins_json)
+        self.assert_measurement(
+            response, value="2",
+            entities=[
+                dict(class_name="c1", key="tc1", name="tc1", test_result="failed"),
+                dict(class_name="c2", key="tc2", name="tc2", test_result="passed")])
+
     def test_nr_of_passed_tests(self):
         """Test that the number of passed tests is returned."""
         jenkins_json = dict(

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Use environment variables for both proxy host and port so the renderer uses the right url to get the report. Fixes [#1031](https://github.com/ICTU/quality-time/issues/1031).
 - OWASP ZAP warning keys were not always unique, causing trouble with marking them as false positive. Fixes [#1032](https://github.com/ICTU/quality-time/issues/1032).
+- The Jenkins test report source would not correctly get the number of passed tests from aggregated test reports. Fixes [#1033](http://github.com/ICTU/quality-time/issues/1033).
 
 ## [1.6.1] - [2020-02-18]
 


### PR DESCRIPTION
…passed tests from aggregated test reports. Fixes #1033.