### PR TITLE
When loading changes to show in the changelog, an internal server err…

### DIFF
--- a/components/server/src/initialization/database.py
+++ b/components/server/src/initialization/database.py
@@ -15,6 +15,7 @@ def init_database() -> Database:
     database_url = os.environ.get("DATABASE_URL", "mongodb://root:root@localhost:27017")
     database = pymongo.MongoClient(database_url).quality_time_db
     logging.info("Connected to database: %s", database)
+    create_indexes(database)
     nr_reports = database.reports.count_documents({})
     nr_measurements = database.measurements.count_documents({})
     logging.info("Database has %d report documents and %d measurement documents", nr_reports, nr_measurements)
@@ -24,6 +25,11 @@ def init_database() -> Database:
         import_example_reports(database)
     update_database(database)
     return database
+
+
+def create_indexes(database: Database) -> None:
+    """Create any indexes."""
+    database.reports.create_index("timestamp")
 
 
 def update_database(database: Database) -> None:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     cap_drop:
       - ALL
   database:
-    image: mongo
+    image: mongo:4.2.3
     restart: always
     env_file:
       - ${ENV:-dev}.env

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- When loading changes to show in the changelog, an internal server error could occur due to lack of memory during sorting the changes. Add an index to the reports collection to prevent out of memory errors during sorting. Fixes [#1077](https://github.com/ICTU/quality-time/issues/1077).
+
 ## [1.8.0] - [2020-03-01]
 
 ### Changed


### PR DESCRIPTION
…or could occur due to lack of memory during sorting the changes. Add an index to the reports collection to prevent out of memory errors during sorting. Fixes #1077.