### PR TITLE
When using the Performancetest-runner as source for the 'slow transac…

### DIFF
--- a/components/collector/src/source_collectors/file_source_collectors/performancetest_runner.py
+++ b/components/collector/src/source_collectors/file_source_collectors/performancetest_runner.py
@@ -2,7 +2,7 @@
 
 from abc import ABC
 from datetime import datetime
-from typing import List
+from typing import Dict, List
 
 from bs4 import BeautifulSoup, Tag
 
@@ -30,6 +30,7 @@ class PerformanceTestRunnerSlowTransactions(PerformanceTestRunnerBaseClass):
     """Collector for the number of slow transactions in a Performancetest-runner performance test report."""
 
     async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
+        """Override to parse the slow transactions from the responses."""
         entities = [self.__entity(transaction) for transaction in await self.__slow_transactions(responses)]
         return SourceMeasurement(entities=entities)
 
@@ -65,6 +66,7 @@ class PerformanceTestRunnerSourceUpToDateness(PerformanceTestRunnerBaseClass, So
     """Collector for the performance test report age."""
 
     async def _parse_source_response_date_time(self, response: Response) -> datetime:
+        """Override to parse the start date time of the test from the response."""
         datetime_parts = [
             int(part) for part in (await self._soup(response)).find(id="start_of_the_test").string.split(".")]
         return datetime(*datetime_parts)  # type: ignore
@@ -74,6 +76,7 @@ class PerformanceTestRunnerPerformanceTestDuration(PerformanceTestRunnerBaseClas
     """Collector for the performance test duration."""
 
     async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
+        """Override to parse the performance test durations from the responses and return the sum in minutes."""
         durations = []
         for response in responses:
             hours, minutes, seconds = [
@@ -86,6 +89,7 @@ class PerformanceTestRunnerPerformanceTestStability(PerformanceTestRunnerBaseCla
     """Collector for the performance test stability."""
 
     async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
+        """Override to parse the trend break percentage from the responses and return the minimum percentage."""
         trend_breaks = []
         for response in responses:
             trend_breaks.append(int((await self._soup(response)).find(id="trendbreak_stability").string))
@@ -95,34 +99,45 @@ class PerformanceTestRunnerPerformanceTestStability(PerformanceTestRunnerBaseCla
 class PerformanceTestRunnerTests(PerformanceTestRunnerBaseClass):
     """Collector for the number of performance test transactions."""
 
+    COLUMN_INDICES = dict(failed=7, success=1)
+
     async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
+        """Override to parse the transactions from the responses and return the transactions with the desired status."""
         transactions_to_include = self._parameter("transactions_to_include")
         transactions_to_ignore = self._parameter("transactions_to_ignore")
-        count = dict(failed=0, success=0)
-        column_indices = dict(failed=7, success=1)
-        total = 0
+        counts = dict(failed=0, success=0)
         for response in responses:
-            soup = await self._soup(response)
-            for transaction in soup.find(id="responsetimestable_begin").select("tr.transaction"):
-                name = self._name(transaction)
-                if transactions_to_include and not match_string_or_regular_expression(name, transactions_to_include):
-                    continue
-                if match_string_or_regular_expression(name, transactions_to_ignore):
-                    continue
-                columns = transaction.find_all("td")
-                for status, column_index in column_indices.items():
-                    nr_tests = int(columns[column_index].string or 0)
-                    count[status] += nr_tests
-                    total += nr_tests
+            count = await self.__parse_response(response, transactions_to_include, transactions_to_ignore)
+            for status in count:
+                counts[status] += count[status]
+        value = sum(counts[status] for status in self._parameter("test_result"))
+        return SourceMeasurement(value=str(value), total=str(sum(counts.values())))
 
-        value = sum(count[status] for status in self._parameter("test_result"))
-        return SourceMeasurement(value=str(value), total=str(total))
+    @classmethod
+    async def __parse_response(
+            cls, response: Response,
+            transactions_to_include: List[str], transactions_to_ignore: List[str]) -> Dict[str, int]:
+        """Parse the transactions from the response."""
+        soup = await cls._soup(response)
+        count = dict(failed=0, success=0)
+        for transaction in soup.find(id="responsetimestable_begin").select("tr.transaction"):
+            name = cls._name(transaction)
+            if transactions_to_include and not match_string_or_regular_expression(name, transactions_to_include):
+                continue
+            if match_string_or_regular_expression(name, transactions_to_ignore):
+                continue
+            columns = transaction.find_all("td")
+            for status, column_index in cls.COLUMN_INDICES.items():
+                nr_tests = int(columns[column_index].string or 0)
+                count[status] += nr_tests
+        return count
 
 
 class PerformanceTestRunnerScalability(PerformanceTestRunnerBaseClass):
     """Collector for the scalability metric."""
 
     async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
+        """Override to parse the scalability breaking point from the responses."""
         trend_breaks = []
         for response in responses:
             breaking_point = int((await self._soup(response)).find(id="trendbreak_scalability").string)

--- a/components/collector/src/source_collectors/file_source_collectors/performancetest_runner.py
+++ b/components/collector/src/source_collectors/file_source_collectors/performancetest_runner.py
@@ -2,7 +2,7 @@
 
 from abc import ABC
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, cast
 
 from bs4 import BeautifulSoup, Tag
 
@@ -103,8 +103,8 @@ class PerformanceTestRunnerTests(PerformanceTestRunnerBaseClass):
 
     async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
         """Override to parse the transactions from the responses and return the transactions with the desired status."""
-        transactions_to_include = self._parameter("transactions_to_include")
-        transactions_to_ignore = self._parameter("transactions_to_ignore")
+        transactions_to_include = cast(List[str], self._parameter("transactions_to_include"))
+        transactions_to_ignore = cast(List[str], self._parameter("transactions_to_ignore"))
         counts = dict(failed=0, success=0)
         for response in responses:
             count = await self.__parse_response(response, transactions_to_include, transactions_to_ignore)

--- a/components/collector/tests/source_collectors/file_source_collectors/test_performancetest_runner.py
+++ b/components/collector/tests/source_collectors/file_source_collectors/test_performancetest_runner.py
@@ -11,14 +11,16 @@ class PerformanceTestRunnerTestCase(SourceCollectorTestCase):
     """Base class for testing the Performancetest-runner collectors."""
 
     def setUp(self):
+        """Extend to set up the metric sources."""
         super().setUp()
         self.sources = dict(source_id=dict(type="performancetest_runner", parameters=dict(url="report.html")))
 
 
 class PerformanceTestRunnerSlowTransactionsTest(PerformanceTestRunnerTestCase):
-    """Unit tests for the performancetest-runner slow transaction collector."""
+    """Unit tests for the Performancetest-runner slow transaction collector."""
 
     def setUp(self):
+        """Set up a metric fixture."""
         super().setUp()
         self.metric = dict(type="slow_transactions", sources=self.sources, addition="sum")
 
@@ -76,7 +78,7 @@ class PerformanceTestRunnerSlowTransactionsTest(PerformanceTestRunnerTestCase):
 
 
 class PerformanceTestRunnerSourceUpToDatenessTest(PerformanceTestRunnerTestCase):
-    """Unit tests for the performancetest-runner source up-to-dateness collector."""
+    """Unit tests for the Performancetest-runner source up-to-dateness collector."""
 
     async def test_source_up_to_dateness(self):
         """Test that the test age is returned."""
@@ -89,7 +91,7 @@ class PerformanceTestRunnerSourceUpToDatenessTest(PerformanceTestRunnerTestCase)
 
 
 class PerformanceTestRunnerDurationTest(PerformanceTestRunnerTestCase):
-    """Unit tests for the performancetest-runner duration collector."""
+    """Unit tests for the Performancetest-runner duration collector."""
 
     async def test_duration(self):
         """Test that the test duration is returned."""
@@ -101,10 +103,12 @@ class PerformanceTestRunnerDurationTest(PerformanceTestRunnerTestCase):
 
 
 class PerformanceTestRunnerTestsTest(PerformanceTestRunnerTestCase):
-    """Unit tests for the performancetest-runner tests collector."""
+    """Unit tests for the Performancetest-runner tests collector."""
 
     def setUp(self):
+        """Prepare a Performancetest-runner HTML-report and the tests metric."""
         super().setUp()
+        self.metric = dict(type="tests", sources=self.sources, addition="sum")
         self.html = '''
 <html>
     <table id="responsetimestable_begin">
@@ -115,55 +119,47 @@ class PerformanceTestRunnerTestsTest(PerformanceTestRunnerTestCase):
 
     async def test_tests(self):
         """Test that the number of performance test transactions is returned."""
-        metric = dict(type="tests", sources=self.sources, addition="sum")
-        response = await self.collect(metric, get_request_text=self.html)
+        response = await self.collect(self.metric, get_request_text=self.html)
         self.assert_measurement(response, value="28", total="28")
 
     async def test_failed_tests(self):
         """Test that the number of failed performance test transactions is returned."""
         # We also pass an obsolete status ("canceled") to test that obsolete statuses are ignored:
         self.sources["source_id"]["parameters"]["test_result"] = ["failed", "canceled"]
-        metric = dict(type="tests", sources=self.sources, addition="sum")
-        response = await self.collect(metric, get_request_text=self.html)
+        response = await self.collect(self.metric, get_request_text=self.html)
         self.assert_measurement(response, value="8", total="28")
 
     async def test_succeeded_tests(self):
         """Test that the number of succeeded performance test transactions is returned."""
         self.sources["source_id"]["parameters"]["test_result"] = ["success"]
-        metric = dict(type="tests", sources=self.sources, addition="sum")
-        response = await self.collect(metric, get_request_text=self.html)
+        response = await self.collect(self.metric, get_request_text=self.html)
         self.assert_measurement(response, value="20", total="28")
 
     async def test_ignored_tests(self):
         """Test that the number of performance test transactions is returned for transactions that are not ignored."""
         self.sources["source_id"]["parameters"]["transactions_to_ignore"] = [".*2"]
-        metric = dict(type="tests", sources=self.sources, addition="sum")
-        response = await self.collect(metric, get_request_text=self.html)
+        response = await self.collect(self.metric, get_request_text=self.html)
         self.assert_measurement(response, value="10", total="10")
 
     async def test_failed_and_ignored_tests(self):
-        """Test that the number of failed performance test transactions is returned for transactions that are not
-        ignored."""
+        """Test that the number of not ignored failed performance test transactions is returned."""
         self.sources["source_id"]["parameters"]["transactions_to_ignore"] = [".*2"]
         self.sources["source_id"]["parameters"]["test_result"] = ["failed"]
-        metric = dict(type="tests", sources=self.sources, addition="sum")
-        response = await self.collect(metric, get_request_text=self.html)
+        response = await self.collect(self.metric, get_request_text=self.html)
         self.assert_measurement(response, value="3", total="10")
 
     async def test_included_tests(self):
         """Test that the number of performance test transactions is returned for transactions that are included."""
         self.sources["source_id"]["parameters"]["transactions_to_include"] = ["T1"]
-        metric = dict(type="tests", sources=self.sources, addition="sum")
-        response = await self.collect(metric, get_request_text=self.html)
+        response = await self.collect(self.metric, get_request_text=self.html)
         self.assert_measurement(response, value="10", total="10")
 
 
 class PerformanceTestRunnerStabilityTest(PerformanceTestRunnerTestCase):
-    """Unit tests for the performancetest-runner performance test stability collector."""
+    """Unit tests for the Performancetest-runner performance test stability collector."""
 
     async def test_stability(self):
-        """Test that the percentage of the duration of the performancetest at which the test becomes unstable is
-        returned."""
+        """Test that the percentage of the duration at which the performance test becomes unstable is returned."""
         html = '''<html><table class="config">
             <tr><td class="name">Trendbreak 'stability' (%)</td><td id="trendbreak_stability">90</td></tr>
             </table></html>'''
@@ -173,15 +169,15 @@ class PerformanceTestRunnerStabilityTest(PerformanceTestRunnerTestCase):
 
 
 class PerformanceTestRunnerScalabilityTest(PerformanceTestRunnerTestCase):
-    """Unit tests for the performancetest-runner performance test scalability collector."""
+    """Unit tests for the Performancetest-runner performance test scalability collector."""
 
     def setUp(self):
+        """Set up the scalability metric."""
         super().setUp()
         self.metric = dict(type="scalability", sources=self.sources, addition="min")
 
     async def test_scalability(self):
-        """Test that the percentage of the max users of the performancetest at which the ramp-up of throughput breaks is
-        returned."""
+        """Test that the percentage of the max users at which the ramp-up of throughput breaks is returned."""
         html = '''<html><table class="config">
             <tr><td class="name">Trendbreak 'scalability' (%)</td><td id="trendbreak_scalability">74</td></tr>
             </table></html>'''
@@ -189,8 +185,11 @@ class PerformanceTestRunnerScalabilityTest(PerformanceTestRunnerTestCase):
         self.assert_measurement(response, value="74")
 
     async def test_scalability_without_breaking_point(self):
-        """Test that if the percentage of the max users of the performancetest at which the ramp-up of throughput breaks
-        is 100%, the metric reports an error (since there is no breaking point)."""
+        """Test the scalability without breaking point.
+
+        Test that if the percentage of the max users at which the ramp-up of throughput breaks is 100%, the metric
+        reports an error (since there is no breaking point).
+        """
         html = '''<html><table class="config">
             <tr><td class="name">Trendbreak 'scalability' (%)</td><td id="trendbreak_scalability">100</td></tr>
             </table></html>'''

--- a/components/collector/tests/source_collectors/file_source_collectors/test_performancetest_runner.py
+++ b/components/collector/tests/source_collectors/file_source_collectors/test_performancetest_runner.py
@@ -46,8 +46,8 @@ class PerformanceTestRunnerSlowTransactionsTest(PerformanceTestRunnerTestCase):
     async def test_warning_only(self):
         """Test that only transactions that exceed the warning threshold are counted."""
         html = '<html><table class="details"><tr class="transaction"><td class="red evaluated"/>' \
-            '</tr><tr class="transaction"><td class="name">Name</td><td class="yellow evaluated"/></tr>' \
-            '<tr class="transaction"><td class="green evaluated"/></tr></table></html>'
+               '</tr><tr class="transaction"><td class="name">Name</td><td class="yellow evaluated"/></tr>' \
+               '<tr class="transaction"><td class="green evaluated"/></tr></table></html>'
         self.sources["source_id"]["parameters"]["thresholds"] = ["warning"]
         response = await self.collect(self.metric, get_request_text=html)
         self.assert_measurement(response, value="1", entities=[dict(key="Name", name="Name", threshold="warning")])
@@ -60,6 +60,17 @@ class PerformanceTestRunnerSlowTransactionsTest(PerformanceTestRunnerTestCase):
                '<tr class="transaction"><td class="name">T3</td><td class="green evaluated"/></tr>' \
                '</table></html>'
         self.sources["source_id"]["parameters"]["transactions_to_ignore"] = ["T[1|3]"]
+        response = await self.collect(self.metric, get_request_text=html)
+        self.assert_measurement(response, value="1", entities=[dict(key="T2", name="T2", threshold="warning")])
+
+    async def test_include_transactions_by_name(self):
+        """Test that transactions can be included by name."""
+        html = '<html><table class="details">' \
+               '<tr class="transaction"><td class="name">T1</td><td class="red evaluated"/></tr>' \
+               '<tr class="transaction"><td class="name">T2</td><td class="yellow evaluated"/></tr>' \
+               '<tr class="transaction"><td class="name">T3</td><td class="green evaluated"/></tr>' \
+               '</table></html>'
+        self.sources["source_id"]["parameters"]["transactions_to_include"] = ["T2"]
         response = await self.collect(self.metric, get_request_text=html)
         self.assert_measurement(response, value="1", entities=[dict(key="T2", name="T2", threshold="warning")])
 
@@ -103,13 +114,13 @@ class PerformanceTestRunnerTestsTest(PerformanceTestRunnerTestCase):
 </html>'''
 
     async def test_tests(self):
-        """Test that the number of performancetest transactions is returned."""
+        """Test that the number of performance test transactions is returned."""
         metric = dict(type="tests", sources=self.sources, addition="sum")
         response = await self.collect(metric, get_request_text=self.html)
         self.assert_measurement(response, value="28", total="28")
 
     async def test_failed_tests(self):
-        """Test that the number of failed performancetest transactions is returned."""
+        """Test that the number of failed performance test transactions is returned."""
         # We also pass an obsolete status ("canceled") to test that obsolete statuses are ignored:
         self.sources["source_id"]["parameters"]["test_result"] = ["failed", "canceled"]
         metric = dict(type="tests", sources=self.sources, addition="sum")
@@ -117,27 +128,34 @@ class PerformanceTestRunnerTestsTest(PerformanceTestRunnerTestCase):
         self.assert_measurement(response, value="8", total="28")
 
     async def test_succeeded_tests(self):
-        """Test that the number of succeeded performancetest transactions is returned."""
+        """Test that the number of succeeded performance test transactions is returned."""
         self.sources["source_id"]["parameters"]["test_result"] = ["success"]
         metric = dict(type="tests", sources=self.sources, addition="sum")
         response = await self.collect(metric, get_request_text=self.html)
         self.assert_measurement(response, value="20", total="28")
 
     async def test_ignored_tests(self):
-        """Test that the number of performancetest transactions is returned for transactions that are not ignored."""
+        """Test that the number of performance test transactions is returned for transactions that are not ignored."""
         self.sources["source_id"]["parameters"]["transactions_to_ignore"] = [".*2"]
         metric = dict(type="tests", sources=self.sources, addition="sum")
         response = await self.collect(metric, get_request_text=self.html)
         self.assert_measurement(response, value="10", total="10")
 
     async def test_failed_and_ignored_tests(self):
-        """Test that the number of failed performancetest transactions is returned for transactions that are not
+        """Test that the number of failed performance test transactions is returned for transactions that are not
         ignored."""
         self.sources["source_id"]["parameters"]["transactions_to_ignore"] = [".*2"]
         self.sources["source_id"]["parameters"]["test_result"] = ["failed"]
         metric = dict(type="tests", sources=self.sources, addition="sum")
         response = await self.collect(metric, get_request_text=self.html)
         self.assert_measurement(response, value="3", total="10")
+
+    async def test_included_tests(self):
+        """Test that the number of performance test transactions is returned for transactions that are included."""
+        self.sources["source_id"]["parameters"]["transactions_to_include"] = ["T1"]
+        metric = dict(type="tests", sources=self.sources, addition="sum")
+        response = await self.collect(metric, get_request_text=self.html)
+        self.assert_measurement(response, value="10", total="10")
 
 
 class PerformanceTestRunnerStabilityTest(PerformanceTestRunnerTestCase):

--- a/components/server/src/data/datamodel.json
+++ b/components/server/src/data/datamodel.json
@@ -2537,7 +2537,7 @@
                 "jobs_to_include": {
                     "name": "Jobs to include (regular expressions or job names)",
                     "short_name": "jobs to include",
-                    "help": "Jobs to include can be specified by job name or by regular expression. Use {parent job name}/{child job name} for the names of nested jobs. If empty, all jobs will be included.",
+                    "help": "Jobs to include can be specified by job name or by regular expression. Use {parent job name}/{child job name} for the names of nested jobs.",
                     "type": "multiple_choice_with_addition",
                     "placeholder": "all",
                     "mandatory":  false,
@@ -4089,6 +4089,19 @@
                     "help": "Transactions to ignore can be specified by transaction name or by regular expression.",
                     "type": "multiple_choice_with_addition",
                     "placeholder": "none",
+                    "mandatory":  false,
+                    "default_value": [],
+                    "metrics": [
+                        "slow_transactions",
+                        "tests"
+                    ]
+                },
+                "transactions_to_include": {
+                    "name": "Transactions to include (regular expressions or transaction names)",
+                    "short_name": "transactions to include",
+                    "help": "Transactions to include can be specified by transaction name or by regular expression.",
+                    "type": "multiple_choice_with_addition",
+                    "placeholder": "all",
                     "mandatory":  false,
                     "default_value": [],
                     "metrics": [

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- When using the Performancetest-runner as source for the 'slow transactions' or 'tests' metric, add a transactions-to-include parameter in addition to the transactions-to-ignore parameter to make it easier to select the relevant transactions. Closes [#1647](https://github.com/ICTU/quality-time/issues/1647).
+
 ### Removed
 
 - The SonarQube rules that *Quality-time* uses to query SonarQube for the 'commented out code', 'complex units', 'long units', 'many parameters', and 'suppressed violations' metrics are no longer a parameter that the user can change. The reason is that it's hardly ever necessary to change these parameters and at the same time it's very easy to accidentally remove a rule and get incorrect results as a consequence. The used rules are documented in the [metrics and sources overview](METRICS_AND_SOURCES.md). Closes [#1648](https://github.com/ICTU/quality-time/issues/1648).

--- a/docs/METRICS_AND_SOURCES.md
+++ b/docs/METRICS_AND_SOURCES.md
@@ -197,7 +197,7 @@ This document lists all [metrics](#metrics) that *Quality-time* can measure and 
 | :-------- | :--- | :-------- | :--- |
 | Failure type | Multiple choice | No | Limit which failure types to count as failed. |
 | Jobs to ignore (regular expressions or job names) | Multiple choice with addition | No | Jobs to ignore can be specified by job name or by regular expression. Use {parent job name}/{child job name} for the names of nested jobs. |
-| Jobs to include (regular expressions or job names) | Multiple choice with addition | No | Jobs to include can be specified by job name or by regular expression. Use {parent job name}/{child job name} for the names of nested jobs. If empty, all jobs will be included. |
+| Jobs to include (regular expressions or job names) | Multiple choice with addition | No | Jobs to include can be specified by job name or by regular expression. Use {parent job name}/{child job name} for the names of nested jobs. |
 | Password or API token for basic authentication | Password | No | [https://wiki.jenkins.io/display/JENKINS/Authenticating+scripted+clients](https://wiki.jenkins.io/display/JENKINS/Authenticating+scripted+clients) |
 | URL | URL | Yes | URL of the Jenkins instance, with port if necessary, but without path. For example, 'https://jenkins.example.org'. |
 | Username for basic authentication | String | No |  |
@@ -379,6 +379,7 @@ This document lists all [metrics](#metrics) that *Quality-time* can measure and 
 | Private token | Password | No |  |
 | Thresholds | Multiple choice | No | If provided, only count transactions that surpass the selected thresholds. |
 | Transactions to ignore (regular expressions or transaction names) | Multiple choice with addition | No | Transactions to ignore can be specified by transaction name or by regular expression. |
+| Transactions to include (regular expressions or transaction names) | Multiple choice with addition | No | Transactions to include can be specified by transaction name or by regular expression. |
 | URL to a Performancetest-runner HTML report or a zip with Performancetest-runner HTML reports | URL | Yes |  |
 | Username for basic authentication | String | No |  |
 
@@ -792,6 +793,7 @@ This document lists all [metrics](#metrics) that *Quality-time* can measure and 
 | Private token | Password | No |  |
 | Test result | Multiple choice | No | Limit which test results to count. Note: depending on which results are selected, the direction of the metric may need to be adapted. For example, when counting passed tests, more is better, but when counting failed tests, fewer is better. |
 | Transactions to ignore (regular expressions or transaction names) | Multiple choice with addition | No | Transactions to ignore can be specified by transaction name or by regular expression. |
+| Transactions to include (regular expressions or transaction names) | Multiple choice with addition | No | Transactions to include can be specified by transaction name or by regular expression. |
 | URL to a Performancetest-runner HTML report or a zip with Performancetest-runner HTML reports | URL | Yes |  |
 | Username for basic authentication | String | No |  |
 
@@ -989,7 +991,7 @@ This document lists all [metrics](#metrics) that *Quality-time* can measure and 
 | Parameter | Type | Mandatory | Help |
 | :-------- | :--- | :-------- | :--- |
 | Jobs to ignore (regular expressions or job names) | Multiple choice with addition | No | Jobs to ignore can be specified by job name or by regular expression. Use {parent job name}/{child job name} for the names of nested jobs. |
-| Jobs to include (regular expressions or job names) | Multiple choice with addition | No | Jobs to include can be specified by job name or by regular expression. Use {parent job name}/{child job name} for the names of nested jobs. If empty, all jobs will be included. |
+| Jobs to include (regular expressions or job names) | Multiple choice with addition | No | Jobs to include can be specified by job name or by regular expression. Use {parent job name}/{child job name} for the names of nested jobs. |
 | Number of days without builds after which to consider CI-jobs unused. | Integer | No |  |
 | Password or API token for basic authentication | Password | No | [https://wiki.jenkins.io/display/JENKINS/Authenticating+scripted+clients](https://wiki.jenkins.io/display/JENKINS/Authenticating+scripted+clients) |
 | URL | URL | Yes | URL of the Jenkins instance, with port if necessary, but without path. For example, 'https://jenkins.example.org'. |


### PR DESCRIPTION
…tions' or 'tests' metric, add a transactions-to-include parameter in addition to the transactions-to-ignore parameter to make it easier to select the relevant transactions. Closes #1647.