### PR TITLE
When using GitLab as source for the 'unused jobs' or 'failed jobs' me…

### DIFF
--- a/components/collector/tests/source_collectors/api_source_collectors/test_gitlab.py
+++ b/components/collector/tests/source_collectors/api_source_collectors/test_gitlab.py
@@ -62,14 +62,53 @@ class GitLabFailedJobsTest(GitLabTestCase):
         response = await self.collect(self.metric, get_request_json_return_value=self.gitlab_jobs_json)
         self.assert_measurement(response, value="0", entities=[])
 
+    async def test_ignore_job_by_name(self):
+        """Test that jobs can be ignored by name."""
+        self.sources["source_id"]["parameters"]["jobs_to_ignore"] = ["job2"]
+        self.gitlab_jobs_json.append(
+            dict(id="2", status="failed", name="job2", stage="stage", created_at="2019-03-31T19:50:39.927Z",
+                 web_url="https://gitlab/job", ref="master"))
+        response = await self.collect(self.metric, get_request_json_return_value=self.gitlab_jobs_json)
+        self.assert_measurement(response, value="1", entities=self.expected_entities)
+
+    async def test_ignore_job_by_ref(self):
+        """Test that jobs can be ignored by ref."""
+        self.sources["source_id"]["parameters"]["refs_to_ignore"] = ["develop"]
+        self.gitlab_jobs_json.append(
+            dict(id="2", status="failed", name="job2", stage="stage", created_at="2019-03-31T19:50:39.927Z",
+                 web_url="https://gitlab/job", ref="develop"))
+        response = await self.collect(self.metric, get_request_json_return_value=self.gitlab_jobs_json)
+        self.assert_measurement(response, value="1", entities=self.expected_entities)
+
 
 class GitLabUnusedJobsTest(GitLabTestCase):
     """Unit tests for the GitLab unused jobs metric."""
 
+    def setUp(self):
+        super().setUp()
+        self.metric = dict(type="unused_jobs", sources=self.sources, addition="sum")
+
     async def test_nr_of_unused_jobs(self):
         """Test that the number of unused jobs is returned."""
-        metric = dict(type="unused_jobs", sources=self.sources, addition="sum")
-        response = await self.collect(metric, get_request_json_return_value=self.gitlab_jobs_json)
+        response = await self.collect(self.metric, get_request_json_return_value=self.gitlab_jobs_json)
+        self.assert_measurement(response, value="1", entities=self.expected_entities)
+
+    async def test_ignore_job_by_name(self):
+        """Test that jobs can be ignored by name."""
+        self.sources["source_id"]["parameters"]["jobs_to_ignore"] = ["job2"]
+        self.gitlab_jobs_json.append(
+            dict(id="2", status="failed", name="job2", stage="stage", created_at="2019-03-31T19:50:39.927Z",
+                 web_url="https://gitlab/job", ref="master"))
+        response = await self.collect(self.metric, get_request_json_return_value=self.gitlab_jobs_json)
+        self.assert_measurement(response, value="1", entities=self.expected_entities)
+
+    async def test_ignore_job_by_ref(self):
+        """Test that jobs can be ignored by ref."""
+        self.sources["source_id"]["parameters"]["refs_to_ignore"] = ["develop"]
+        self.gitlab_jobs_json.append(
+            dict(id="2", status="failed", name="job2", stage="stage", created_at="2019-03-31T19:50:39.927Z",
+                 web_url="https://gitlab/job", ref="develop"))
+        response = await self.collect(self.metric, get_request_json_return_value=self.gitlab_jobs_json)
         self.assert_measurement(response, value="1", entities=self.expected_entities)
 
 

--- a/components/server/src/data/datamodel.json
+++ b/components/server/src/data/datamodel.json
@@ -2003,6 +2003,19 @@
                         "unmerged_branches"
                     ]
                 },
