### PR TITLE
Turn on processing of DTD's (despite the fact that security tools com…

### DIFF
--- a/components/collector/src/collector_utilities/functions.py
+++ b/components/collector/src/collector_utilities/functions.py
@@ -15,7 +15,7 @@ from .type import URL, Namespaces, Response
 
 async def parse_source_response_xml(response: Response, allowed_root_tags: Collection[str] = None) -> Element:
     """Parse the XML from the source response."""
-    tree = cast(Element, ElementTree.fromstring(await response.text(), forbid_dtd=True))
+    tree = cast(Element, ElementTree.fromstring(await response.text(), forbid_dtd=False))
     if allowed_root_tags and tree.tag not in allowed_root_tags:
         raise AssertionError(f'The XML root element should be one of "{allowed_root_tags}" but is "{tree.tag}"')
     return tree

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- Turn on processing of DTD's (despite the fact that security tools complain that this is insecure) because otherwise OJAudit reports can't be read. Fixes [#1655](https://github.com/ICTU/quality-time/issues/1655). 
+
 ## [3.13.0] - [2020-11-08]
 
 ### Added


### PR DESCRIPTION
…plain that this is insecure) because otherwise OJAudit reports can't be read. Fixes #1655.