### PR TITLE
Quality-time would not measure the manual test execution metric until…

### DIFF
--- a/components/collector/src/base_collectors/metrics_collector.py
+++ b/components/collector/src/base_collectors/metrics_collector.py
@@ -132,7 +132,7 @@ class MetricsCollector:
             parameters = self.data_model.get("sources", {}).get(source["type"], {}).get("parameters", {})
             for parameter_key, parameter in parameters.items():
                 if parameter.get("mandatory") and metric["type"] in parameter.get("metrics") and \
-                        not source.get("parameters", {}).get(parameter_key):
+                        not source.get("parameters", {}).get(parameter_key) and not parameter.get("default_value"):
                     return False
         return bool(sources)
 

--- a/components/collector/tests/base_collectors/test_metrics_collector.py
+++ b/components/collector/tests/base_collectors/test_metrics_collector.py
@@ -171,6 +171,28 @@ class CollectorTest(unittest.IsolatedAsyncioTestCase):
         await self.fetch_measurements(mock_async_get_request)
         mocked_post.assert_not_called()
 
+    @patch("aiohttp.ClientSession.post")
+    async def test_missing_mandatory_parameter_with_default_value(self, mocked_post):
+        """Test that a metric with sources and a missing mandatory parameter, but with a default value, is not
+        skipped."""
+        metrics = dict(
+            metric_uuid=dict(
+                type="metric", addition="sum",
+                sources=dict(source_id=dict(type="source", parameters=dict(url=self.url)))))
+        self.data_model["sources"]["source"]["parameters"]["token"] = dict(
+            default_value="xxx", mandatory=True, metrics=["metric"])
+        self.metrics_collector.data_model = self.data_model
+        mock_async_get_request = AsyncMock()
+        mock_async_get_request.json.return_value = metrics
+        await self.fetch_measurements(mock_async_get_request)
+        mocked_post.assert_called_once_with(
+            "http://localhost:5001/api/v3/measurements",
+            json=dict(
+                sources=[
+                    dict(api_url=self.url, landing_url=self.url, value="42", total="84", entities=[],
+                         connection_error=None, parse_error=None, source_uuid="source_id")],
+                metric_uuid="metric_uuid"))
+
     @patch("builtins.open", mock_open())
     async def test_fetch_data_model_after_failure(self):
         """Test that the data model is fetched on the second try."""

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - When measuring the 'manual test duration' metric *Quality-time* would subtract one minute for each ignored test case, instead of the duration of the ignored test case. Fixes [#1361](https://github.com/ICTU/quality-time/issues/1361).
+- *Quality-time* would not measure the 'manual test execution' metric until the user changed the 'default expected manual test execution frequency' field. Fixes [#1363](https://github.com/ICTU/quality-time/issues/1363).
 
 ## [3.1.0] - [2020-08-07]
 


### PR DESCRIPTION
… the user changed the default expected manual test execution frequency field. Fixes #1363.