### PR TITLE
Show how to set the time zone of the renderer in the docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -88,6 +88,7 @@ services:
     image: ictu/url-to-pdf-api:v1.0.0
     environment:
       - ALLOW_HTTP=true
-      - LC_ALL=en_GB.UTF-8
+      - LC_ALL=en_GB.UTF-8  # Set the data format in the PDF export to DD-MM-YYYY
+      - TZ=Europe/Amsterdam  # Make the PDF export use the correct timezone
 volumes:
   dbdata:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- Show how to set the time zone of the renderer in the [docker-compose.yml](../docker/docker-compose.yml) to that PDF exports contain the correct local time. Fixes [#1529](https://github.com/ICTU/quality-time/issues/1529).
+
 ## [3.8.0] - [2020-10-04]
 
 ### Changed
@@ -330,7 +336,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Cache data model and other performance improvements. Note: the proxy settings for the data model API have been updated. See the Caddy configuration in the [docker-compose](../docker/docker-compose.yml). The order of the metric tabs has been changed. From left to right: first tab is the metric configuration, second the source(s) configuration, third the trend graph, and finally the tab(s) with details per source, if applicable. This makes it possible to lazily load the data for the trend graph and the details per source and show the tabs as soon as the data becomes available. Fixes [#1026](https://github.com/ICTU/quality-time/issues/1026).
+- Cache data model and other performance improvements. Note: the proxy settings for the data model API have been updated. See the Caddy configuration in the [docker-compose.yml](../docker/docker-compose.yml). The order of the metric tabs has been changed. From left to right: first tab is the metric configuration, second the source(s) configuration, third the trend graph, and finally the tab(s) with details per source, if applicable. This makes it possible to lazily load the data for the trend graph and the details per source and show the tabs as soon as the data becomes available. Fixes [#1026](https://github.com/ICTU/quality-time/issues/1026).
 
 ### Added
 


### PR DESCRIPTION
...so that PDF exports contain the correct local time. Fixes #1529.