### PR TITLE
Add support for Forwarded Authentication

### DIFF
--- a/components/server/src/routes/auth.py
+++ b/components/server/src/routes/auth.py
@@ -106,7 +106,7 @@ def verify_user(username: str, password: str) -> Tuple[bool, str]:
 @bottle.post("/api/v3/login")
 def login(database: Database) -> Dict[str, Union[bool, str]]:
     """Log the user in. Add credentials as JSON payload, e.g. {username: 'user', password: 'pass'}."""
-    forward_auth_enabled = bool(os.environ.get("FORWARD_AUTH_ENABLED", None))
+    forward_auth_enabled = bool(os.environ.get("FORWARD_AUTH_ENABLED"))
     if forward_auth_enabled:
         forward_auth_header = str(os.environ.get("FORWARD_AUTH_HEADER", "X-Forwarded-User"))
         username = bottle.request.get_header(forward_auth_header, None)

--- a/components/server/src/routes/auth.py
+++ b/components/server/src/routes/auth.py
@@ -106,8 +106,14 @@ def verify_user(username: str, password: str) -> Tuple[bool, str]:
 @bottle.post("/api/v3/login")
 def login(database: Database) -> Dict[str, Union[bool, str]]:
     """Log the user in. Add credentials as JSON payload, e.g. {username: 'user', password: 'pass'}."""
-    username, password = get_credentials()
-    verified, email = verify_user(username, password)
+    forward_auth_enabled = bool(os.environ.get("FORWARD_AUTH_ENABLED", None))
+    if forward_auth_enabled:
+        forward_auth_header = str(os.environ.get("FORWARD_AUTH_HEADER", "X-Forwarded-User"))
+        username = bottle.request.get_header(forward_auth_header, None)
+        verified, email = username is not None, username
+    else:
+        username, password = get_credentials()
+        verified, email = verify_user(username, password)
     if verified:
         create_session(database, username, email)
     return dict(ok=verified, email=email)

--- a/components/server/tests/routes/test_auth.py
+++ b/components/server/tests/routes/test_auth.py
@@ -80,7 +80,7 @@ class LoginTests(AuthTestCase):
         connection_enter.assert_not_called()
 
     def test_forwardauth_login_no_header(self, connection_mock, connection_enter):
-        """Test successful login from forwarded authentication header."""
+        """Test failed login if forwarded authentication is enabled but no header is present."""
         connection_mock.return_value = None
         with patch.dict("os.environ", {"FORWARD_AUTH_ENABLED": "True", "FORWARD_AUTH_HEADER": "X-Forwarded-User"}):
             with patch("bottle.request.get_header", Mock(return_value=None)):

--- a/components/server/tests/routes/test_auth.py
+++ b/components/server/tests/routes/test_auth.py
@@ -69,14 +69,14 @@ class LoginTests(AuthTestCase):
         self.assertEqual(f"user {username} <{email}>", logging_mock.call_args[0][1])
         self.assertIsInstance(logging_mock.call_args[0][2], exception)
 
-    def test_successful_forwardauth_login(self, connection_mock, connection_enter):
+    def test_successful_forwardauth_login(self):
         """Test successful login from forwarded authentication header."""
         with patch.dict("os.environ", {"FORWARD_AUTH_ENABLED": "True", "FORWARD_AUTH_HEADER": "X-Forwarded-User"}):
             with patch("bottle.request.get_header", Mock(return_value=self.user_email)):
                 self.assertEqual(dict(ok=True, email=self.user_email), auth.login(self.database))
         self.assert_cookie_has_session_id()
 
-    def test_forwardauth_login_no_header(self, connection_mock, connection_enter):
+    def test_forwardauth_login_no_header(self):
         """Test successful login from forwarded authentication header."""
         with patch.dict("os.environ", {"FORWARD_AUTH_ENABLED": "True", "FORWARD_AUTH_HEADER": "X-Forwarded-User"}):
             with patch("bottle.request.get_header", Mock(return_value=None)):

--- a/components/server/tests/routes/test_auth.py
+++ b/components/server/tests/routes/test_auth.py
@@ -69,18 +69,24 @@ class LoginTests(AuthTestCase):
         self.assertEqual(f"user {username} <{email}>", logging_mock.call_args[0][1])
         self.assertIsInstance(logging_mock.call_args[0][2], exception)
 
-    def test_successful_forwardauth_login(self):
+    def test_successful_forwardauth_login(self, connection_mock, connection_enter):
         """Test successful login from forwarded authentication header."""
+        connection_mock.return_value = None
         with patch.dict("os.environ", {"FORWARD_AUTH_ENABLED": "True", "FORWARD_AUTH_HEADER": "X-Forwarded-User"}):
             with patch("bottle.request.get_header", Mock(return_value=self.user_email)):
                 self.assertEqual(dict(ok=True, email=self.user_email), auth.login(self.database))
         self.assert_cookie_has_session_id()
+        connection_mock.assert_not_called()
+        connection_enter.assert_not_called()
 
