### PR TITLE
Trend graphs showing metrics with minutes as unit would have their y-axis labeled 'hours'

### DIFF
--- a/components/frontend/src/metric/Measurement.js
+++ b/components/frontend/src/metric/Measurement.js
@@ -7,7 +7,7 @@ import { MeasurementDetails } from './MeasurementDetails';
 import { StatusIcon } from './StatusIcon';
 import { Tag } from '../widgets/Tag';
 import { TableRowWithDetails } from '../widgets/TableRowWithDetails';
-import { get_metric_name, get_metric_target, format_minutes } from '../utils';
+import { get_metric_name, get_metric_target, format_metric_unit, format_minutes } from '../utils';
 import "./Measurement.css";
 
 export function Measurement(props) {
@@ -43,19 +43,14 @@ export function Measurement(props) {
     return sources.map((source, index) => [index > 0 && ", ", <SourceStatus key={source.source_uuid} source_uuid={source.source_uuid}
       metric={metric} source={source} datamodel={props.datamodel} />])
   }
-  function get_metric_unit() {
-    const metric_unit_prefix = metric.scale === "percentage" ? "% " : " ";
-    const metric_type_unit = metric_type.unit === 'minutes' && metric.scale !== 'percentage' ? 'hours' : metric_type.unit;
-    return `${metric_unit_prefix}${metric.unit || metric_type_unit}`;
-  }
   const metric = props.report.subjects[props.subject_uuid].metrics[props.metric_uuid];
   const metric_type = props.datamodel.metrics[metric.type];
   const latest_measurements = metric.recent_measurements;
   const latest_measurement = latest_measurements.length > 0 ? latest_measurements[latest_measurements.length - 1] : null;
   const sources = (latest_measurement && latest_measurement.sources) || [];
-  const metric_unit = get_metric_unit();
+  const metric_unit = format_metric_unit(metric_type, metric);
   const metric_name = get_metric_name(metric, props.datamodel);
-  const details = <MeasurementDetails measurement={latest_measurement} metric_name={metric_name} scale={metric.scale} unit={metric_unit} {...props} />
+  const details = <MeasurementDetails measurement={latest_measurement} metric_name={metric_name} scale={metric.scale} unit={format_metric_unit(metric_type, metric, false)} {...props} />
   return (
     <TableRowWithDetails id={props.metric_uuid} className={metric.status} details={details}>
       <Table.Cell>{metric_name}</Table.Cell>

--- a/components/frontend/src/utils.js
+++ b/components/frontend/src/utils.js
@@ -59,6 +59,15 @@ export function format_minutes(number) {
     return `${hours}:${leading_zero}${minutes}`
 }
 
+export function format_metric_unit(metric_type, metric, with_multiple=true) {
+    const metric_unit_prefix = metric.scale === "percentage" ? "% " : " ";
+    let metric_type_unit = metric_type.unit;
+    if (with_multiple) {
+        metric_type_unit = metric_type.unit === 'minutes' && metric.scale !== 'percentage' ? 'hours' : metric_type.unit;
+    }
+    return `${metric_unit_prefix}${metric.unit || metric_type_unit}`;
+}
+
 export function useURLSearchQuery(history, key, state_type) {
     // state_type can either be "boolean" or "array"
     const [state, setState] = useState(getState());

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Some exceptions thrown by the aiohttp library have no explicit error message. This would cause *Quality-time* to try and parse the non-existing source response, erroneously complaining about a parse error. Although in these cases the connection error would be logged, without an error message the logging would not be very informative. Fixed by having the collector log the class of the aiohttp exception if the error message is empty. Fixes [#1422](https://github.com/ICTU/quality-time/issues/1422).
 - The PDF export would always export the most recent report, even when the user picked another date. Fixes [#1498](https://github.com/ICTU/quality-time/issues/1498).
 - The 'commented-out code' metric claimed to measure the number of lines of commented-out code, but SonarQube actually reports the number of *blocks* of commented-out lines of code. Changed the metric description and unit to conform to the SonarQube data. Fixes [#1507](https://github.com/ICTU/quality-time/issues/1507).
+- Trend graphs showing metrics with minutes as unit would have their y-axis labeled 'hours'. Fixes [#1522](https://github.com/ICTU/quality-time/issues/1522).
 - Tokens with an underscore would not be completely redacted from the collector log. Fixes [#1523](https://github.com/ICTU/quality-time/issues/1523).
 
 ## [3.7.0] - [2020-09-27]


### PR DESCRIPTION
Fixes #1522.