### PR TITLE
Don't include SonarQube security hotspots in the complex units, long …

### DIFF
--- a/components/collector/src/source_collectors/api_source_collectors/sonarqube.py
+++ b/components/collector/src/source_collectors/api_source_collectors/sonarqube.py
@@ -67,7 +67,7 @@ class SonarQubeViolations(SonarQubeCollector):
         need to retrieved, the first call to retrieve bugs, vulnerabilities and code smells can be skipped."""
         types = self._parameter("types")
         api_urls = [] if ["security_hotspot"] == types else list(urls)
-        if "security_hotspot" in types:
+        if self.rules_parameter == "" and "security_hotspot" in types:
             url = await super()._api_url()
             component = self._parameter("component")
             branch = self._parameter("branch")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- Don't include SonarQube security hotspots in the complex units, long units, many parameters, commented out code, and suppressed violations metrics. Fixes [#1138](https://github.com/ICTU/quality-time/issues/1138).
+
+
 ## [2.2.1] - [2020-04-22]
 
 ### Fixed


### PR DESCRIPTION
…units, many parameters, commented out code, and suppressed violations metrics. Fixes #1138.