### PR TITLE
Use local time instead of UTC in the filenames of PDF exports

### DIFF
--- a/components/frontend/src/widgets/Button.js
+++ b/components/frontend/src/widgets/Button.js
@@ -45,8 +45,9 @@ function download_pdf(report_uuid, query_string, callback) {
         let url = window.URL.createObjectURL(response);
         let a = document.createElement('a');
         a.href = url;
-        let now = new Date();
-        a.download = `Quality-time-report-${report_uuid}-${now.toISOString()}.pdf`;
+        const now = new Date();
+        const local_now = new Date(now.getTime() - (now.getTimezoneOffset() * 60000));
+        a.download = `Quality-time-report-${report_uuid}-${local_now.toISOString().split(".")[0]}.pdf`;
         a.click();
       }
     }).finally(() => callback());

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Use local time instead of UTC in the filenames of PDF exports. Closes [#1505](https://github.com/ICTU/quality-time/issues/1505).
+
 ### Added
 
 - The 'slow transactions' metric with the Performancetest-runner as source allows for ignoring transactions by name or by regular expression. Closes [#1493](https://github.com/ICTU/quality-time/issues/1493).


### PR DESCRIPTION
Closes #1505.