### PR TITLE
Improve Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ Clone this repository:
 git clone https://github.com/ICTU/quality-time.git
 ```
 
+Move into the 'quality-time/docker/' directory:
+```console
+cd quality-time/docker/
+```
+
 Build the containers:
 
 ```console


### PR DESCRIPTION
It wasn't initially clear that there was a docker subfolder, so I got an error when building. It was quickly resolved, but it's better to just add it in the readme.