### PR TITLE
Use the default value of a source parameter if the user sets it to an empty string

### DIFF
--- a/components/collector/src/base_collectors/source_collector.py
+++ b/components/collector/src/base_collectors/source_collector.py
@@ -72,7 +72,7 @@ class SourceCollector(ABC):
                 value = [v for v in value if v in parameter_info["values"]] or parameter_info["values"]
         else:
             default_value = parameter_info.get("default_value", "")
-            value = self.__parameters.get(parameter_key, default_value)
+            value = self.__parameters.get(parameter_key) or default_value
         if api_values := parameter_info.get("api_values"):
             value = api_values.get(value, value) if isinstance(value, str) else [api_values.get(v, v) for v in value]
         if parameter_key.endswith("url"):

--- a/components/collector/tests/source_collectors/test_collector.py
+++ b/components/collector/tests/source_collectors/test_collector.py
@@ -1,5 +1,6 @@
 """Unit tests for the Collector class."""
 
+from datetime import datetime
 from unittest.mock import Mock, patch
 
 import aiohttp
@@ -69,3 +70,10 @@ class CollectorTest(SourceCollectorTestCase):
             async with aiohttp.ClientSession() as session:
                 response = await FailingLandingUrl(session, self.metric, {}).get()
         self.assertEqual("https://api_url", response["landing_url"])
+
+    async def test_default_parameter_value_supersedes_empty_string(self):
+        """Test that a parameter default value takes precedence over an empty string."""
+        sources = dict(source_uuid=dict(type="calendar", parameters=dict(date="")))
+        metric = dict(type="source_up_to_dateness", addition="max", sources=sources)
+        response = await self.collect(metric)
+        self.assert_measurement(response, value=str((datetime.today() - datetime(2020, 1, 1)).days))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Use the default value of a source parameter if the user sets it to an empty string. Fixes [#1417](https://github.com/ICTU/quality-time/issues/1417).
+
 ### Changed
 
 - Rename the 'ready user story points' to 'user story points' as it can not just be used to count ready user stories, but rather any selection of user stories. Closes [#1415](https://github.com/ICTU/quality-time/issues/1415).


### PR DESCRIPTION
Fixes #1417.