### PR TITLE
Turn on processing of all DTD's 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- Turn on processing of all DTD's (despite the fact that security tools complain that this is insecure) because otherwise XML reports referring to a DTD can't be read. Fixes [#1676](https://github.com/ICTU/quality-time/issues/1676).
+
 ## [3.14.0] - [2020-11-15]
 
 ### Added


### PR DESCRIPTION
despite the fact that security tools complain that this is insecure, because otherwise XML reports referring to a DTD can't be read. Fixes #1676.