### PR TITLE
When using SonarQube as source for duplication, uncovered lines, or u…

### DIFF
--- a/components/collector/src/source_collectors/__init__.py
+++ b/components/collector/src/source_collectors/__init__.py
@@ -31,7 +31,7 @@ from .quality_time import QualityTimeMetrics
 from .random_number import Random
 from .robot_framework import RobotFrameworkTests, RobotFrameworkSourceUpToDateness
 from .sonarqube import (
-    SonarQubeDuplicatedLines, SonarQubeComplexUnits, SonarQubeCommentedOutCode, SonarQubeFailedTests, SonarQubeLOC,
+    SonarQubeDuplicatedLines, SonarQubeComplexUnits, SonarQubeCommentedOutCode, SonarQubeLOC,
     SonarQubeLongUnits, SonarQubeManyParameters, SonarQubeSourceUpToDateness, SonarQubeSuppressedViolations,
     SonarQubeTests, SonarQubeUncoveredBranches, SonarQubeUncoveredLines, SonarQubeViolations)
 from .trello import TrelloIssues, TrelloSourceUpToDateness

--- a/components/collector/src/source_collectors/sonarqube.py
+++ b/components/collector/src/source_collectors/sonarqube.py
@@ -163,7 +163,8 @@ class SonarQubeMetricsBaseClass(SourceCollector):
         url = super()._landing_url(responses)
         component = self._parameter("component")
         branch = self._parameter("branch")
-        return URL(f"{url}/component_measures?id={component}&metric={self._metric_keys()}&branch={branch}")
+        metric = self._metric_keys().split(",")[0]
+        return URL(f"{url}/component_measures?id={component}&metric={metric}&branch={branch}")
 
     def _api_url(self) -> URL:
         url = super()._api_url()
@@ -194,12 +195,6 @@ class SonarQubeDuplicatedLines(SonarQubeMetricsBaseClass):
     """SonarQube duplicated lines collector."""
 
     metricKeys = "duplicated_lines,lines"
-
-
-class SonarQubeFailedTests(SonarQubeMetricsBaseClass):
-    """SonarQube failed tests collector."""
-
-    metricKeys = "test_failures"
 
 
 class SonarQubeLOC(SonarQubeMetricsBaseClass):

--- a/components/collector/tests/source_collectors/test_sonarqube.py
+++ b/components/collector/tests/source_collectors/test_sonarqube.py
@@ -26,14 +26,22 @@ class SonarQubeTest(SourceCollectorTestCase):
                  url="https://sonar/project/issues?id=id&issues=a&open=a&branch=master"),
             dict(component="b", key="b", message="b", severity="major", type="code_smell",
                  url="https://sonar/project/issues?id=id&issues=b&open=b&branch=master")]
-        self.assert_measurement(response, value="2", entities=expected_entities)
+        self.assert_measurement(
+            response, value="2", entities=expected_entities,
+            landing_url="https://sonar/project/issues?id=id&resolved=false&branch=master")
 
     def test_commented_out_code(self):
         """Test that the number of lines with commented out code is returned."""
         json = dict(total="2")
         metric = dict(type="commented_out_code", addition="sum", sources=self.sources)
         response = self.collect(metric, get_request_json_return_value=json)
-        self.assert_measurement(response, value="2", total="100")
+        self.assert_measurement(
+            response, value="2", total="100",
+            landing_url="https://sonar/project/issues?id=id&resolved=false&branch=master&rules=abap:S125,apex:S125,"
+                        "c:CommentedCode,cpp:CommentedCode,flex:CommentedCode,csharpsquid:S125,"
+                        "javascript:CommentedCode,kotlin:S125,objc:CommentedCode,php:S125,plsql:S125,python:S125,"
+                        "scala:S125,squid:CommentedOutCodeLine,swift:S125,typescript:S125,"
+                        "Web:AvoidCommentedOutCodeCheck,xml:S125")
 
     def test_complex_units(self):
         """Test that the number of lines with commented out code is returned."""
@@ -41,14 +49,21 @@ class SonarQubeTest(SourceCollectorTestCase):
         functions_json = dict(component=dict(measures=[dict(metric="functions", value="4")]))
         metric = dict(type="complex_units", addition="sum", sources=self.sources)
         response = self.collect(metric, get_request_json_side_effect=[complex_units_json, functions_json] * 2)
-        self.assert_measurement(response, value="2", total="4")
+        self.assert_measurement(
+            response, value="2", total="4",
+            landing_url="https://sonar/project/issues?id=id&resolved=false&branch=master&rules=csharpsquid:S1541,"
+                        "csharpsquid:S3776,flex:FunctionComplexity,javascript:FunctionComplexity,javascript:S3776,"
+                        "go:S3776,kotlin:S3776,php:S1541,php:S3776,python:FunctionComplexity,python:S3776,ruby:S3776,"
+                        "scala:S3776,squid:MethodCyclomaticComplexity,squid:S3776,typescript:S1541,typescript:S3776,"
+                        "vbnet:S1541,vbnet:S3776")
 
     def test_tests(self):
         """Test that the number of tests is returned."""
         json = dict(component=dict(measures=[dict(metric="tests", value="88")]))
         metric = dict(type="tests", addition="sum", sources=self.sources)
         response = self.collect(metric, get_request_json_return_value=json)
