### PR TITLE
In addition to the trend, target, source, comment, and tags columns, …

### DIFF
--- a/components/frontend/src/metric/Measurement.js
+++ b/components/frontend/src/metric/Measurement.js
@@ -56,8 +56,8 @@ export function Measurement(props) {
     <TableRowWithDetails id={props.metric_uuid} className={metric.status} details={details}>
       <Table.Cell>{metric_name}</Table.Cell>
       {!props.hiddenColumns.includes("trend") && <Table.Cell><TrendSparkline measurements={latest_measurements} scale={metric.scale} /></Table.Cell>}
-      <Table.Cell textAlign='center'><StatusIcon status={metric.status} /></Table.Cell>
-      <Table.Cell><MeasurementValue /></Table.Cell>
+      {!props.hiddenColumns.includes("status") && <Table.Cell textAlign='center'><StatusIcon status={metric.status} /></Table.Cell>}
+      {!props.hiddenColumns.includes("measurement") && <Table.Cell><MeasurementValue /></Table.Cell>}
       {!props.hiddenColumns.includes("target") && <Table.Cell>{measurement_target()}</Table.Cell>}
       {!props.hiddenColumns.includes("source") && <Table.Cell>{measurement_sources()}</Table.Cell>}
       {!props.hiddenColumns.includes("comment") && <Table.Cell><div dangerouslySetInnerHTML={{ __html: metric.comment }} /></Table.Cell>}

--- a/components/frontend/src/subject/Subject.js
+++ b/components/frontend/src/subject/Subject.js
@@ -125,6 +125,8 @@ export function Subject(props) {
             </Dropdown.Item>
             <Dropdown.Header>Columns</Dropdown.Header>
             <ColumnMenuItem column="trend"/>
+            <ColumnMenuItem column="status"/>
+            <ColumnMenuItem column="measurement"/>
             <ColumnMenuItem column="target"/>
             <ColumnMenuItem column="source"/>
             <ColumnMenuItem column="comment"/>
@@ -141,8 +143,8 @@ export function Subject(props) {
           <HamburgerHeader />
           <SortableHeader column='name' label='Metric' />
           {!props.hiddenColumns.includes("trend") && <Table.HeaderCell width="2">Trend (7 days)</Table.HeaderCell>}
-          <SortableHeader column='status' label='Status' textAlign='center' />
-          <SortableHeader column='measurement' label='Measurement' />
+          {!props.hiddenColumns.includes("status") && <SortableHeader column='status' label='Status' textAlign='center' />}
+          {!props.hiddenColumns.includes("measurement") && <SortableHeader column='measurement' label='Measurement' />}
           {!props.hiddenColumns.includes("target") && <SortableHeader column='target' label='Target' />}
           {!props.hiddenColumns.includes("source") && <SortableHeader column='source' label='Source' />}
           {!props.hiddenColumns.includes("comment") && <SortableHeader column='comment' label='Comment' />}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - When exporting quality reports to PDF, hide the same metric table rows and columns in the PDF as hidden by the user in the user interface. Closes [#1466](https://github.com/ICTU/quality-time/issues/1466).
+- In addition to the trend, target, source, comment, and tags columns, also allow for hiding the status and measurement columns in metric tables. Closes [#1474](https://github.com/ICTU/quality-time/issues/1474).
 
 ## [3.6.0] - [2020-09-19]
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -254,4 +254,4 @@ If the PDF report needs to be downloaded programmatically, e.g. for inclusion in
 
 To hide metrics that do not need any action, set the `hide_metrics_not_requiring_action` parameter to true, i.e. `http://www.quality-time.example.org/api/v3/report/<report_uuid>/pdf?hide_metrics_not_requiring_action=true`. 
 
-To hide columns from the report, set the `hidden_columns` parameter, for example `http://www.quality-time.example.org/api/v3/report/<report_uuid>/pdf?hidden_columsn=target,comment`. Possible options are `trend`, `target`, `source`, `comment`, and `tags`.
+To hide columns from the report, set the `hidden_columns` parameter, for example `http://www.quality-time.example.org/api/v3/report/<report_uuid>/pdf?hidden_columns=target,comment`. Possible options are `trend`, `status`, `measurement`, `target`, `source`, `comment`, and `tags`.


### PR DESCRIPTION
…also allow for hiding the status and measurement columns in metric tables. Closes #1474.