### PR TITLE
Tokens with an underscore would not be completely redacted from the collector log

### DIFF
--- a/components/collector/src/collector_utilities/functions.py
+++ b/components/collector/src/collector_utilities/functions.py
@@ -32,7 +32,7 @@ async def parse_source_response_xml_with_namespace(
 
 Substitution = Tuple[Pattern[str], str]
 MEMORY_ADDRESS_SUB: Substitution = (re.compile(r" at 0x[0-9abcdef]+>"), ">")
-TOKEN_SUB: Substitution = (re.compile(r"token=[0-9a-zA-Z]+"), "token=<redacted>")
+TOKEN_SUB: Substitution = (re.compile(r"token=[^&]+"), "token=<redacted>")
 KEY_SUB: Substitution = (re.compile(r"key=[0-9abcdef]+"), "key=<redacted>")
 HASH_SUB: Substitution = (re.compile(r"(?i)[a-f0-9]{20,}"), "hashremoved")
 

--- a/components/collector/tests/collector_utilities/test_functions.py
+++ b/components/collector/tests/collector_utilities/test_functions.py
@@ -24,7 +24,7 @@ class StableTracebackTest(unittest.TestCase):
         """Test that tokens are redacted from tracebacks."""
         self.assertEqual(
             "https://example.com?id=5&token=<redacted>&page=0",
-            stable_traceback("https://example.com?id=5&token=abcdef45321a&page=0"))
+            stable_traceback("https://example.com?id=5&token=abcdef_45321-a&page=0"))
 
     def test_no_keys(self):
         """Test that keys are redacted from tracebacks."""

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Some exceptions thrown by the aiohttp library have no explicit error message. This would cause *Quality-time* to try and parse the non-existing source response, erroneously complaining about a parse error. Although in these cases the connection error would be logged, without an error message the logging would not be very informative. Fixed by having the collector log the class of the aiohttp exception if the error message is empty. Fixes [#1422](https://github.com/ICTU/quality-time/issues/1422).
 - The PDF export would always export the most recent report, even when the user picked another date. Fixes [#1498](https://github.com/ICTU/quality-time/issues/1498).
 - The 'commented-out code' metric claimed to measure the number of lines of commented-out code, but SonarQube actually reports the number of *blocks* of commented-out lines of code. Changed the metric description and unit to conform to the SonarQube data. Fixes [#1507](https://github.com/ICTU/quality-time/issues/1507).
+- Tokens with an underscore would not be completely redacted from the collector log. Fixes [#1523](https://github.com/ICTU/quality-time/issues/1523).
 
 ## [3.7.0] - [2020-09-27]
 


### PR DESCRIPTION
Fixes #1523.