### PR TITLE
Don't verify ssl for metric sources

### DIFF
--- a/components/collector/src/base_collectors/metrics_collector.py
+++ b/components/collector/src/base_collectors/metrics_collector.py
@@ -70,7 +70,7 @@ class MetricsCollector:
             self.record_health()
             logging.info("Collecting...")
             async with aiohttp.ClientSession(
-                    connector=aiohttp.TCPConnector(limit_per_host=20), raise_for_status=True, timeout=timeout,
+                    connector=aiohttp.TCPConnector(limit_per_host=20, verify_ssl=False), raise_for_status=True, timeout=timeout,
                     trust_env=True) as session:
                 with timer() as collection_timer:
                     await self.collect_metrics(session, measurement_frequency)

--- a/components/server/src/routes/source.py
+++ b/components/server/src/routes/source.py
@@ -209,7 +209,7 @@ def _check_url_availability(url: URL, source_parameters: Dict[str, str]) -> Dict
     """Check the availability of the URL."""
     try:
         response = requests.get(
-            url, auth=_basic_auth_credentials(source_parameters), headers=_headers(source_parameters))
+            url, auth=_basic_auth_credentials(source_parameters), headers=_headers(source_parameters), verify=False)
         return dict(status_code=response.status_code, reason=response.reason)
     except Exception:  # pylint: disable=broad-except
         return dict(status_code=-1, reason='Unknown error')


### PR DESCRIPTION
Skip verification of SSL certificates for metric sources. This allows the usage of metric sources using HTTPS with self-signed certificates.