### PR TITLE
Adding a metric or changing the type of a metric would sometimes fail…

### DIFF
--- a/components/frontend/src/dashboard/CardDashboard.js
+++ b/components/frontend/src/dashboard/CardDashboard.js
@@ -35,10 +35,11 @@ export function CardDashboard({ cards, initial_layout, save_layout }) {
     const [layout, setLayout] = useState(initial_layout);
     if (cards.length === 0) { return null }
     function onLayoutChange(new_layout) {
-        if (JSON.stringify(new_layout) !== JSON.stringify(layout)) {
-            setLayout(new_layout);
+        if (new_layout.length === layout.length && JSON.stringify(new_layout) !== JSON.stringify(layout)) {
+            // Only save the layout if it was changed by rearranging cards
             save_layout(new_layout)
         }
+        setLayout(new_layout);
     }
     function onDragStart(current_layout, oldItem, newItem, placeholder, event) {
         setDragging(true);

--- a/components/frontend/src/dashboard/CardDashboard.test.js
+++ b/components/frontend/src/dashboard/CardDashboard.test.js
@@ -19,7 +19,7 @@ describe("<CardDashboard />", () => {
             <ReadOnlyContext.Provider value={false}>
                 <CardDashboard
                     cards={[<MetricSummaryCard red={1} green={2} yellow={1} white={0} grey={0} />]}
-                    initial_layout={[]}
+                    initial_layout={[{h: 6, w: 4, x: 0, y: 0}]}
                     save_layout={mockCallBack}
                 />
             </ReadOnlyContext.Provider>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- Adding a metric or changing the type of a metric would sometimes fail due to a conflict with saving the dashboard layout. Fixed by only saving the dashboard layout when the user manually rearranges cards and not when a card gets added or removed. Fixes [#1160](https://github.com/ICTU/quality-time/issues/1160).
+
 ## [2.2.3] - [2020-05-10]
 
 ### Fixed


### PR DESCRIPTION
… due to a conflict with saving the dashboard layout. Fixed by only saving the dashboard layout when the user manually rearranges cards and not when a card gets added or removed. Fixes #1160.