-    def test_forwardauth_login_no_header(self):
+    def test_forwardauth_login_no_header(self, connection_mock, connection_enter):
         """Test successful login from forwarded authentication header."""
+        connection_mock.return_value = None
         with patch.dict("os.environ", {"FORWARD_AUTH_ENABLED": "True", "FORWARD_AUTH_HEADER": "X-Forwarded-User"}):
             with patch("bottle.request.get_header", Mock(return_value=None)):
                 self.assertEqual(dict(ok=False, email=None), auth.login(self.database))
+        connection_mock.assert_not_called()
+        connection_enter.assert_not_called()
 
     def test_successful_login(self, connection_mock, connection_enter):
         """Test successful login."""

--- a/components/server/tests/routes/test_auth.py
+++ b/components/server/tests/routes/test_auth.py
@@ -69,6 +69,19 @@ class LoginTests(AuthTestCase):
         self.assertEqual(f"user {username} <{email}>", logging_mock.call_args[0][1])
         self.assertIsInstance(logging_mock.call_args[0][2], exception)
 
+    def test_successful_forwardauth_login(self, connection_mock, connection_enter):
+        """Test successful login from forwarded authentication header."""
+        with patch.dict("os.environ", {"FORWARD_AUTH_ENABLED": "True", "FORWARD_AUTH_HEADER": "X-Forwarded-User"}):
+            with patch("bottle.request.get_header", Mock(return_value=self.user_email)):
+                self.assertEqual(dict(ok=True, email=self.user_email), auth.login(self.database))
+        self.assert_cookie_has_session_id()
+
+    def test_forwardauth_login_no_header(self, connection_mock, connection_enter):
+        """Test successful login from forwarded authentication header."""
+        with patch.dict("os.environ", {"FORWARD_AUTH_ENABLED": "True", "FORWARD_AUTH_HEADER": "X-Forwarded-User"}):
+            with patch("bottle.request.get_header", Mock(return_value=None)):
+                self.assertEqual(dict(ok=False, email=None), auth.login(self.database))
+
     def test_successful_login(self, connection_mock, connection_enter):
         """Test successful login."""
         connection_mock.return_value = None

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -82,6 +82,8 @@ services:
       - LDAP_LOOKUP_USER_PASSWORD=admin
       - LDAP_SEARCH_FILTER=(|(uid=$$username)(cn=$$username))
       - LOAD_EXAMPLE_REPORTS=True
+      - FORWARD_AUTH_ENABLED=False
+      - FORWARD_AUTH_HEADER=X-Forwarded-User
     depends_on:
       - database
     cap_drop:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Added
+
+- Support for Forwarded Authentication in a situation where *Quality-time* is behind a reverse proxy that is responsible for authentication.
+
 ## [3.9.0] - [2020-10-11]
 
 ### Added

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -35,10 +35,6 @@ To configure Forwarded Authentication, set the `FORWARD_AUTH_ENABLED` and `FORWA
       - FORWARD_AUTH_HEADER=X-Forwarded-User
 ```
 
-When using the `LDAP_SEARCH_FILTER` as shown above, users can use either their LDAP canonical name (`cn`) or their LDAP user id to login. The `$username` variable is filled by *Quality-time* at run time with the username that the user enters in the login dialog box.
-
-See [https://ldap.com/ldap-filters/](https://ldap.com/ldap-filters/) for more information on LDAP filters.
-
 ## Settings per component
 
 ### Proxy

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -24,6 +24,21 @@ When using the `LDAP_SEARCH_FILTER` as shown above, users can use either their L
 
 See [https://ldap.com/ldap-filters/](https://ldap.com/ldap-filters/) for more information on LDAP filters.
 
+## Configuring Forwarded Authentication
+
+To configure Forwarded Authentication, set the `FORWARD_AUTH_ENABLED` and `FORWARD_AUTH_HEADER` environment variables. Security warning: Only enable Forwarded Authentication if *Quality-time* is setup behind a reverse proxy that is responsible for authentication and direct access to *Quality-time* is not possible. Add the environment variables to the server service in the [compose file](../docker/docker-compose.yml):
+
+```yaml
+  server:
+    environment:
+      - FORWARD_AUTH_ENABLED=True
+      - FORWARD_AUTH_HEADER=X-Forwarded-User
+```
+
+When using the `LDAP_SEARCH_FILTER` as shown above, users can use either their LDAP canonical name (`cn`) or their LDAP user id to login. The `$username` variable is filled by *Quality-time* at run time with the username that the user enters in the login dialog box.
+
+See [https://ldap.com/ldap-filters/](https://ldap.com/ldap-filters/) for more information on LDAP filters.
+
 ## Settings per component
 
 ### Proxy


### PR DESCRIPTION
This feature adds support for Forwarded Authentication.

When Quality-Time is setup behind a reverse proxy that is responsible for authentication, an HTTP header such as `X-Forwarded-User` may be added to the request. If Forwarded Authentication is enabled and this header is present, Quality-Time will automatically login the user specified in the header.

**Security warning:** never enable Forwarded Authentication when Quality-Time is not behind a reverse proxy that is responsible for authentication.