### PR TITLE
Add a private token parameter to all sources that consists of JSON, X…

### DIFF
--- a/components/collector/tests/source_collectors/source_collector_test_case.py
+++ b/components/collector/tests/source_collectors/source_collector_test_case.py
@@ -28,7 +28,7 @@ class SourceCollectorTestCase(unittest.TestCase):
                 post_request_side_effect=None,
                 post_request_json_return_value=None,
                 post_request_json_side_effect=None) -> Measurement:
-        """Collect the metric. Keep a reference to the collector so it can be queried."""
+        """Collect the metric."""
         mock_get_request = Mock()
         if get_request_json_side_effect:
             mock_get_request.json.side_effect = get_request_json_side_effect

--- a/components/collector/tests/source_collectors/test_bandit.py
+++ b/components/collector/tests/source_collectors/test_bandit.py
@@ -66,6 +66,12 @@ class BanditSecurityWarningsTest(BanditTestCase):
         response = self.collect(self.metric, get_request_content=bytes_io.getvalue())
         self.assert_measurement(response, value="1", entities=self.expected_entities)
 
+    def test_report_in_gitlab(self):
+        """Test that a private token can be added to the request header for accessing a report in GitLab."""
+        self.sources["source_id"]["parameters"]["private_token"] = "token"
+        response = self.collect(self.metric, get_request_json_return_value=self.bandit_json)
+        self.assert_measurement(response, value="1", entities=self.expected_entities)
+
 
 class BanditSourceUpToDatenessTest(BanditTestCase):
     """Unit tests for the source up to dateness metric."""

