### PR TITLE
When using GitLab as source with a private token, pass the token to G…

### DIFF
--- a/components/collector/src/source_collectors/api_source_collectors/gitlab.py
+++ b/components/collector/src/source_collectors/api_source_collectors/gitlab.py
@@ -25,12 +25,16 @@ class GitLabBase(SourceCollector, ABC):  # pylint: disable=abstract-method
         api_url = f"{url}/api/v4/projects/{project}/{api}"
         sep = "&" if "?" in api_url else "?"
         api_url += f"{sep}per_page=100"
-        if private_token := self._parameter("private_token"):
-            api_url += f"&private_token={private_token}"
         return URL(api_url)
 
     def _basic_auth_credentials(self) -> Optional[Tuple[str, str]]:
-        return None  # The private token is passed as URI parameter
+        return None  # The private token is passed as header
+
+    def _headers(self) -> Dict[str, str]:
+        headers = super()._headers()
+        if private_token := self._parameter("private_token"):
+            headers["Private-Token"] = str(private_token)
+        return headers
 
 
 class GitLabJobsBase(GitLabBase):

--- a/components/collector/src/source_collectors/api_source_collectors/gitlab.py
+++ b/components/collector/src/source_collectors/api_source_collectors/gitlab.py
@@ -105,8 +105,7 @@ class GitLabSourceUpToDateness(GitLabBase):
         return URL(f"{web_url}/blob/{branch}/{file_path}")
 
     async def _get_source_responses(self, *urls: URL) -> SourceResponses:
-        """Override to get the last commit metadata of the file or, if the file is a folder, of the files in the folder,
-        recursively."""
+        """Get the last commit metadata of the file or, in case of a folder, of the files in the folder, recursively."""
         # First, get the project info so we can use the web url as landing url
         responses = await super()._get_source_responses(*urls)
         # Then, collect the commits
@@ -128,6 +127,7 @@ class GitLabSourceUpToDateness(GitLabBase):
         return SourceResponses(responses=list(itertools.chain(*(await asyncio.gather(*commits)))))
 
     async def __last_commit(self, file_path: str) -> SourceResponses:
+        """Return the last, meaning the most recent, commit"""
         files_api_url = await self._gitlab_api_url(
             f"repository/files/{file_path}?ref={self._parameter('branch', quote=True)}")
         response = await self._session.head(files_api_url)

--- a/components/collector/src/source_collectors/api_source_collectors/gitlab.py
+++ b/components/collector/src/source_collectors/api_source_collectors/gitlab.py
@@ -127,7 +127,7 @@ class GitLabSourceUpToDateness(GitLabBase):
         return SourceResponses(responses=list(itertools.chain(*(await asyncio.gather(*commits)))))
 
     async def __last_commit(self, file_path: str) -> SourceResponses:
-        """Return the last, meaning the most recent, commit"""
+        """Return the last, meaning the most recent, commit."""
         files_api_url = await self._gitlab_api_url(
             f"repository/files/{file_path}?ref={self._parameter('branch', quote=True)}")
         response = await self._session.head(files_api_url)

--- a/components/collector/tests/source_collectors/api_source_collectors/test_gitlab.py
+++ b/components/collector/tests/source_collectors/api_source_collectors/test_gitlab.py
@@ -46,11 +46,9 @@ class CommonGitLabJobsTestsMixin:
     async def test_private_token(self):
         """Test that the private token is used."""
         self.sources["source_id"]["parameters"]["private_token"] = "token"
-        response = await self.collect(self.metric)
+        response = await self.collect(self.metric, get_request_json_return_value=self.gitlab_jobs_json)
         self.assert_measurement(
-            response,
-            api_url="https://gitlab/api/v4/projects/namespace%2Fproject/jobs?per_page=100&private_token=token",
-            parse_error="Traceback")
+            response, value="2", api_url="https://gitlab/api/v4/projects/namespace%2Fproject/jobs?per_page=100")
 
 
 class GitLabFailedJobsTest(CommonGitLabJobsTestsMixin, GitLabTestCase):

--- a/components/collector/tests/source_collectors/api_source_collectors/test_gitlab.py
+++ b/components/collector/tests/source_collectors/api_source_collectors/test_gitlab.py
@@ -8,6 +8,7 @@ from tests.source_collectors.source_collector_test_case import SourceCollectorTe
 
 class GitLabTestCase(SourceCollectorTestCase):
     """Base class for testing GitLab collectors."""
+
     def setUp(self):
         super().setUp()
         self.sources = dict(

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- When using GitLab as source with a private token, pass the token to GitLab as header instead of URL parameter to prevent redirection. Closes [#1638](https://github.com/ICTU/quality-time/issues/1638).
+
 ### Fixed
 
 - Introduce separate namespace for internal API's. Fixes [#1632](https://github.com/ICTU/quality-time/issues/1632).


### PR DESCRIPTION
…itLab as header instead of URL parameter to prevent redirection. Closes #1638.