### PR TITLE
The collector wakes up every minute, collects measurement data if nec…

### DIFF
--- a/components/collector/src/metric_collectors/metrics_collector.py
+++ b/components/collector/src/metric_collectors/metrics_collector.py
@@ -50,15 +50,17 @@ class MetricsCollector:
 
     def start(self) -> NoReturn:
         """Start fetching measurements indefinitely."""
-        sleep_duration = int(os.environ.get("COLLECTOR_SLEEP_DURATION", 60))
+        max_sleep_duration = int(os.environ.get("COLLECTOR_SLEEP_DURATION", 60))
         measurement_frequency = int(os.environ.get("COLLECTOR_MEASUREMENT_FREQUENCY", 15 * 60))
-        self.data_model = self.fetch_data_model(sleep_duration)
+        self.data_model = self.fetch_data_model(max_sleep_duration)
         while True:
             self.record_health()
             logging.info("Collecting...")
             with timer() as collection_timer:
                 self.fetch_measurements(measurement_frequency)
-            logging.info("Collecting took %.1fs. Sleeping %ss...", collection_timer.duration, sleep_duration)
+            sleep_duration = max(0, max_sleep_duration - collection_timer.duration)
+            logging.info(
+                "Collecting took %.1f seconds. Sleeping %.1f seconds...", collection_timer.duration, sleep_duration)
             time.sleep(sleep_duration)
 
     def fetch_data_model(self, sleep_duration: int) -> JSON:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- The collector wakes up every minute, collects measurement data if necessary, and then pauses for a minute. Have the length of the pause depend on how long the data collection took so that the user does not have to wait too long for a new measurement after changing the configuration of a metric. Closes [#1100](https://github.com/ICTU/quality-time/issues/1100).
+
 ### Fixed
 
 - The metrics "violations" and "suppressed violations" show zero violations (green status) even though the component has no SonarQube analysis. Fixes [#1090](https://github.com/ICTU/quality-time/issues/1090).


### PR DESCRIPTION
…essary, and then pauses for a minute. Have the length of the pause depend on how long the data collection took so that the user does not have to wait too long for a new measurement after changing the configuration of a metric. Closes #1100.