### PR TITLE
The git clone URL in the README.md required people to have a public S…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 *Quality-time* is an automated quality system for software development and maintenance. *Quality-time* collects measurement data from sources such as Gitlab, SonarQube, Jira, Azure DevOps, and OWASP Dependency Check, to provide an overview of the quality of software products and projects. It does so by comparing measurement data with metric targets and informing development teams about the metrics that need improvement actions.
 
-Technically, *Quality-time* consists of a Mongo database server, an API-server written in Python, a metrics data collector component also written in Python, and a React frontend. 
+Technically, *Quality-time* consists of a Mongo database server, an API-server written in Python, a metrics data collector component also written in Python, and a React frontend.
 
 Users can add and configure reports, metrics, and sources (such as SonarQube and Jira) in the frontend. The collector collects metrics data from the configured metric sources. It posts the measurements to the server which in turn stores them in the database. The frontend calls the server to get the reports and the measurements and presents them to the user.
 
@@ -75,7 +75,7 @@ For more plans, see the [issue tracker](https://github.com/ICTU/quality-time/iss
 Clone this repository:
 
 ```console
-git clone git@github.com:ICTU/quality-time.git
+git clone https://github.com/ICTU/quality-time.git
 ```
 
 Build the containers:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Collecting unmerged branches using Azure DevOps as source would fail if the project name contained spaces and the user did not specify a repository. Quality-time would fail to find the default repository because it would use the URL-quoted project name to look for it, instead of the unquoted project name. Fixes [#1224](https://github.com/ICTU/quality-time/issues/1224).
 - When using Jira as source for the 'ready user story points' metric, changing the status of a user story in the details tab didn't work. Fixes [#1230](https://github.com/ICTU/quality-time/issues/1230).
 - When using Jira as source for the 'ready user story points' metric, changing the status of a user story in the details tab to wont't fix, false positive or fixed would reduce the total number of story points with one instead of the number of story points of the ignored user story. Fixes [#1233](https://github.com/ICTU/quality-time/issues/1233).
+- The `git clone` URL in the [README.md](README.md) required people to have a public SSH key added to their GitHub account. Replaced with a https URL which doesn't have this issue. Fixes [#1235](https://github.com/ICTU/quality-time/issues/1235).
 - When using the OWASP Dependency Check as source for the 'security warnings' metric, changing the status of a warning in the details tab didn't work. Fixes [#1238](https://github.com/ICTU/quality-time/issues/1238).
 
 ## [2.3.2] - [2020-06-10]


### PR DESCRIPTION
…SH key added to their GitHub account. Replaced with a https URL which doesn't have this issue. Fixes #1235.