### PR TITLE
Collapsing an expanded metric would sometimes result in a crash of the frontend

### DIFF
--- a/components/frontend/src/metric/Measurement.js
+++ b/components/frontend/src/metric/Measurement.js
@@ -56,8 +56,10 @@ export function Measurement(props) {
     if (expand) {
       props.toggleVisibleDetailsTab(`${props.metric_uuid}:0`)
     } else {
-      const tab = props.visibleDetailsTabs.filter((each) => each.startsWith(props.metric_uuid))[0];
-      props.toggleVisibleDetailsTab(tab)
+      const tabs = props.visibleDetailsTabs.filter((each) => each.startsWith(props.metric_uuid));
+      if (tabs.length > 0) {
+        props.toggleVisibleDetailsTab(tabs[0])
+      }
     }
   }
   return (

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,12 +15,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Show since when a metric has its current status via a popup over the status icon. Closes [#1091](https://github.com/ICTU/quality-time/issues/1091).
 
+### Fixed
+
+- Collapsing an expanded metric would sometimes result in a crash of the frontend. Fixes [#1717](https://github.com/ICTU/quality-time/issues/1717).
+
 ## [3.15.0] - [2020-11-29]
 
 ### Added
 
 - When using Jira as source for the 'issues' and the 'user story points' metric, show the issue type in the metric details. Closes [#1674](https://github.com/ICTU/quality-time/issues/1674).
-- Allow for limiting editing rights to specific people. Grant editing rights to people by adding their username or email address to the editors field on the homepage. Expand the overview title to access the editors field. Also see the [user manual](USAGE.md#limiting-editing-rights). Closes [#294](https://github.com/ICTU/quality-time/issues/294). 
+- Allow for limiting editing rights to specific people. Grant editing rights to people by adding their username or email address to the editors field on the homepage. Expand the overview title to access the editors field. Also see the [user manual](USAGE.md#limiting-editing-rights). Closes [#294](https://github.com/ICTU/quality-time/issues/294).
 
 ### Fixed
 


### PR DESCRIPTION
Fixes #1717.