### PR TITLE
Quality-time was using the 5.1 version of the Azure DevOps API to get…

### DIFF
--- a/components/collector/src/source_collectors/api_source_collectors/azure_devops.py
+++ b/components/collector/src/source_collectors/api_source_collectors/azure_devops.py
@@ -127,7 +127,7 @@ class AzureDevopsTests(SourceCollector):
 
     async def _api_url(self) -> URL:
         api_url = await super()._api_url()
-        return URL(f"{api_url}/_apis/test/runs?automated=true&includeRunDetails=true&$top=1&api-version=5.1")
+        return URL(f"{api_url}/_apis/test/runs?automated=true&includeRunDetails=true&$top=1&api-version=5.0")
 
     async def _parse_source_responses(self, responses: Responses) -> Tuple[Value, Value, Entities]:
         test_results = cast(List[str], self._parameter("test_result"))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- Quality-time was using the 5.1 version of the Azure DevOps API to get the number of tests for the 'tests' metric causing Quality-time to not work with Azure DevOps Server 2019. Fixed by using the 5.0 version of the API that also returns the required data. Fixes [#1182](https://github.com/ICTU/quality-time/issues/1182).
+
 ## [2.2.4] - [2020-05-11]
 
 ### Fixed


### PR DESCRIPTION
… the number of tests for the 'tests' metric causing Quality-time to not work with Azure DevOps Server 2019. Fixed by using the 5.0 version of the API that also returns the required data. Fixes #1182.