### PR TITLE
Accepting the technical debt of a metric with one ore more unreachabl…

### DIFF
--- a/components/server/src/model/metric.py
+++ b/components/server/src/model/metric.py
@@ -63,9 +63,9 @@ class Metric:
     def status(self, measurement_value: Optional[str]) -> Optional[Status]:
         """Return the metric status, given a measurement value."""
         if measurement_value is None:
-            # Allow for accepted debt even if there is no measurement yet so that the fact that a metric does not have a
+            # Allow for accepted debt if there is no measurement yet so that the fact that a metric does not have a
             # source can be accepted as technical debt
-            return None if self.accept_debt_expired() else "debt_target_met"
+            return None if self.accept_debt_expired() or self.sources() else "debt_target_met"
         value = float(measurement_value)
         better_or_equal = {">": float.__ge__, "<": float.__le__}[self.direction()]
         if better_or_equal(value, self.target()):

--- a/components/server/tests/routes/test_metric.py
+++ b/components/server/tests/routes/test_metric.py
@@ -145,6 +145,32 @@ class PostMetricAttributeTest(unittest.TestCase):
                 metric_uuid=METRIC_ID,
                 count=dict(
                     value=None,
+                    status=None,
+                    target="0",
+                    near_target="10",
+                    debt_target=None,
+                    direction="<",
+                ),
+            ),
+            post_metric_attribute(METRIC_ID, "accept_debt", self.database),
+        )
+        self.assert_delta("accept_debt of metric 'name' of subject 'Subject' in report 'Report' from '' to 'True'")
+
+    @patch("database.measurements.iso_timestamp", new=Mock(return_value="2019-01-01"))
+    def test_post_metric_technical_debt_without_sources(self, request):
+        """Test that accepting technical debt when the metric has no sources also sets the status to debt target met."""
+        self.report["subjects"][SUBJECT_ID]["metrics"][METRIC_ID]["sources"] = {}
+        self.database.measurements.find_one.return_value = dict(_id="id", metric_uuid=METRIC_ID, sources=[])
+        self.database.measurements.insert_one.side_effect = self.set_measurement_id
+        request.json = dict(accept_debt=True)
+        self.assertEqual(
+            dict(
+                end="2019-01-01",
+                sources=[],
+                start="2019-01-01",
+                metric_uuid=METRIC_ID,
+                count=dict(
+                    value=None,
                     status="debt_target_met",
                     status_start="2019-01-01",
                     target="0",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Collapsing an expanded metric would sometimes result in a crash of the frontend. Fixes [#1717](https://github.com/ICTU/quality-time/issues/1717).
+- Accepting the technical debt of a metric with one ore more unreachable sources would set the metric status to 'technical debt target met' instead of 'unknown'. Fixes [#1636](https://github.com/ICTU/quality-time/issues/1636).
 
 ## [3.15.0] - [2020-11-29]
 


### PR DESCRIPTION
…e sources would set the metric status to 'technical debt target met' instead of 'unknown'. Fixes #1636.