### PR TITLE
Older GitLab versions don't return a web_url as part of the repository/branches API, be prepared.

### DIFF
--- a/components/collector/src/source_collectors/api_source_collectors/gitlab.py
+++ b/components/collector/src/source_collectors/api_source_collectors/gitlab.py
@@ -156,4 +156,4 @@ class GitLabUnmergedBranches(GitLabBase, UnmergedBranchesSourceCollector):
         return parse(branch["commit"]["committed_date"])
 
     def _branch_landing_url(self, branch) -> URL:
-        return URL(branch["web_url"])
+        return URL(branch.get("web_url", ""))

--- a/components/server/src/data/datamodel.json
+++ b/components/server/src/data/datamodel.json
@@ -597,7 +597,7 @@
         },
         "unmerged_branches": {
             "name": "Unmerged branches",
-            "description": "The number of branches that have not been merged to master.",
+            "description": "The number of branches that have not been merged to the default branch.",
             "scales": [
                 "count"
             ],

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- Older GitLab versions don't return a `web_url` as part of the `repository/branches` API, be prepared. Fixes [#1280](https://github.com/ICTU/quality-time/issues/1280).
+
 ## [2.5.0] - [2020-07-05]
 
 ### Fixed

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -28,7 +28,7 @@
 | Tests | The number of tests. | ≧ 0 tests | test quality | Azure DevOps Server, Jenkins test report, JUnit XML report, Performancetest-runner, Robot Framework, SonarQube |
 | Test branch coverage | The amount of code branches not covered by tests. | ≦ 0 uncovered branches | test quality | Cobertura, JaCoCo, JaCoCo Jenkins plugin, NCover, SonarQube |
 | Test line coverage | The amount of lines of code not covered by tests. | ≦ 0 uncovered lines | test quality | Cobertura, JaCoCo, JaCoCo Jenkins plugin, NCover, SonarQube |
-| Unmerged branches | The number of branches that have not been merged to master. | ≦ 0 branches | ci | Azure DevOps Server, GitLab |
+| Unmerged branches | The number of branches that have not been merged to the default branch. | ≦ 0 branches | ci | Azure DevOps Server, GitLab |
 | Unused CI-jobs | The number of continuous integration jobs that are unused. | ≦ 0 CI-jobs | ci | Azure DevOps Server, GitLab, Jenkins |
 | Violations | The number of violations of programming rules in the software. | ≦ 0 violations | maintainability | OJAudit, SonarQube |
 


### PR DESCRIPTION
 Fixes #1280.