### PR TITLE
Remove code to fix the database structure. 

### DIFF
--- a/components/server/src/database/reports.py
+++ b/components/server/src/database/reports.py
@@ -83,7 +83,6 @@ def changelog(database: Database, nr_changes: int, **uuids):
     if not uuids:
         changes.extend(database.reports_overviews.find(
             filter=delta_filter, sort=sort_order, limit=nr_changes*2, projection=projection))
-        print(changes)
     old_report_delta_filter = {f"delta.{key}": value for key, value in uuids.items() if value}
     new_report_delta_filter = {"delta.uuids": {"$in": list(uuids.values())}}
     delta_filter["$or"] = [old_report_delta_filter, new_report_delta_filter]

--- a/components/server/tests/initialization/test_database.py
+++ b/components/server/tests/initialization/test_database.py
@@ -58,20 +58,3 @@ class DatabaseInitTest(unittest.TestCase):
             self.init_database('{"change": "yes"}', False)
         self.database.datamodels.insert_one.assert_called_once()
         self.database.reports_overviews.insert.assert_called_once()
-
-    def test_update_database(self):
-        """Test that some fields are removed."""
-        self.database.reports.find.return_value = [
-            dict(_id="report_uuid", subjects=dict(subject_uuid=dict(metrics=dict(metric_uuid=dict()))))]
-        self.database.reports.count_documents.return_value = 1
-        self.init_database("{}")
-        self.database.reports.update_one.assert_called_once_with(
-            {'_id': 'report_uuid'},
-            update={
-                '$unset': {
-                    'summary': '',
-                    'summary_by_subject': '',
-                    'summary_by_tag': '',
-                    'subjects.subject_uuid.metrics.metric_uuid.recent_measurements': '',
-                    'subjects.subject_uuid.metrics.metric_uuid.status': '',
-                    'subjects.subject_uuid.metrics.metric_uuid.value': ''}})

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 - Version 2 of the *Quality-time* API has been removed.
+- Remove code to fix the database structure. If you are migrating from a *Quality-time* version < 2.0.0 you need to install at least one *Quality-time* version >= 2.0.0 and < 3.0.0.
 
 ## [2.5.2] - [2020-07-10]
 


### PR DESCRIPTION
If you are migrating from a Quality-time version < 2.0.0 you need to install at least one Quality-time version >= 2.0.0 and < 3.0.0.