### PR TITLE
Jenkins jobs with slashes in their names couldn't be marked as false positive or won't fix

### DIFF
--- a/components/collector/src/collector_utilities/functions.py
+++ b/components/collector/src/collector_utilities/functions.py
@@ -58,9 +58,9 @@ def hashless(url: URL) -> URL:
     return URL(urllib.parse.urlunsplit((scheme, netloc, path, query, fragment)))
 
 
-def slashless(string: str) -> str:
-    """Return a slashless version of the string."""
-    return string.replace("/", "-")
+def safe_entity_key(key: str) -> str:
+    """Return a escaped version of the key that is safe in URLs and as Mongo document key."""
+    return key.replace("/", "-").replace(".", "_")
 
 
 def md5_hash(string: str) -> str:

--- a/components/collector/src/collector_utilities/functions.py
+++ b/components/collector/src/collector_utilities/functions.py
@@ -58,6 +58,11 @@ def hashless(url: URL) -> URL:
     return URL(urllib.parse.urlunsplit((scheme, netloc, path, query, fragment)))
 
 
+def slashless(string: str) -> str:
+    """Return a slashless version of the string."""
+    return string.replace("/", "-")
+
+
 def md5_hash(string: str) -> str:
     """Return a md5 hash of the string."""
     return hashlib.md5(string.encode("utf-8")).hexdigest()  # nosec, Not used for cryptography

--- a/components/collector/src/source_collectors/api_source_collectors/jenkins.py
+++ b/components/collector/src/source_collectors/api_source_collectors/jenkins.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import cast, Iterator
 
-from collector_utilities.functions import days_ago, match_string_or_regular_expression, slashless
+from collector_utilities.functions import days_ago, match_string_or_regular_expression, safe_entity_key
 from collector_utilities.type import Job, Jobs, URL
 from base_collectors import SourceCollector, SourceMeasurement, SourceResponses
 
@@ -19,7 +19,8 @@ class JenkinsJobs(SourceCollector):
     async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
         entities = [
             dict(
-                key=slashless(job["name"]), name=job["name"], url=job["url"], build_status=self._build_status(job),
+                key=safe_entity_key(job["name"]), name=job["name"], url=job["url"],
+                build_status=self._build_status(job),
                 build_date=str(self._build_datetime(job).date()) if self._build_datetime(job) > datetime.min else "")
             for job in self.__jobs((await responses[0].json())["jobs"])]
         return SourceMeasurement(entities=entities)

--- a/components/collector/src/source_collectors/api_source_collectors/jenkins.py
+++ b/components/collector/src/source_collectors/api_source_collectors/jenkins.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import cast, Iterator
 
-from collector_utilities.functions import days_ago, match_string_or_regular_expression
+from collector_utilities.functions import days_ago, match_string_or_regular_expression, slashless
 from collector_utilities.type import Job, Jobs, URL
 from base_collectors import SourceCollector, SourceMeasurement, SourceResponses
 
@@ -19,7 +19,7 @@ class JenkinsJobs(SourceCollector):
     async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
         entities = [
             dict(
-                key=job["name"], name=job["name"], url=job["url"], build_status=self._build_status(job),
+                key=slashless(job["name"]), name=job["name"], url=job["url"], build_status=self._build_status(job),
                 build_date=str(self._build_datetime(job).date()) if self._build_datetime(job) > datetime.min else "")
             for job in self.__jobs((await responses[0].json())["jobs"])]
         return SourceMeasurement(entities=entities)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - When measuring the 'manual test duration' metric *Quality-time* would subtract one minute for each ignored test case, instead of the duration of the ignored test case. Fixes [#1361](https://github.com/ICTU/quality-time/issues/1361).
 - *Quality-time* would not measure the 'manual test execution' metric until the user changed the 'default expected manual test execution frequency' field. Fixes [#1363](https://github.com/ICTU/quality-time/issues/1363).
 - When measuring 'tests' with Azure DevOps, only the latest build of all matching test runs was reported instead of the latest build of each matching test run. Fixes [#1382](https://github.com/ICTU/quality-time/issues/1382).
+- Jenkins jobs with slashes in their names couldn't be marked as false positive or won't fix. Fixes [#1390](https://github.com/ICTU/quality-time/issues/1390).
 
 ### Added
 


### PR DESCRIPTION
Fixes #1390.