### PR TITLE
Don't disable the 'scroll to dashboard' button when the dashboard is …

### DIFF
--- a/components/frontend/src/App.js
+++ b/components/frontend/src/App.js
@@ -22,8 +22,7 @@ class App extends Component {
     super(props);
     this.state = {
       datamodel: {}, reports: [], report_uuid: '', search_string: '', report_date_string: '', reports_overview: {},
-      nr_measurements: 0, loading: true, user: null, email: null, last_update: new Date(), login_error: false,
-      dashboard_visible: true
+      nr_measurements: 0, loading: true, user: null, email: null, last_update: new Date(), login_error: false
     };
     this.history = createBrowserHistory();
     this.history.listen((location, action) => {
@@ -134,7 +133,7 @@ class App extends Component {
   go_home() {
     if (this.history.location.pathname !== "/") {
       this.history.push("/");
-      this.setState({ report_uuid: "", loading: true, dashboard_visible: true }, () => this.reload());
+      this.setState({ report_uuid: "", loading: true }, () => this.reload());
     }
   }
 
@@ -221,7 +220,6 @@ class App extends Component {
       <div style={{ display: "flex", minHeight: "100vh", flexDirection: "column" }}>
         <HashLinkObserver />
         <Menubar
-          dashboard_visible={this.state.dashboard_visible}
           email={this.state.email}
           go_dashboard={(e) => this.go_dashboard(e)}
           go_home={() => this.go_home()}
@@ -242,7 +240,6 @@ class App extends Component {
               :
               this.state.report_uuid === "" ?
                 <Reports
-                  set_dashboard_visible={(visible) => this.setState({dashboard_visible: visible})}
                   open_report={(e, r) => this.open_report(e, r)}
                   open_tag_report={(e, t) => this.open_tag_report(e, t)}
                   reports_overview={this.state.reports_overview}
@@ -250,7 +247,6 @@ class App extends Component {
                 />
                 :
                 <Report
-                  set_dashboard_visible={(visible) => this.setState({dashboard_visible: visible})}
                   datamodel={this.state.datamodel}
                   go_home={() => this.go_home()}
                   nr_measurements={this.state.nr_measurements}

--- a/components/frontend/src/App.test.js
+++ b/components/frontend/src/App.test.js
@@ -63,17 +63,9 @@ describe("<App/>", () => {
     expect(wrapper.find('Container').find('Segment').exists()).toBe(false);
   });
 
-  it('sets the dashboard to visible on go home', () => {
-    const wrapper = shallow(<App />);
-    wrapper.instance().open_report(new Event('click'), "report_uuid");
-    wrapper.instance().go_home();
-    expect(wrapper.state('dashboard_visible')).toBe(true);
-  });
-
   it('does not crash scrolling if there is no dashboard', () => {
     const wrapper = shallow(<App />);
     wrapper.instance().go_dashboard(new Event('click'));
-    expect(wrapper.state('dashboard_visible')).toBe(true);
   });
 
   it('scrolls the dashboard', () => {
@@ -83,7 +75,6 @@ describe("<App/>", () => {
     Object.defineProperty(global.window, 'scrollBy', { value: jest.fn() });
     const wrapper = shallow(<App />);
     wrapper.instance().go_dashboard(new Event('click'));
-    expect(wrapper.state('dashboard_visible')).toBe(true);
     expect(scrollIntoView).toHaveBeenCalled()
   });
 });

--- a/components/frontend/src/dashboard/CardDashboard.js
+++ b/components/frontend/src/dashboard/CardDashboard.js
@@ -1,5 +1,5 @@
-import React, { createRef, useState } from 'react';
-import { Ref, Segment, Visibility } from 'semantic-ui-react';
+import React, { useState } from 'react';
+import { Segment } from 'semantic-ui-react';
 import RGL, { WidthProvider } from "react-grid-layout";
 import { ReadOnlyContext } from '../context/ReadOnly';
 
@@ -29,12 +29,11 @@ function card_divs(cards, cols, isDragging, card_width = 4, card_height = 6) {
     return divs;
 }
 
-export function CardDashboard({ cards, initial_layout, save_layout, set_dashboard_visible }) {
+export function CardDashboard({ cards, initial_layout, save_layout }) {
     const [dragging, setDragging] = useState(false);
     const [mousePos, setMousePos] = useState([0, 0, 0]);
     const [layout, setLayout] = useState(initial_layout);
     if (cards.length === 0) { return null }
-    const contextRef = createRef();
     function onLayoutChange(new_layout) {
         if (dragging && new_layout.length === layout.length && JSON.stringify(new_layout) !== JSON.stringify(layout)) {
             // Only save the layout if it was changed by rearranging cards
@@ -60,26 +59,22 @@ export function CardDashboard({ cards, initial_layout, save_layout, set_dashboar
     const cols = 32;
     const divs = card_divs(cards, cols, isDragging);
     return (
-        <Ref innerRef={contextRef}>
-            <Visibility onUpdate={(e, { calculations }) => set_dashboard_visible(calculations.topVisible)}>
-                <Segment>
-                    <ReadOnlyContext.Consumer>{(readOnly) => (
-                        <ReactGridLayout
-                            cols={cols}
-                            compactType={null}
-                            isDraggable={!readOnly}
-                            layout={layout}
-                            onDragStart={onDragStart}
-                            onDragStop={onDragStop}
-                            onLayoutChange={onLayoutChange}
-                            preventCollision={true}
-                            rowHeight={24}
-                        >
-                            {divs}
-                        </ReactGridLayout>)}
-                    </ReadOnlyContext.Consumer>
-                </Segment>
-            </Visibility>
-        </Ref>
+        <Segment>
+            <ReadOnlyContext.Consumer>{(readOnly) => (
+                <ReactGridLayout
+                    cols={cols}
+                    compactType={null}
+                    isDraggable={!readOnly}
+                    layout={layout}
+                    onDragStart={onDragStart}
+                    onDragStop={onDragStop}
+                    onLayoutChange={onLayoutChange}
+                    preventCollision={true}
+                    rowHeight={24}
+                >
+                    {divs}
+                </ReactGridLayout>)}
+            </ReadOnlyContext.Consumer>
+        </Segment>
     )
 }

--- a/components/frontend/src/dashboard/CardDashboard.test.js
+++ b/components/frontend/src/dashboard/CardDashboard.test.js
@@ -22,7 +22,7 @@ describe("<CardDashboard />", () => {
                     <CardDashboard
                         cards={[<MetricSummaryCard red={1} green={2} yellow={1} white={0} grey={0} />]}
                         initial_layout={[{ h: 6, w: 4, x: 0, y: 0 }]}
-                        save_layout={mockCallback} set_dashboard_visible={mockCallback}
+                        save_layout={mockCallback}
                     />
                 </ReadOnlyContext.Provider>
             );

--- a/components/frontend/src/header_footer/Menubar.js
+++ b/components/frontend/src/header_footer/Menubar.js
@@ -49,7 +49,7 @@ export function Menubar(props) {
         />
         <Popup content="Scroll to dashboard" trigger={
           <Menu.Item>
-            <Button disabled={props.dashboard_visible} inverted icon="arrow circle up" onClick={(e) => props.go_dashboard(e)} />
+            <Button inverted icon="arrow circle up" onClick={(e) => props.go_dashboard(e)} />
           </Menu.Item>}
         />
         <Menu.Menu position='right'>

--- a/components/frontend/src/header_footer/Menubar.test.js
+++ b/components/frontend/src/header_footer/Menubar.test.js
@@ -11,7 +11,7 @@ it('calls the go-home callback on click', () => {
 
 it('calls the scroll-to-dashboard callback on click', () => {
   const mockCallBack = jest.fn();
-  const wrapper = mount(<Menubar report_date_string="2019-10-10" onDate={console.log} go_dashboard={mockCallBack} dashboard_visible={false} />);
+  const wrapper = mount(<Menubar report_date_string="2019-10-10" onDate={console.log} go_dashboard={mockCallBack} />);
   wrapper.find("Button").at(0).simulate("click");
   expect(mockCallBack).toHaveBeenCalled();
 });

--- a/components/frontend/src/report/Report.js
+++ b/components/frontend/src/report/Report.js
@@ -36,7 +36,6 @@ function ReportDashboard(props) {
                 cards={subject_cards().concat(tag_cards())}
                 initial_layout={props.report.layout || []}
                 save_layout={function (layout) { if (!readOnly) { set_report_attribute(props.report.report_uuid, "layout", layout, props.reload) } }}
-                set_dashboard_visible={props.set_dashboard_visible}
             />)}
         </ReadOnlyContext.Consumer>
     )

--- a/components/frontend/src/report/Reports.js
+++ b/components/frontend/src/report/Reports.js
@@ -31,7 +31,6 @@ function ReportsDashboard(props) {
       cards={report_cards.concat(tag_cards)}
       initial_layout={props.layout || []}
       save_layout={function (layout) { set_reports_attribute("layout", layout, props.reload) }}
-      set_dashboard_visible={props.set_dashboard_visible}
     />
   )
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- Don't disable the 'scroll to dashboard' button when the dashboard is visible. This requires listening for scroll events which makes scrolling of big reports slow. Fixes [#1260](https://github.com/ICTU/quality-time/issues/1260).
+
 ## [2.4.0] - [2020-06-23]
 
 ### Added


### PR DESCRIPTION
…visible. This requires listening for scroll events which makes scrolling of big reports slow. Fixes #1260.