### PR TITLE
The 'source up-to-dateness' metric could report a negative number of …

### DIFF
--- a/components/collector/src/collector_utilities/functions.py
+++ b/components/collector/src/collector_utilities/functions.py
@@ -70,7 +70,7 @@ def sha1_hash(string: str) -> str:
 
 def days_ago(date_time: datetime) -> int:
     """Return the days since the date/time."""
-    return (datetime.now(tz=date_time.tzinfo) - date_time).days
+    return max(0, (datetime.now(tz=date_time.tzinfo) - date_time).days)
 
 
 def is_regexp(string: str) -> bool:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Reenable environment variables to set a proxy to be used by the collector. See https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support. Fixes [#1217](https://github.com/ICTU/quality-time/issues/1217).
+- The 'source up-to-dateness' metric could report a negative number of days ago due to differences in timezone or system clock between Quality-time and the source. Fixes [#1217](https://github.com/ICTU/quality-time/issues/1213).
+- Reenable environment variables to set a proxy to be used by the collector. See the [deployment documentation](DEPLOY.md). Fixes [#1217](https://github.com/ICTU/quality-time/issues/1217).
 
 ## [2.3.1] - [2020-06-02]
 


### PR DESCRIPTION
…days ago due to differences in timezone or system clock between Quality-time and the source. Fixes #1217.