--- a/components/server/src/data/datamodel.json
+++ b/components/server/src/data/datamodel.json
@@ -671,7 +671,8 @@
                     "default_value": "",
                     "validate_on": [
                         "username",
-                        "password"
+                        "password",
+                        "private_token"
                     ],
                     "metrics": [
                         "security_warnings"
@@ -685,7 +686,8 @@
                     "default_value": "",
                     "validate_on": [
                         "username",
-                        "password"
+                        "password",
+                        "private_token"
                     ],
                     "metrics": [
                         "source_up_to_dateness"
@@ -716,6 +718,17 @@
                 "password": {
                     "name": "Password for basic authentication",
                     "short_name": "password",
+                    "type": "password",
+                    "mandatory": false,
+                    "default_value": "",
+                    "metrics": [
+                        "security_warnings",
+                        "source_up_to_dateness"
+                    ]
+                },
+                "private_token": {
+                    "name": "Private token",
+                    "short_name": "private token",
                     "type": "password",
                     "mandatory": false,
                     "default_value": "",
@@ -789,7 +802,8 @@
                     "default_value": "",
                     "validate_on": [
                         "username",
-                        "password"
+                        "password",
+                        "private_token"
                     ],
                     "metrics": [
                         "accessibility"
@@ -818,6 +832,16 @@
                 "password": {
                     "name": "Password for basic authentication",
                     "short_name": "password",
+                    "type": "password",
+                    "mandatory": false,
+                    "default_value": "",
+                    "metrics": [
+                        "accessibility"
+                    ]
+                },
+                "private_token": {
+                    "name": "Private token",
+                    "short_name": "private token",
                     "type": "password",
                     "mandatory": false,
                     "default_value": "",
@@ -1299,7 +1323,8 @@
                     "type": "url",
                     "validate_on": [
                         "username",
-                        "password"
+                        "password",
+                        "private_token"
                     ],
                     "mandatory": true,
                     "default_value": "",
@@ -1333,6 +1358,17 @@
                 "password": {
                     "name": "Password for basic authentication",
                     "short_name": "password",
+                    "type": "password",
+                    "mandatory": false,
+                    "default_value": "",
+                    "metrics": [
+                        "security_warnings",
+                        "source_up_to_dateness"
+                    ]
+                },
+                "private_token": {
+                    "name": "Private token",
+                    "short_name": "private token",
                     "type": "password",
                     "mandatory": false,
                     "default_value": "",
@@ -1433,7 +1469,8 @@
                     "help_url": "https://getcomposer.org/doc/03-cli.md#outdated",
                     "validate_on": [
                         "username",
-                        "password"
+                        "password",
+                        "private_token"
                     ],
                     "mandatory": true,
                     "default_value": "",
@@ -1465,6 +1502,16 @@
                 "password": {
                     "name": "Password for basic authentication",
                     "short_name": "password",
+                    "type": "password",
+                    "mandatory": false,
+                    "default_value": "",
+                    "metrics": [
+                        "dependencies"
+                    ]
+                },
+                "private_token": {
+                    "name": "Private token",
+                    "short_name": "private token",
                     "type": "password",
                     "mandatory": false,
                     "default_value": "",
@@ -1842,7 +1889,8 @@
                     "type": "url",
                     "validate_on": [
                         "username",
-                        "password"
+                        "password",
+                        "private_token"
                     ],
                     "mandatory": true,
                     "default_value": "",
@@ -1879,6 +1927,18 @@
                 "password": {
                     "name": "Password for basic authentication",
                     "short_name": "password",
+                    "type": "password",
+                    "mandatory": false,
+                    "default_value": "",
+                    "metrics": [
+                        "source_up_to_dateness",
+                        "uncovered_lines",
+                        "uncovered_branches"
+                    ]
+                },
+                "private_token": {
+                    "name": "Private token",
+                    "short_name": "private token",
                     "type": "password",
                     "mandatory": false,
                     "default_value": "",
@@ -2360,7 +2420,8 @@
                     "type": "url",
                     "validate_on": [
                         "username",
-                        "password"
+                        "password",
+                        "private_token"
                     ],
                     "mandatory": true,
                     "default_value": "",
@@ -2394,6 +2455,17 @@
                 "password": {
                     "name": "Password for basic authentication",
                     "short_name": "password",
+                    "type": "password",
+                    "mandatory": false,
+                    "default_value": "",
+                    "metrics": [
+                        "source_up_to_dateness",
+                        "tests"
+                    ]
+                },
+                "private_token": {
+                    "name": "Private token",
+                    "short_name": "private token",
                     "type": "password",
                     "mandatory": false,
                     "default_value": "",
@@ -2502,7 +2574,8 @@
                     "type": "url",
                     "validate_on": [
                         "username",
-                        "password"
+                        "password",
+                        "private_token"
                     ],
                     "mandatory": true,
                     "default_value": "",
@@ -2535,6 +2608,18 @@
                         "uncovered_branches",
                         "source_up_to_dateness"
                     ]
+                },
+                "private_token": {
+                    "name": "Private token",
+                    "short_name": "private token",
+                    "type": "password",
+                    "mandatory": false,
+                    "default_value": "",
+                    "metrics": [
+                        "uncovered_lines",
+                        "uncovered_branches",
+                        "source_up_to_dateness"
+                    ]
                 }
             },
             "entities": {}
@@ -2550,7 +2635,8 @@
                     "type": "url",
                     "validate_on": [
                         "username",
-                        "password"
+                        "password",
+                        "private_token"
                     ],
                     "mandatory": true,
                     "default_value": "",
@@ -2581,6 +2667,16 @@
                 "password": {
                     "name": "Password for basic authentication",
                     "short_name": "password",
+                    "type": "password",
+                    "mandatory": false,
+                    "default_value": "",
+                    "metrics": [
+                        "violations"
+                    ]
+                },
+                "private_token": {
+                    "name": "Private token",
+                    "short_name": "private token",
                     "type": "password",
                     "mandatory": false,
                     "default_value": "",
@@ -2648,7 +2744,8 @@
                     "type": "url",
                     "validate_on": [
                         "username",
-                        "password"
+                        "password",
+                        "private_token"
                     ],
                     "mandatory": true,
                     "default_value": "",
@@ -2682,6 +2779,17 @@
                 "password": {
                     "name": "Password for basic authentication",
                     "short_name": "password",
+                    "type": "password",
+                    "mandatory": false,
+                    "default_value": "",
+                    "metrics": [
+                        "security_warnings",
+                        "source_up_to_dateness"
+                    ]
+                },
+                "private_token": {
+                    "name": "Private token",
+                    "short_name": "private token",
                     "type": "password",
                     "mandatory": false,
                     "default_value": "",
@@ -2753,7 +2861,8 @@
                     "type": "url",
                     "validate_on": [
                         "username",
-                        "password"
+                        "password",
+                        "private_token"
                     ],
                     "mandatory": true,
                     "default_value": "",
@@ -2787,6 +2896,17 @@
                 "password": {
                     "name": "Password for basic authentication",
                     "short_name": "password",
+                    "type": "password",
+                    "mandatory": false,
+                    "default_value": "",
+                    "metrics": [
+                        "security_warnings",
+                        "source_up_to_dateness"
+                    ]
+                },
+                "private_token": {
+                    "name": "Private token",
+                    "short_name": "private token",
                     "type": "password",
                     "mandatory": false,
                     "default_value": "",
@@ -2937,7 +3057,8 @@
                     "type": "url",
                     "validate_on": [
                         "username",
-                        "password"
+                        "password",
+                        "private_token"
                     ],
                     "mandatory": true,
                     "default_value": "",
@@ -2971,6 +3092,17 @@
                 "password": {
                     "name": "Password for basic authentication",
                     "short_name": "password",
+                    "type": "password",
+                    "mandatory": false,
+                    "default_value": "",
+                    "metrics": [
+                        "security_warnings",
+                        "source_up_to_dateness"
+                    ]
+                },
+                "private_token": {
+                    "name": "Private token",
+                    "short_name": "private token",
                     "type": "password",
                     "mandatory": false,
                     "default_value": "",
@@ -3060,7 +3192,8 @@
                     "type": "url",
                     "validate_on": [
                         "username",
-                        "password"
+                        "password",
+                        "private_token"
                     ],
                     "mandatory": true,
                     "default_value": "",
@@ -3091,6 +3224,21 @@
                 "password": {
                     "name": "Password for basic authentication",
                     "short_name": "password",
+                    "type": "password",
+                    "mandatory": false,
+                    "default_value": "",
+                    "metrics": [
+                        "performancetest_duration",
+                        "performancetest_stability",
+                        "scalability",
+                        "slow_transactions",
+                        "source_up_to_dateness",
+                        "tests"
+                    ]
+                },
+                "private_token": {
+                    "name": "Private token",
+                    "short_name": "private token",
                     "type": "password",
                     "mandatory": false,
                     "default_value": "",
@@ -3175,7 +3323,8 @@
                     "type": "url",
                     "validate_on": [
                         "username",
-                        "password"
+                        "password",
+                        "private_token"
                     ],
                     "mandatory": true,
                     "default_value": "",
@@ -3196,6 +3345,16 @@
                 "password": {
                     "name": "Password for basic authentication",
                     "short_name": "password",
+                    "type": "password",
+                    "mandatory": false,
+                    "default_value": "",
+                    "metrics": [
+                        "security_warnings"
+                    ]
+                },
+                "private_token": {
+                    "name": "Private token",
+                    "short_name": "private token",
                     "type": "password",
                     "mandatory": false,
                     "default_value": "",
@@ -3496,7 +3655,8 @@
                     "type": "url",
                     "validate_on": [
                         "username",
-                        "password"
+                        "password",
+                        "private_token"
                     ],
                     "mandatory": true,
                     "default_value": "",
@@ -3530,6 +3690,17 @@
                 "password": {
                     "name": "Password for basic authentication",
                     "short_name": "password",
+                    "type": "password",
+                    "mandatory": false,
+                    "default_value": "",
+                    "metrics": [
+                        "source_up_to_dateness",
+                        "tests"
+                    ]
+                },
+                "private_token": {
+                    "name": "Private token",
+                    "short_name": "private token",
                     "type": "password",
                     "mandatory": false,
                     "default_value": "",

--- a/components/server/src/routes/source.py
+++ b/components/server/src/routes/source.py
@@ -179,7 +179,8 @@ def _availability_checks(data, parameter_key: str) -> List[Dict[str, Union[str, 
 def _check_url_availability(url: URL, source_parameters: Dict[str, str]) -> Dict[str, Union[int, str]]:
     """Check the availability of the URL."""
     try:
-        response = requests.get(url, auth=_basic_auth_credentials(source_parameters))
+        response = requests.get(
+            url, auth=_basic_auth_credentials(source_parameters), headers=_headers(source_parameters))
         return dict(status_code=response.status_code, reason=response.reason)
     except Exception:  # pylint: disable=broad-except
         return dict(status_code=-1, reason='Unknown error')
@@ -192,3 +193,8 @@ def _basic_auth_credentials(source_parameters) -> Optional[Tuple[str, str]]:
     if "username" in source_parameters and "password" in source_parameters:
         return source_parameters["username"], source_parameters["password"]
     return None
+
+
+def _headers(source_parameters) -> Dict:
+    """Return the headers for the url-check."""
+    return {"Private-Token": source_parameters["private_token"]} if "private_token" in source_parameters else dict()

--- a/components/server/tests/routes/test_source.py
+++ b/components/server/tests/routes/test_source.py
@@ -140,7 +140,7 @@ class PostSourceParameterTest(SourceTestCase):
         response = post_source_parameter(SOURCE_ID, "url", self.database)
         self.assert_url_check(response)
         self.database.reports.insert.assert_called_once_with(self.report)
-        mock_get.assert_called_once_with(self.url, auth=None)
+        mock_get.assert_called_once_with(self.url, auth=None, headers={})
         self.assertEqual(
             dict(uuids=[REPORT_ID, SUBJECT_ID, METRIC_ID, SOURCE_ID], email=self.email,
                  description="Jenny changed the url of source 'Source' of metric 'Metric' of subject 'Subject' in "
@@ -171,7 +171,7 @@ class PostSourceParameterTest(SourceTestCase):
         response = post_source_parameter(SOURCE_ID, "url", self.database)
         self.assert_url_check(response)
         self.database.reports.insert.assert_called_once_with(self.report)
-        mock_get.assert_called_once_with(self.url, auth=('un', 'pwd'))
+        mock_get.assert_called_once_with(self.url, auth=('un', 'pwd'), headers={})
 
     @patch.object(requests, 'get')
     def test_url_no_url_type(self, mock_get, request):
@@ -201,7 +201,7 @@ class PostSourceParameterTest(SourceTestCase):
         response = post_source_parameter(SOURCE_ID, "url", self.database)
         self.assert_url_check(response)
         self.database.reports.insert.assert_called_once_with(self.report)
-        mock_get.assert_called_once_with(self.url, auth=('xxx', ''))
+        mock_get.assert_called_once_with(self.url, auth=('xxx', ''), headers={"Private-Token": "xxx"})
 
     @patch.object(requests, 'get')
     def test_urls_connection_on_update_other_field(self, mock_get, request):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add a private token parameter to all sources that consists of JSON, XML, or HTML reports so that they can be retrieved from GitLab job artifacts. Closes [#1067](https://github.com/ICTU/quality-time/issues/1067). 
 - Add a column to show the status (unconfirmed, confirmed, false positive, etc.) of security warnings, violations, etc. so that the user doesn't have to expand them to see the status. Closes [#1070](https://github.com/ICTU/quality-time/issues/1070).
 - Show end date of technical debt in the measurement target column. Closes [#1072](https://github.com/ICTU/quality-time/issues/1072).
 - Allow for accepting technical debt for a metric that has no sources or failing sources. Closes [#1076](https://github.com/ICTU/quality-time/issues/1076).

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -90,7 +90,7 @@ Metrics can have zero or more arbitrary "Tags". Most metric have a default tag, 
 
 The "Metric scale" field determines what scale to use to measure the metric. All metrics currently support either the "Count" scale or the "Percentage" scale, or both. In the example of the duplicated lines metric above, setting the metric scale to "Percentage" means that the percentage of lines that are duplicated is shown instead of the count of duplicated lines.
 
-The "Metric direction" determines whether lower measurement values are considered to be better or worse. Usually, the default direction is correct. An example of a metric where you might want to changes the direction is the "tests" metric. When used to measure the number of tests, more tests is better. But when used to measure the number of failing tests, fewer is better.
+The "Metric direction" determines whether lower measurement values are considered to be better or worse. Usually, the default direction is correct. An example of a metric where you might want to change the direction is the "tests" metric. When used to measure the number of tests, more tests is better. But when used to measure the number of failing tests, fewer is better.
 
 The "Metric unit" derives its default value from the metric type. Override as needed.
 
@@ -126,7 +126,7 @@ The parameters that sources need differ per source type. Most sources need a URL
 
 ![Editing source screenshot](screenshots/editing_source.png)
 
-Source parameter (URL's, usernames, passwords, etc.) changes can be applied to different scopes: to just the source being edited or to multiple sources that have the same type and value as the one being edited. When applying the change to multiple sources, the user can change all sources that have the same type and value of a metric, of a subject, of a report, or of all reports.
+Source parameter (URL's, user names, passwords, etc.) changes can be applied to different scopes: to just the source being edited or to multiple sources that have the same type and value as the one being edited. When applying the change to multiple sources, the user can change all sources that have the same type and value of a metric, of a subject, of a report, or of all reports.
 
 ### Deleting sources
 


### PR DESCRIPTION
…ML, or HTML reports so that they can be retrieved from GitLab job artifacts. Closes #1067.