### PR TITLE
The 'source up-to-dateness' metric combined with the Calendar didn't work

### DIFF
--- a/components/collector/src/source_collectors/local_source_collectors/calendar.py
+++ b/components/collector/src/source_collectors/local_source_collectors/calendar.py
@@ -1,14 +1,19 @@
 """Calendar metric source."""
 
 from datetime import datetime
-from typing import cast
+from typing import Sequence, cast
 
-from base_collectors import SourceUpToDatenessCollector
+from base_collectors import SourceResponses, SourceUpToDatenessCollector
 from collector_utilities.type import Response
 
 
 class CalendarSourceUpToDateness(SourceUpToDatenessCollector):
     """Collector class to get the number of days since a user-specified date."""
 
+    async def _parse_source_response_date_times(self, responses: SourceResponses) -> Sequence[datetime]:
+        return [datetime.fromisoformat(cast(str, self._parameter("date")))]
+
     async def _parse_source_response_date_time(self, response: Response) -> datetime:
-        return datetime.fromisoformat(cast(str, self._parameter("date")))
+        # Since the Calendar has no real source responses, we return the answer in _parse_source_response_date_times()
+        # and this method is never called
+        pass  # pragma: no cover

--- a/components/collector/tests/source_collectors/local_source_collectors/test_calendar.py
+++ b/components/collector/tests/source_collectors/local_source_collectors/test_calendar.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from tests.source_collectors.source_collector_test_case import SourceCollectorTestCase
+from ..source_collector_test_case import SourceCollectorTestCase
 
 
 class CalendarSourceUpToDatenessTest(SourceCollectorTestCase):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- The 'source up-to-dateness' metric combined with the Calendar would report a parse error instead of returning the number of days since the specified date. Fixes [#1399](https://github.com/ICTU/quality-time/issues/1399).
+
 ## [3.2.0] - [2020-08-22]
 
 ### Fixed


### PR DESCRIPTION
It would report a parse error instead of returning the number of days since the specified date. Fixes #1399.