+                "refs_to_ignore": {
+                    "name": "Branches and tags to ignore (regular expressions, branch names or tag names)",
+                    "short_name": "branches and tags to ignore",
+                    "type": "multiple_choice_with_addition",
+                    "placeholder": "none",
+                    "mandatory": false,
+                    "help_url": "https://docs.gitlab.com/ee/user/project/repository/branches/",
+                    "default_value": [],
+                    "metrics": [
+                        "failed_jobs",
+                        "unused_jobs"
+                    ]
+                },
                 "inactive_days": {
                     "name": "Number of days since last commit after which to consider branches inactive",
                     "short_name": "number of days since last commit",
@@ -2043,6 +2056,19 @@
                     "metrics": [
                         "failed_jobs"
                     ]
+                },
+                "jobs_to_ignore": {
+                    "name": "Jobs to ignore (regular expressions or job names)",
+                    "short_name": "jobs to ignore",
+                    "help": "Jobs to ignore can be specified by job name or by regular expression.",
+                    "type": "multiple_choice_with_addition",
+                    "placeholder": "none",
+                    "mandatory":  false,
+                    "default_value": [],
+                    "metrics": [
+                        "failed_jobs",
+                        "unused_jobs"
+                    ]
                 }
             },
             "entities": {
@@ -2060,7 +2086,7 @@
                             "key": "stage"
                         },
                         {
-                            "name": "Branch name",
+                            "name": "Branch or tag",
                             "key": "branch"
                         },
                         {
@@ -2119,7 +2145,7 @@
                             "key": "stage"
                         },
                         {
-                            "name": "Branch name",
+                            "name": "Branch or tag",
                             "key": "branch"
                         },
                         {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Added
+
+- When using GitLab as source for the 'unused jobs' or 'failed jobs' metrics, allow for ignoring jobs/pipelines by name, by branch, and by tag. Closes [#1288](https://github.com/ICTU/quality-time/issues/1288).
+
 ## [2.5.2] - [2020-07-10]
 
 ### Fixed

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -181,7 +181,9 @@
 | GitLab instance URL | URL | Yes | URL of the GitLab instance, with port if necessary, but without path. For example, 'https://gitlab.com'. |
 | Project (name with namespace or id) | String | Yes | [https://docs.gitlab.com/ee/user/project/](https://docs.gitlab.com/ee/user/project/) |
 | Private token | Password | No | [https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) |
+| Branches and tags to ignore (regular expressions, branch names or tag names) | Multiple choice with addition | No | [https://docs.gitlab.com/ee/user/project/repository/branches/](https://docs.gitlab.com/ee/user/project/repository/branches/) |
 | Failure type | Multiple choice | No | Limit which failure types to count as failed. |
+| Jobs to ignore (regular expressions or job names) | Multiple choice with addition | No | Jobs to ignore can be specified by job name or by regular expression. |
 
 ### Issues from Azure DevOps Server
 
@@ -851,7 +853,9 @@
 | GitLab instance URL | URL | Yes | URL of the GitLab instance, with port if necessary, but without path. For example, 'https://gitlab.com'. |
 | Project (name with namespace or id) | String | Yes | [https://docs.gitlab.com/ee/user/project/](https://docs.gitlab.com/ee/user/project/) |
 | Private token | Password | No | [https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) |
+| Branches and tags to ignore (regular expressions, branch names or tag names) | Multiple choice with addition | No | [https://docs.gitlab.com/ee/user/project/repository/branches/](https://docs.gitlab.com/ee/user/project/repository/branches/) |
 | Number of days without builds after which to consider CI-jobs unused. | Integer | No |  |
+| Jobs to ignore (regular expressions or job names) | Multiple choice with addition | No | Jobs to ignore can be specified by job name or by regular expression. |
 
 ### Unused CI-jobs from Jenkins
 


### PR DESCRIPTION
…trics, allow for ignoring jobs/pipelines by name, by branch, and by tag. Closes #1288.