### PR TITLE
Make source links open in a new window

### DIFF
--- a/components/frontend/src/metric/SourceStatus.js
+++ b/components/frontend/src/metric/SourceStatus.js
@@ -8,7 +8,7 @@ export function SourceStatus(props) {
   const source = props.metric.sources[props.source_uuid];
   const source_name = get_source_name(source, props.datamodel);
   function source_label() {
-    return (props.source.landing_url ? <a href={props.source.landing_url}>{source_name}</a> : source_name)
+    return (props.source.landing_url ? <a href={props.source.landing_url} target='_blank'>{source_name}</a> : source_name)
   }
   if (props.source.connection_error || props.source.parse_error) {
     return (

--- a/components/frontend/src/metric/SourceStatus.js
+++ b/components/frontend/src/metric/SourceStatus.js
@@ -8,7 +8,7 @@ export function SourceStatus(props) {
   const source = props.metric.sources[props.source_uuid];
   const source_name = get_source_name(source, props.datamodel);
   function source_label() {
-    return (props.source.landing_url ? <a href={props.source.landing_url} target='_blank'>{source_name}</a> : source_name)
+    return (props.source.landing_url ? <a href={props.source.landing_url} target='_blank' rel='noopener noreferrer'>{source_name}</a> : source_name)
   }
   if (props.source.connection_error || props.source.parse_error) {
     return (

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [2.3.2] - [2020-06-04]
+
+### Changed
+
+- Open the source links in separate window. Closes [#1203](https://github.com/ICTU/quality-time/issues/1203).
+
 ## [2.3.1] - [2020-06-02]
 
 ### Fixed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
-## [2.3.2] - [2020-06-04]
+## [Unreleased]
 
 ### Changed
 


### PR DESCRIPTION
Opening source links in the same window will, when returning to QT using the back-button, result in coming back to the main QT screen. This means losing the focus of your work.
