### PR TITLE
Retrieving measurements for the trend graph of a metric with many mea…

### DIFF
--- a/components/server/src/routes/measurement.py
+++ b/components/server/src/routes/measurement.py
@@ -122,8 +122,4 @@ def stream_nr_measurements(database: Database) -> Iterator[str]:
 def get_measurements(metric_uuid: MetricId, database: Database) -> Dict:
     """Return the measurements for the metric."""
     metric_uuid = cast(MetricId, metric_uuid.split("&")[0])
-    measurements = []
-    for measurement in all_measurements(database, metric_uuid, report_date_time()):
-        measurement["_id"] = str(measurement["_id"])
-        measurements.append(measurement)
-    return dict(measurements=measurements)
+    return dict(measurements=list(all_measurements(database, metric_uuid, report_date_time())))

--- a/components/server/tests/routes/test_measurement.py
+++ b/components/server/tests/routes/test_measurement.py
@@ -12,11 +12,20 @@ from ..fixtures import JOHN, METRIC_ID, REPORT_ID, SOURCE_ID, SUBJECT_ID, SUBJEC
 class GetMeasurementsTest(unittest.TestCase):
     """Unit tests for the get measurements route."""
 
+    def setUp(self):
+        self.database = Mock()
+
     def test_get_measurements(self):
         """Tests that the measurements for the requested metric are returned."""
-        database = Mock()
-        database.measurements.find.return_value = [dict(_id="id")]
-        self.assertEqual(dict(measurements=[dict(_id="id")]), get_measurements(METRIC_ID, database))
+        self.database.measurements.find_one.return_value = dict(start="1")
+        self.database.measurements.find.return_value = [dict(start="0"), dict(start="1")]
+        self.assertEqual(
+            dict(measurements=[dict(start="0"), dict(start="1")]), get_measurements(METRIC_ID, self.database))
+
+    def test_get_measurements_when_there_are_none(self):
+        """Tests that the measurements for the requested metric are returned."""
+        self.database.measurements.find_one.return_value = None
+        self.assertEqual(dict(measurements=[]), get_measurements(METRIC_ID, self.database))
 
 
 @patch("database.measurements.iso_timestamp", new=Mock(return_value="2019-01-01"))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Support version 2.4 and 2.5 of the OWASP Dependency Check XSD. Closes [#1460](https://github.com/ICTU/quality-time/issues/1460).
-- Allow for hiding the trend, target, source, comment, and tags columns in the metric tables. This can be done through the 'hamburger' menu on the top left side of each metric table. Partially implements [#1464](https://github.com/ICTU/quality-time/issues/1464).
+- Allow for hiding the trend, target, source, comment, and tags columns in the metric tables. This can be done through the 'hamburger' menu on the top left side of each metric table. Closes [#1464](https://github.com/ICTU/quality-time/issues/1464).
+
+### Fixed
+
+- Retrieving measurements for the trend graph of a metric with many measurements and entities (violations, user stories, security warnings, etc.) was slow because *Quality-time* would retrieve all entities for all measurements even though it only needs the entities for the most recent measurement. Fixes [#1468](https://github.com/ICTU/quality-time/issues/1468).
 
 ## [3.5.0] - [2020-09-12]
 


### PR DESCRIPTION
…surements and entities (violations, user stories, security warnings, etc.) was slow because Quality-time would retrieve all entities for all measurements even though it only needs the entities for the most recent measurement. Fixes #1468.