### PR TITLE
Allow for specifying variable parts of URLs in OWASP ZAP reports. Thi…

### DIFF
--- a/components/collector/src/source_collectors/owasp_zap.py
+++ b/components/collector/src/source_collectors/owasp_zap.py
@@ -2,13 +2,13 @@
 
 import re
 from datetime import datetime
-from typing import cast, List, Tuple
+from typing import cast, Dict, List, Tuple
 from xml.etree.ElementTree import Element  # nosec, Element is not available from defusedxml, but only used as type
 
 from dateutil.parser import parse
 
 from collector_utilities.functions import hashless, md5_hash, parse_source_response_xml
-from collector_utilities.type import Entities, Response, Responses, URL, Value
+from collector_utilities.type import Entities, Entity, Response, Responses, URL, Value
 from .source_collector import XMLFileSourceCollector, SourceUpToDatenessCollector
 
 
@@ -16,7 +16,7 @@ class OWASPZAPSecurityWarnings(XMLFileSourceCollector):
     """Collector to get security warnings from OWASP ZAP."""
 
     def _parse_source_responses(self, responses: Responses) -> Tuple[Value, Value, Entities]:
-        entities: Entities = []
+        entities: Dict[str, Entity] = {}
         tag_re = re.compile(r"<[^>]*>")
         risks = cast(List[str], self._parameter("risks"))
         for alert in self.__alerts(responses, risks):
@@ -27,15 +27,19 @@ class OWASPZAPSecurityWarnings(XMLFileSourceCollector):
             risk = alert.findtext("riskdesc", default="")
             for alert_instance in alert.findall("./instances/instance"):
                 method = alert_instance.findtext("method", default="")
-                uri = hashless(URL(alert_instance.findtext("uri", default="")))
-                # We need to add evidence to the key because apparently alert_key, method, and uri can be the same for
-                # different alert instances. Add evidence, when available, to make keys unique. Add without ":" as not
-                # to change the keys of existing entities that don't have evidence.
-                evidence = alert_instance.findtext("evidence", default="")
-                key = md5_hash(f"{alert_key}:{method}:{uri}{evidence}")
-                entities.append(
-                    dict(key=key, name=name, description=description, uri=uri, location=f"{method} {uri}", risk=risk))
-        return str(len(entities)), "100", entities
+                uri = self.__stable(hashless(URL(alert_instance.findtext("uri", default=""))))
+                key = md5_hash(f"{alert_key}:{method}:{uri}")
+                entities[key] = dict(
+                    key=key, name=name, description=description, uri=uri, location=f"{method} {uri}", risk=risk)
+        return str(len(entities)), "100", list(entities.values())
+
+    def __stable(self, url: URL) -> URL:
+        """Return the url without the variable parts."""
+        reg_exps = self._parameter("variable_url_regexp")
+        stable_url = cast(str, url)
+        for reg_exp in reg_exps:
+            stable_url = re.sub(reg_exp, "variable-part-removed", stable_url)
+        return URL(stable_url)
 
     @staticmethod
     def __alerts(responses: Responses, risks: List[str]) -> List[Element]:

--- a/components/server/src/data/datamodel.json
+++ b/components/server/src/data/datamodel.json
@@ -3001,6 +3001,18 @@
                     "metrics": [
                         "security_warnings"
                     ]
+                },
+                "variable_url_regexp": {
+                    "name": "Parts of URLs to ignore (regular expressions)",
+                    "short_name": "parts of URLs to ignore",
+                    "type": "multiple_choice_with_addition",
+                    "help": "Parts of URLs to ignore can be specified by regular expression. The parts of URLs that match one or more of the regular expressions are removed. If, after applying the regular expressions, multiple warnings are the same only one is reported.",
+                    "placeholder": "none",
+                    "mandatory": false,
+                    "default_value": [],
+                    "metrics": [
+                        "security_warnings"
+                    ]
                 }
             },
             "entities": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,12 +13,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Cache data model and other performance improvements. Fixes [#1026](https://github.com/ICTU/quality-time/issues/1026).
+- Cache data model and other performance improvements. Note: the proxy settings for the data model API have been updated. See the Caddy configuration in the [docker-compose](../docker/docker-compose.yml). Fixes [#1026](https://github.com/ICTU/quality-time/issues/1026).
 
 ### Added
 
-- Allow for specifying variable parts of URLs in OWASP ZAP reports. This makes it possible to mark warnings as false positive even if parts of URLs change between runs of OWASP ZAP. Closes [#1045](https://github.com/ICTU/quality-time/issues/1045).
-- A new metric for measuring the number of (outdated) dependencies, and a new source that supports this metric: Composer for PHP. Closes [#1056](https://github.com/ICTU/quality-time/issues/1056).
+- Allow for specifying variable parts of URLs in OWASP ZAP reports. This makes it possible to mark warnings as false positive even when parts of URLs change between runs of OWASP ZAP. Note: because the way Quality-time keeps track of the warnings has been changed, some OWASP ZAP warnings may need to be marked as false positive again. Closes [#1045](https://github.com/ICTU/quality-time/issues/1045).
+- A new metric for measuring the number of (outdated) dependencies and a new source (Composer for PHP) that supports this metric were added. Closes [#1056](https://github.com/ICTU/quality-time/issues/1056).
 
 ## [1.7.1] - [2020-02-26]
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
-## [1.8.0-rc.1] - [2020-02-28]
+## [Unreleased]
 
 ### Changed
 
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Allow for specifying variable parts of URLs in OWASP ZAP reports. This makes it possible to mark warnings as false positive even if parts of URLs change between runs of OWASP ZAP. Closes [#1045](https://github.com/ICTU/quality-time/issues/1045).
 - A new metric for measuring the number of (outdated) dependencies, and a new source that supports this metric: Composer for PHP. Closes [#1056](https://github.com/ICTU/quality-time/issues/1056).
 
 ## [1.7.1] - [2020-02-26]

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -108,7 +108,7 @@
 | URL to Composer 'outdated' report in a human readable format | String | No | [https://getcomposer.org/doc/03-cli.md#outdated](https://getcomposer.org/doc/03-cli.md#outdated) |
 | Username for basic authentication | String | No |  |
 | Password for basic authentication | Password | No |  |
-| Latest version status | Multiple choice | No |  |
+| Latest version status | Multiple choice | No | Limit which latest version statuses to show. The status 'safe update possible' means that based on semantic versioning the update should be backwards compatible. |
 
 ### Duplicated lines from SonarQube
 
@@ -546,6 +546,7 @@
 | Username for basic authentication | String | No |  |
 | Password for basic authentication | Password | No |  |
 | Risks | Multiple choice | No |  |
+| Parts of URLs to ignore (regular expressions) | Multiple choice with addition | No | Parts of URLs to ignore can be specified by regular expression. The parts of URLs that match one or more of the regular expressions are removed. If, after applying the regular expressions, multiple warnings are the same only one is reported. |
 
 ### Security warnings from Pyupio Safety
 


### PR DESCRIPTION
…s makes it possible to mark warnings as false positive even if parts of URLs change between runs of OWASP ZAP. Closes #1045.