### PR TITLE
Don't strip hyphens from usernames when authenticating them with LDAP…

### DIFF
--- a/components/server/src/routes/auth.py
+++ b/components/server/src/routes/auth.py
@@ -60,7 +60,7 @@ def check_password(ssha_ldap_salted_password, password):
 def get_credentials() -> Tuple[str, str]:
     """Return the credentials from the request."""
     credentials = dict(bottle.request.json)
-    unsafe_characters = re.compile(r"[^\w ]+", re.UNICODE)
+    unsafe_characters = re.compile(r"[^\w\- ]+", re.UNICODE)
     username = re.sub(unsafe_characters, "", credentials.get("username", "no username given"))
     password = credentials.get("password", "no password given")
     return username, password

--- a/components/server/tests/routes/test_auth.py
+++ b/components/server/tests/routes/test_auth.py
@@ -12,7 +12,7 @@ from database import sessions
 from routes import auth
 
 
-USERNAME = "jodoe"
+USERNAME = "john-doe"
 PASSWORD = "secret"
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- Don't strip hyphens from usernames when authenticating them with LDAP. Fixes [#1198](https://github.com/ICTU/quality-time/issues/1198).
+
 ## [2.3.0] - [2020-06-01]
 
 ### Added


### PR DESCRIPTION
…. Fixes #1198.