-        self.assert_measurement(response, value="88")
+        self.assert_measurement(
+            response, value="88", landing_url="https://sonar/component_measures?id=id&metric=tests&branch=master")
 
     def test_uncovered_lines(self):
         """Test that the number of uncovered lines and the number of lines to cover are returned."""
@@ -57,7 +72,9 @@ class SonarQubeTest(SourceCollectorTestCase):
                 measures=[dict(metric="uncovered_lines", value="100"), dict(metric="lines_to_cover", value="1000")]))
         metric = dict(type="uncovered_lines", addition="sum", sources=self.sources)
         response = self.collect(metric, get_request_json_return_value=json)
-        self.assert_measurement(response, value="100", total="1000")
+        self.assert_measurement(
+            response, value="100", total="1000",
+            landing_url="https://sonar/component_measures?id=id&metric=uncovered_lines&branch=master")
 
     def test_uncovered_branches(self):
         """Test that the number of uncovered branches and the number of branches to cover are returned."""
@@ -67,7 +84,9 @@ class SonarQubeTest(SourceCollectorTestCase):
                     dict(metric="uncovered_conditions", value="10"), dict(metric="conditions_to_cover", value="200")]))
         metric = dict(type="uncovered_branches", addition="sum", sources=self.sources)
         response = self.collect(metric, get_request_json_return_value=json)
-        self.assert_measurement(response, value="10", total="200")
+        self.assert_measurement(
+            response, value="10", total="200",
+            landing_url="https://sonar/component_measures?id=id&metric=uncovered_conditions&branch=master")
 
     def test_duplicated_lines(self):
         """Test that the number of duplicated lines and the total number of lines are returned."""
@@ -77,7 +96,9 @@ class SonarQubeTest(SourceCollectorTestCase):
                     dict(metric="duplicated_lines", value="10"), dict(metric="lines", value="100")]))
         metric = dict(type="duplicated_lines", addition="sum", sources=self.sources)
         response = self.collect(metric, get_request_json_return_value=json)
-        self.assert_measurement(response, value="10", total="100")
+        self.assert_measurement(
+            response, value="10", total="100",
+            landing_url="https://sonar/component_measures?id=id&metric=duplicated_lines&branch=master")
 
     def test_many_parameters(self):
         """Test that the number of functions with too many parameters is returned."""
@@ -86,7 +107,12 @@ class SonarQubeTest(SourceCollectorTestCase):
         functions_json = dict(component=dict(measures=[dict(metric="functions", value="4")]))
         metric = dict(type="many_parameters", addition="sum", sources=self.sources)
         response = self.collect(metric, get_request_json_side_effect=[many_parameters_json, functions_json] * 2)
-        self.assert_measurement(response, value="2", total="4")
+        self.assert_measurement(
+            response, value="2", total="4",
+            landing_url="https://sonar/project/issues?id=id&resolved=false&branch=master&rules=c:S107,csharpsquid:S107,"
+                        "csharpsquid:S2436,cpp:S107,flex:S107,javascript:ExcessiveParameterList,objc:S107,php:S107,"
+                        "plsql:PlSql.FunctionAndProcedureExcessiveParameters,python:S107,squid:S00107,tsql:S107,"
+                        "typescript:S107")
 
     def test_long_units(self):
         """Test that the number of long units is returned."""
@@ -95,7 +121,14 @@ class SonarQubeTest(SourceCollectorTestCase):
         functions_json = dict(component=dict(measures=[dict(metric="functions", value="4")]))
         metric = dict(type="long_units", addition="sum", sources=self.sources)
         response = self.collect(metric, get_request_json_side_effect=[long_units_json, functions_json] * 2)
-        self.assert_measurement(response, value="2", total="4")
+        self.assert_measurement(
+            response, value="2", total="4",
+            landing_url="https://sonar/project/issues?id=id&resolved=false&branch=master&rules=abap:S104,c:FileLoc,"
+                        "cpp:FileLoc,csharpsquid:S104,csharpsquid:S138,flex:S138,go:S104,go:S138,javascript:S104,"
+                        "javascript:S138,kotlin:S104,kotlin:S138,objc:FileLoc,php:S104,php:S138,php:S2042,Pylint:R0915,"
+                        "python:S104,ruby:S104,ruby:S138,scala:S104,scala:S138,squid:S00104,squid:S1188,squid:S138,"
+                        "squid:S2972,swift:S104,typescript:S104,typescript:S138,vbnet:S104,vbnet:S138,"
+                        "Web:FileLengthCheck,Web:LongJavaScriptCheck")
 
     def test_source_up_to_dateness(self):
         """Test that the number of days since the last analysis is returned."""
