### PR TITLE
The date picker for the end date of technical debt has a minimum date…

### DIFF
--- a/components/frontend/src/fields/DateInput.js
+++ b/components/frontend/src/fields/DateInput.js
@@ -5,6 +5,8 @@ import { ReadOnlyOrEditable } from '../context/ReadOnly';
 import { Input } from './Input';
 
 function EditableDateInput(props) {
+    // We don't use the minDate property because having a value < minDate can crash the date picker,
+    // see https://github.com/ICTU/quality-time/issues/1534
     return (
         <Form>
             <CalendarDateInput
@@ -14,7 +16,6 @@ function EditableDateInput(props) {
                 disabled={false}
                 error={props.required && props.value === ""}
                 label={props.label}
-                minDate={props.minDate}
                 onChange={(event, { value }) => { if (value !== props.value) { props.set_value(value)}}}
                 placeholder={props.placeholder}
                 value={props.value}
@@ -24,10 +25,9 @@ function EditableDateInput(props) {
 }
 
 export function DateInput(props) {
-    const { minDate, ...readonlyProps} = props;
     return (
         <ReadOnlyOrEditable
-            readOnlyComponent={<Input {...readonlyProps} />}
+            readOnlyComponent={<Input {...props} />}
             editableComponent={<EditableDateInput {...props} label={props.editableLabel || props.label} />}
         />
     )

--- a/components/frontend/src/metric/MetricParameters.js
+++ b/components/frontend/src/metric/MetricParameters.js
@@ -156,7 +156,6 @@ export function MetricParameters(props) {
                     <Grid.Column>
                         <DateInput
                             label="Technical debt end date"
-                            minDate={new Date()}
                             placeholder="no end date"
                             set_value={(value) => set_metric_attribute(props.metric_uuid, "debt_end_date", value, props.reload)}
                             value={props.metric.debt_end_date || ""}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Show how to set the time zone of the renderer in the [docker-compose.yml](../docker/docker-compose.yml) to that PDF exports contain the correct local time. Fixes [#1529](https://github.com/ICTU/quality-time/issues/1529).
+- The date picker for the end date of technical debt has a minimum date set to today. Apparently, if the current value of the technical debt end date is far enough in the past so that the whole month popup consists of disabled dates, the date picker will crash. Worked around by removing the minimum date. Fixes [#1534](https://github.com/ICTU/quality-time/issues/1534).
 
 ## [3.8.0] - [2020-10-04]
 


### PR DESCRIPTION
… set to today. Apparently, if the current value of the technical debt end date is far enough in the past so that the whole month popup consists of disabled dates, the date picker will crash. Worked around by removing the minimum date. Fixes #1534.