### PR TITLE
When measuring the number of test cases using Jenkins test report as …

### DIFF
--- a/components/collector/src/source_collectors/api_source_collectors/jenkins_test_report.py
+++ b/components/collector/src/source_collectors/api_source_collectors/jenkins_test_report.py
@@ -40,7 +40,9 @@ class JenkinsTestReportTests(SourceCollector):
     def __entity(self, case: TestCase) -> Entity:
         """Transform a test case into a test case entity."""
         name = case.get("name", "<nameless test case>")
-        return dict(key=name, name=name, class_name=case.get("className", ""), test_result=self.__status(case))
+        return dict(
+            key=name, name=name, class_name=case.get("className", ""), test_result=self.__status(case),
+            age=str(case.get("age", 0)))
 
     @staticmethod
     def __status(case: TestCase) -> str:

--- a/components/collector/tests/source_collectors/api_source_collectors/test_jenkins_test_report.py
+++ b/components/collector/tests/source_collectors/api_source_collectors/test_jenkins_test_report.py
@@ -17,15 +17,15 @@ class JenkinsTestReportTest(SourceCollectorTestCase):
         """Test that the number of tests is returned."""
         jenkins_json = dict(
             failCount=1, passCount=1, suites=[dict(
-                cases=[dict(status="FAILED", name="tc1", className="c1"),
-                       dict(status="PASSED", name="tc2", className="c2")])])
+                cases=[dict(status="FAILED", name="tc1", className="c1", age=1),
+                       dict(status="PASSED", name="tc2", className="c2", age=0)])])
         metric = dict(type="tests", addition="sum", sources=self.sources)
         response = await self.collect(metric, get_request_json_return_value=jenkins_json)
         self.assert_measurement(
             response, value="2",
             entities=[
-                dict(class_name="c1", key="tc1", name="tc1", test_result="failed"),
-                dict(class_name="c2", key="tc2", name="tc2", test_result="passed")])
+                dict(class_name="c1", key="tc1", name="tc1", test_result="failed", age="1"),
+                dict(class_name="c2", key="tc2", name="tc2", test_result="passed", age="0")])
 
     async def test_nr_of_tests_with_aggregated_report(self):
         """Test that the number of tests is returned when the test report is an aggregated report."""
@@ -36,41 +36,41 @@ class JenkinsTestReportTest(SourceCollectorTestCase):
                         failCount=1, passCount=1,
                         suites=[dict(
                             cases=[
-                                dict(status="FAILED", name="tc1", className="c1"),
-                                dict(status="PASSED", name="tc2", className="c2")])]))])
+                                dict(status="FAILED", name="tc1", className="c1", age=2),
+                                dict(status="PASSED", name="tc2", className="c2", age=0)])]))])
         metric = dict(type="tests", addition="sum", sources=self.sources)
         response = await self.collect(metric, get_request_json_return_value=jenkins_json)
         self.assert_measurement(
             response, value="2",
             entities=[
-                dict(class_name="c1", key="tc1", name="tc1", test_result="failed"),
-                dict(class_name="c2", key="tc2", name="tc2", test_result="passed")])
+                dict(class_name="c1", key="tc1", name="tc1", test_result="failed", age="2"),
+                dict(class_name="c2", key="tc2", name="tc2", test_result="passed", age="0")])
 
     async def test_nr_of_passed_tests(self):
         """Test that the number of passed tests is returned."""
         jenkins_json = dict(
             failCount=1, passCount=1, suites=[dict(
-                cases=[dict(status="FAILED", name="tc1", className="c1"),
-                       dict(status="PASSED", name="tc2", className="c2")])])
+                cases=[dict(status="FAILED", name="tc1", className="c1", age=3),
+                       dict(status="PASSED", name="tc2", className="c2", age=0)])])
         self.sources["source_id"]["parameters"]["test_result"] = ["passed"]
         metric = dict(type="tests", addition="sum", sources=self.sources)
         response = await self.collect(metric, get_request_json_return_value=jenkins_json)
-        expected_entities = [dict(class_name="c2", key="tc2", name="tc2", test_result="passed")]
+        expected_entities = [dict(class_name="c2", key="tc2", name="tc2", test_result="passed", age="0")]
         self.assert_measurement(response, value="1", entities=expected_entities)
 
     async def test_nr_of_failed_tests(self):
         """Test that the number of failed tests is returned."""
         jenkins_json = dict(
             failCount=2, suites=[dict(
-                cases=[dict(status="FAILED", name="tc1", className="c1"),
-                       dict(status="FAILED", name="tc2", className="c2"),
-                       dict(status="PASSED", name="tc3", className="c3")])])
+                cases=[dict(status="FAILED", name="tc1", className="c1", age=1),
+                       dict(status="FAILED", name="tc2", className="c2", age=2),
+                       dict(status="PASSED", name="tc3", className="c3", age=0)])])
         self.sources["source_id"]["parameters"]["test_result"] = ["failed"]
         metric = dict(type="tests", addition="sum", sources=self.sources)
         response = await self.collect(metric, get_request_json_return_value=jenkins_json)
         expected_entities = [
-            dict(class_name="c1", key="tc1", name="tc1", test_result="failed"),
-            dict(class_name="c2", key="tc2", name="tc2", test_result="failed")]
+            dict(class_name="c1", key="tc1", name="tc1", test_result="failed", age="1"),
+            dict(class_name="c2", key="tc2", name="tc2", test_result="failed", age="2")]
         self.assert_measurement(response, value="2", entities=expected_entities)
 
     async def test_source_up_to_dateness(self):

--- a/components/server/src/data/datamodel.json
+++ b/components/server/src/data/datamodel.json
@@ -2514,7 +2514,7 @@
                             }
                         },
                         {
-                            "name": "Number of builds failing",
+                            "name": "Number of builds the test has been failing",
                             "key": "age",
                             "type": "integer"
                         }

--- a/components/server/src/data/datamodel.json
+++ b/components/server/src/data/datamodel.json
@@ -2512,6 +2512,11 @@
                                 "passed": "positive",
                                 "skipped": "warning"
                             }
+                        },
+                        {
+                            "name": "Number of builds failing",
+                            "key": "age",
+                            "type": "integer"
                         }
                     ]
                 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- When measuring the number of test cases using Jenkins test report as source, for each failing test case show how many builds it has been failing. Closes [#1373](https://github.com/ICTU/quality-time/issues/1373).
 - Add a new metric 'violation remediation effort' that reports the effort needed to remediate violations. Currently, the only source supporting this metric is SonarQube. Closes [#1374](https://github.com/ICTU/quality-time/issues/1374).
 
 ## [3.1.0] - [2020-08-07]


### PR DESCRIPTION
…source, for each failing test case show how many builds it has been failing. Closes 1372.