@@ -104,7 +137,8 @@ class SonarQubeTest(SourceCollectorTestCase):
         response = self.collect(metric, get_request_json_return_value=json)
         timezone_info = timezone(timedelta(hours=1))
         expected_age = (datetime.now(timezone_info) - datetime(2019, 3, 29, 14, 20, 15, tzinfo=timezone_info)).days
-        self.assert_measurement(response, value=str(expected_age))
+        self.assert_measurement(
+            response, value=str(expected_age), landing_url="https://sonar/project/activity?id=id&branch=master")
 
     def test_suppressed_violations(self):
         """Test that the number of suppressed violations includes both suppressed issues as well as suppressed rules."""
@@ -123,14 +157,19 @@ class SonarQubeTest(SourceCollectorTestCase):
                  resolution="", url="https://sonar/project/issues?id=id&issues=a&open=a&branch=master"),
             dict(component="b", key="b", message="b", severity="major", type="code_smell",
                  resolution="won't fix", url="https://sonar/project/issues?id=id&issues=b&open=b&branch=master")]
-        self.assert_measurement(response, value="2", total="4", entities=expected_entities)
+        self.assert_measurement(
+            response, value="2", total="4", entities=expected_entities,
+            landing_url="https://sonar/project/issues?id=id&resolved=false&branch=master&rules=csharpsquid:S1309,"
+                        "php:NoSonar,Pylint:I0011,Pylint:I0020,squid:NoSonar,squid:S1309,squid:S1310,squid:S1315")
 
     def test_loc_returns_ncloc_by_default(self):
         """Test that the number of lines of non-comment code is returned."""
         json = dict(component=dict(measures=[dict(metric="ncloc", value="1234")]))
         metric = dict(type="loc", addition="sum", sources=self.sources)
         response = self.collect(metric, get_request_json_return_value=json)
-        self.assert_measurement(response, value="1234", total="100")
+        self.assert_measurement(
+            response, value="1234", total="100",
+            landing_url="https://sonar/component_measures?id=id&metric=ncloc&branch=master")
 
     def test_loc_all_lines(self):
         """Test that the number of lines of code is returned."""
@@ -138,14 +177,18 @@ class SonarQubeTest(SourceCollectorTestCase):
         json = dict(component=dict(measures=[dict(metric="lines", value="1234")]))
         metric = dict(type="loc", addition="sum", sources=self.sources)
         response = self.collect(metric, get_request_json_return_value=json)
-        self.assert_measurement(response, value="1234", total="100")
+        self.assert_measurement(
+            response, value="1234", total="100",
+            landing_url="https://sonar/component_measures?id=id&metric=lines&branch=master")
 
     def test_nr_of_tests(self):
         """Test that the number of tests is returned."""
         json = dict(component=dict(measures=[dict(metric="tests", value="123")]))
         metric = dict(type="tests", addition="sum", sources=self.sources)
         response = self.collect(metric, get_request_json_return_value=json)
-        self.assert_measurement(response, value="123", total="123")
+        self.assert_measurement(
+            response, value="123", total="123",
+            landing_url="https://sonar/component_measures?id=id&metric=tests&branch=master")
 
     def test_nr_of_skipped_tests(self):
         """Test that the number of skipped tests is returned."""
@@ -154,11 +197,15 @@ class SonarQubeTest(SourceCollectorTestCase):
         self.sources["source_id"]["parameters"]["test_result"] = ["skipped"]
         metric = dict(type="tests", addition="sum", sources=self.sources)
         response = self.collect(metric, get_request_json_return_value=json)
-        self.assert_measurement(response, value="4", total="123")
+        self.assert_measurement(
+            response, value="4", total="123",
+            landing_url="https://sonar/component_measures?id=id&metric=tests&branch=master")
 
     def test_nr_of_tests_without_tests(self):
         """Test that the collector throws an exception if there are no tests."""
         json = dict(component=dict(measures=[]))
         metric = dict(type="tests", addition="sum", sources=self.sources)
         response = self.collect(metric, get_request_json_return_value=json)
-        self.assert_measurement(response, value=None, total=None, parse_error="KeyError")
+        self.assert_measurement(
+            response, value=None, total=None, parse_error="KeyError",
+            landing_url="https://sonar/component_measures?id=id&metric=tests&branch=master")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
- 
-- Reversed proxy container now waits for server and frontend containers. Fixes [#1046](https://github.com/ICTU/quality-time/issues/1046).
+
+- When using SonarQube as source for duplication, uncovered lines, or uncovered branches, the landing url would be incorrect. Fixes [#1044](https://github.com/ICTU/quality-time/issues/1044).
+- Proxy container now waits for server and frontend containers to start. Fixes [#1046](https://github.com/ICTU/quality-time/issues/1046).
 
 ## [1.7.0] - [2020-02-22]
 


### PR DESCRIPTION
…ncovered branches, the landing url would be incorrect. Fixes #1044.