### PR TITLE
When measuring 'tests' with Azure DevOps, only the latest build of al…

### DIFF
--- a/components/collector/src/source_collectors/api_source_collectors/azure_devops.py
+++ b/components/collector/src/source_collectors/api_source_collectors/azure_devops.py
@@ -5,8 +5,10 @@ See https://docs.microsoft.com/en-gb/rest/api/azure/devops/?view=azure-devops-re
 """
 
 from abc import ABC
+from collections import defaultdict
 from datetime import datetime
 from typing import cast, Any, Dict, Final, List
+import itertools
 import urllib.parse
 
 from dateutil.parser import parse
@@ -141,34 +143,32 @@ class AzureDevopsTests(SourceCollector):
         test_results = cast(List[str], self._parameter("test_result"))
         test_run_names_to_include = cast(List[str], self._parameter("test_run_names_to_include")) or ["all"]
         runs = (await responses[0].json()).get("value", [])
-        test_count = 0
-        test_runs = []
-        for test_run_name in test_run_names_to_include:
-            highest_build_test_count = 0
-            highest_build_nr_seen = 0
-            highest_build_nr_test_runs: Entities = []
-            for run in runs:
-                if test_run_name != "all" and not match_string_or_regular_expression(run["name"], [test_run_name]):
-                    continue
-                build_nr = int(run.get("build", {}).get("id", "-1"))
-                if build_nr < highest_build_nr_seen:
-                    continue
-                if build_nr > highest_build_nr_seen:
-                    highest_build_nr_seen = build_nr
-                    highest_build_nr_test_runs = []
-                    highest_build_test_count = 0
-                highest_build_test_count += sum(run.get(test_result, 0) for test_result in test_results)
-                highest_build_nr_test_runs.append(
-                    dict(key=run["id"], name=run.get("name", "Unknown test run name"), state=run.get("state", ""),
-                         build_id=str(build_nr), url=run.get("webAccessUrl", ""),
-                         started_date=run.get("startedDate", ""), completed_date=run.get("completedDate", ""),
-                         incomplete_tests=str(run.get("incompleteTests", 0)),
-                         not_applicable_tests=str(run.get("notApplicableTests", 0)),
-                         passed_tests=str(run.get("passedTests", 0)),
-                         unanalyzed_tests=str(run.get("unanalyzedTests", 0)),
-                         total_tests=str(run.get("totalTests", 0))))
-            test_count += highest_build_test_count
-            test_runs.extend(highest_build_nr_test_runs)
+        highest_build_nr_seen: Dict[str, int] = defaultdict(int)
+        highest_build_nr_test_runs: Dict[str, Entities] = defaultdict(list)
+        highest_build_test_count = defaultdict(int)
+        for run in runs:
+            name = run.get("name", "Unknown test run name")
+            if test_run_names_to_include != ["all"] and \
+                    not match_string_or_regular_expression(name, test_run_names_to_include):
+                continue
+            build_nr = int(run.get("build", {}).get("id", "-1"))
+            if build_nr < highest_build_nr_seen[name]:
+                continue
+            if build_nr > highest_build_nr_seen[name]:
+                highest_build_nr_seen[name] = build_nr
+                highest_build_nr_test_runs[name] = []
+                highest_build_test_count[name] = 0
+            highest_build_test_count[name] += sum(run.get(test_result, 0) for test_result in test_results)
+            highest_build_nr_test_runs[name].append(
+                dict(
+                    key=run["id"], name=run.get("name", "Unknown test run name"), state=run.get("state", ""),
+                    build_id=str(build_nr), url=run.get("webAccessUrl", ""), started_date=run.get("startedDate", ""),
+                    completed_date=run.get("completedDate", ""), incomplete_tests=str(run.get("incompleteTests", 0)),
+                    not_applicable_tests=str(run.get("notApplicableTests", 0)),
+                    passed_tests=str(run.get("passedTests", 0)), unanalyzed_tests=str(run.get("unanalyzedTests", 0)),
+                    total_tests=str(run.get("totalTests", 0))))
+        test_count = sum(highest_build_test_count.values())
+        test_runs = list(itertools.chain.from_iterable(highest_build_nr_test_runs.values()))
         return SourceMeasurement(value=str(test_count), entities=test_runs)
 
 

--- a/components/collector/tests/source_collectors/api_source_collectors/test_azure_devops.py
+++ b/components/collector/tests/source_collectors/api_source_collectors/test_azure_devops.py
@@ -128,7 +128,7 @@ class AzureDevopsTestsTest(AzureDevopsTestCase):
     async def test_nr_of_tests(self):
         """Test that the number of tests is returned."""
         self.sources["source_id"]["test_result"] = []
-        self.sources["source_id"]["parameters"]["test_run_names_to_include"] = ["A"]
+        self.sources["source_id"]["parameters"]["test_run_names_to_include"] = ["A.*"]
         metric = dict(type="tests", sources=self.sources, addition="sum")
         response = await self.collect(
             metric, get_request_json_return_value=dict(
@@ -139,14 +139,18 @@ class AzureDevopsTestsTest(AzureDevopsTestCase):
                          webAccessUrl="https://azuredevops/project/run"),
                     dict(id="3", name="A", build=dict(id="1"), state="Completed", passedTests=4, totalTests=4),
                     dict(id="4", name="A", build=dict(id="2"), state="Completed", passedTests=1, totalTests=1),
-                    dict(id="5", name="B", build=dict(id="3"), state="Completed", passedTests=5, totalTests=5)]))
-        self.assert_measurement(response, value="4", entities=[
+                    dict(id="5", name="B", build=dict(id="3"), state="Completed", passedTests=5, totalTests=5),
+                    dict(id="6", name="A+", build=dict(id="1"), state="Completed", passedTests=6, totalTests=6)]))
+        self.assert_measurement(response, value="10", entities=[
             dict(key="2", name="A", state="Completed", build_id="2", started_date="2020-06-20T14:56:00.58Z",
                  completed_date="2020-06-20T14:56:00.633Z", incomplete_tests="0", not_applicable_tests="1",
                  passed_tests="2", unanalyzed_tests="0", total_tests="3", url="https://azuredevops/project/run"),
             dict(key="4", name="A", state="Completed", build_id="2", started_date="", completed_date="",
                  incomplete_tests="0", not_applicable_tests="0", passed_tests="1", unanalyzed_tests="0",
-                 total_tests="1", url="")])
+                 total_tests="1", url=""),
+            dict(key="6", name="A+", state="Completed", build_id="1", started_date="", completed_date="",
+                 incomplete_tests="0", not_applicable_tests="0", passed_tests="6", unanalyzed_tests="0",
+                 total_tests="6", url="")])
 
     async def test_nr_of_failed_tests(self):
         """Test that the number of failed tests is returned."""

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - When measuring the 'manual test duration' metric *Quality-time* would subtract one minute for each ignored test case, instead of the duration of the ignored test case. Fixes [#1361](https://github.com/ICTU/quality-time/issues/1361).
 - *Quality-time* would not measure the 'manual test execution' metric until the user changed the 'default expected manual test execution frequency' field. Fixes [#1363](https://github.com/ICTU/quality-time/issues/1363).
+- When measuring 'tests' with Azure DevOps, only the latest build of all matching test runs was reported instead of the latest build of each matching test run. Fixes [#1382](https://github.com/ICTU/quality-time/issues/1382).
 
 ### Added
 


### PR DESCRIPTION
…l matching test runs was reported instead of the latest build of each matching test run. Fixes #1382.