### PR TITLE
Reordering items or changing the type of a metric would sometimes fai…

### DIFF
--- a/components/frontend/src/dashboard/CardDashboard.js
+++ b/components/frontend/src/dashboard/CardDashboard.js
@@ -35,7 +35,7 @@ export function CardDashboard({ cards, initial_layout, save_layout }) {
     const [layout, setLayout] = useState(initial_layout);
     if (cards.length === 0) { return null }
     function onLayoutChange(new_layout) {
-        if (new_layout.length === layout.length && JSON.stringify(new_layout) !== JSON.stringify(layout)) {
+        if (dragging && new_layout.length === layout.length && JSON.stringify(new_layout) !== JSON.stringify(layout)) {
             // Only save the layout if it was changed by rearranging cards
             save_layout(new_layout)
         }

--- a/components/frontend/src/dashboard/CardDashboard.test.js
+++ b/components/frontend/src/dashboard/CardDashboard.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
-import { ReadOnlyContext} from '../context/ReadOnly';
+import { ReadOnlyContext } from '../context/ReadOnly';
 import { CardDashboard } from './CardDashboard';
 import { MetricSummaryCard } from './MetricSummaryCard';
 
@@ -12,25 +13,46 @@ describe("<CardDashboard />", () => {
 });
 
 describe("<CardDashboard />", () => {
-    var mockCallBack, wrapper;
-    beforeEach(() => {
-        mockCallBack = jest.fn();
-        wrapper = mount(
-            <ReadOnlyContext.Provider value={false}>
-                <CardDashboard
-                    cards={[<MetricSummaryCard red={1} green={2} yellow={1} white={0} grey={0} />]}
-                    initial_layout={[{h: 6, w: 4, x: 0, y: 0}]}
-                    save_layout={mockCallBack}
-                />
-            </ReadOnlyContext.Provider>
-        );
-    });
-    it('calls the callback on drag', () => {
-        wrapper.find("div.react-draggable").at(0).simulate("drag");
+    it('saves the layout after drag', async () => {
+        let wrapper;
+        let mockCallBack = jest.fn();
+        await act(async () => {
+            wrapper = mount(
+                <ReadOnlyContext.Provider value={false}>
+                    <CardDashboard
+                        cards={[<MetricSummaryCard red={1} green={2} yellow={1} white={0} grey={0} />]}
+                        initial_layout={[{ h: 6, w: 4, x: 0, y: 0 }]}
+                        save_layout={mockCallBack}
+                    />
+                </ReadOnlyContext.Provider>
+            );
+            wrapper.find("ReactGridLayout").at(0).prop("onDragStart")({}, {}, {}, {}, { clientX: 0, clientY: 0 });
+            wrapper.setProps({})  // rerender
+        });
+        await act(async () => {
+            wrapper.find("ReactGridLayout").at(0).prop("onLayoutChange")([{h: 6, w: 4, x: 200, y: 200}]);
+        });
         expect(mockCallBack).toHaveBeenCalled();
     });
-    it('calls the callback on click', () => {
-        wrapper.find("div.react-draggable").at(0).simulate("click");
-        expect(mockCallBack).toHaveBeenCalled();
+    it('does not save the layout after click', async () => {
+        let wrapper;
+        let mockCallBack = jest.fn();
+        await act(async () => {
+            wrapper = mount(
+                <ReadOnlyContext.Provider value={false}>
+                    <CardDashboard
+                        cards={[<MetricSummaryCard red={1} green={2} yellow={1} white={0} grey={0} />]}
+                        initial_layout={[{ h: 6, w: 4, x: 0, y: 0 }]}
+                        save_layout={mockCallBack}
+                    />
+                </ReadOnlyContext.Provider>
+            );
+            wrapper.find("ReactGridLayout").at(0).prop("onDragStart")({}, {}, {}, {}, { clientX: 100, clientY: 100 });
+            wrapper.setProps({})  // rerender
+        });
+        await act(async () => {
+            wrapper.find("div.react-draggable").at(0).simulate("click");
+        });
+        expect(mockCallBack).not.toHaveBeenCalled();
     });
 });

--- a/components/frontend/src/dashboard/CardDashboard.test.js
+++ b/components/frontend/src/dashboard/CardDashboard.test.js
@@ -13,46 +13,33 @@ describe("<CardDashboard />", () => {
 });
 
 describe("<CardDashboard />", () => {
-    it('saves the layout after drag', async () => {
-        let wrapper;
-        let mockCallBack = jest.fn();
+    let mockCallback, wrapper;
+    beforeEach(async () => {
+        mockCallback = jest.fn();
         await act(async () => {
             wrapper = mount(
                 <ReadOnlyContext.Provider value={false}>
                     <CardDashboard
                         cards={[<MetricSummaryCard red={1} green={2} yellow={1} white={0} grey={0} />]}
                         initial_layout={[{ h: 6, w: 4, x: 0, y: 0 }]}
-                        save_layout={mockCallBack}
+                        save_layout={mockCallback}
                     />
                 </ReadOnlyContext.Provider>
             );
             wrapper.find("ReactGridLayout").at(0).prop("onDragStart")({}, {}, {}, {}, { clientX: 0, clientY: 0 });
             wrapper.setProps({})  // rerender
         });
+    });
+    it('saves the layout after drag', async () => {
         await act(async () => {
             wrapper.find("ReactGridLayout").at(0).prop("onLayoutChange")([{h: 6, w: 4, x: 200, y: 200}]);
         });
-        expect(mockCallBack).toHaveBeenCalled();
+        expect(mockCallback).toHaveBeenCalled();
     });
     it('does not save the layout after click', async () => {
-        let wrapper;
-        let mockCallBack = jest.fn();
-        await act(async () => {
-            wrapper = mount(
-                <ReadOnlyContext.Provider value={false}>
-                    <CardDashboard
-                        cards={[<MetricSummaryCard red={1} green={2} yellow={1} white={0} grey={0} />]}
-                        initial_layout={[{ h: 6, w: 4, x: 0, y: 0 }]}
-                        save_layout={mockCallBack}
-                    />
-                </ReadOnlyContext.Provider>
-            );
-            wrapper.find("ReactGridLayout").at(0).prop("onDragStart")({}, {}, {}, {}, { clientX: 100, clientY: 100 });
-            wrapper.setProps({})  // rerender
-        });
         await act(async () => {
             wrapper.find("div.react-draggable").at(0).simulate("click");
         });
-        expect(mockCallBack).not.toHaveBeenCalled();
+        expect(mockCallback).not.toHaveBeenCalled();
     });
 });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Moved the Copy and Move buttons next to the Add buttons, making the UI more consistent. This also allows the user to copy an existing item to the right position in one go, instead of having to copy and then move it. To support adding items by copying an existing item, the API has been updated to version 3. Version 2 of the API is deprecated. See <http://quality-time.example.org/api/>, <http://quality-time.example.org/api/v2>, and <http://quality-time.example.org/api/v3>. Note that your Docker composition may need to be changed to use the new API version. See the Caddy proxy configuration in the example [docker-compose.yml](../docker/docker-compose.yml). Closes [#1197](https://github.com/ICTU/quality-time/issues/1197).
 
+### Fixed
+
+- Reordering items or changing the type of a metric would sometimes fail because Quality-time would also try to save the layout of the dashboard. Fixed by only saving the dashboard layout when the user deliberately changes the layout by dragging a card. Fixes [#1160](https://github.com/ICTU/quality-time/issues/1160).
+
 ## [2.3.2] - [2020-06-10]
 
 ### Changed


### PR DESCRIPTION
…l because Quality-time would also try to save the layout of the dashboard. Fixed by only saving the dashboard layout when the user deliberately changes the layout by dragging a card. Fixes #1160.