### PR TITLE
Some dependencies in the OWASP Dependency Check report have no hash. …

### DIFF
--- a/components/collector/src/source_collectors/file_source_collectors/owasp_dependency_check.py
+++ b/components/collector/src/source_collectors/file_source_collectors/owasp_dependency_check.py
@@ -16,8 +16,10 @@ from source_model import Entity, SourceMeasurement, SourceResponses
 class OWASPDependencyCheckBase(XMLFileSourceCollector, ABC):  # pylint: disable=abstract-method
     """Base class for OWASP Dependency Check collectors."""
 
-    allowed_root_tags = [f"{{https://jeremylong.github.io/DependencyCheck/dependency-check.{version}.xsd}}analysis"
-                         for version in ("2.0", "2.1", "2.2", "2.3", "2.4", "2.5")]
+    allowed_root_tags = [
+        f"{{https://jeremylong.github.io/DependencyCheck/dependency-check.{version}.xsd}}analysis"
+        for version in ("2.0", "2.1", "2.2", "2.3", "2.4", "2.5")
+    ]
 
 
 class OWASPDependencyCheckDependencies(OWASPDependencyCheckBase):
@@ -29,8 +31,11 @@ class OWASPDependencyCheckDependencies(OWASPDependencyCheckBase):
         for response in responses:
             tree, namespaces = await parse_source_response_xml_with_namespace(response, self.allowed_root_tags)
             entities.extend(
-                [self._parse_entity(dependency, index, namespaces, landing_url) for (index, dependency)
-                 in enumerate(self._dependencies(tree, namespaces))])
+                [
+                    self._parse_entity(dependency, index, namespaces, landing_url)
+                    for (index, dependency) in enumerate(self._dependencies(tree, namespaces))
+                ]
+            )
         return SourceMeasurement(entities=entities)
 
     def _dependencies(self, tree: Element, namespaces: Namespaces) -> List[Element]:  # pylint: disable=no-self-use
@@ -38,15 +43,17 @@ class OWASPDependencyCheckDependencies(OWASPDependencyCheckBase):
         return tree.findall(".//ns:dependency", namespaces)
 
     def _parse_entity(  # pylint: disable=no-self-use
-            self, dependency: Element, dependency_index: int, namespaces: Namespaces, landing_url: str) -> Entity:
+        self, dependency: Element, dependency_index: int, namespaces: Namespaces, landing_url: str
+    ) -> Entity:
         """Parse the entity from the dependency."""
         file_path = dependency.findtext("ns:filePath", default="", namespaces=namespaces)
+        file_name = dependency.findtext("ns:fileName", default="", namespaces=namespaces)
         sha1 = dependency.findtext("ns:sha1", namespaces=namespaces)
         # We can only generate an entity landing url if a sha1 is present in the XML, but unfortunately not all
         # dependencies have one, so check for it:
         entity_landing_url = f"{landing_url}#l{dependency_index + 1}_{sha1}" if sha1 else ""
-        key = sha1 if sha1 else sha1_hash(file_path)
-        return Entity(key=key, file_path=file_path, url=entity_landing_url)
+        key = sha1 if sha1 else sha1_hash(file_path + file_name)
+        return Entity(key=key, file_path=file_path, file_name=file_name, url=entity_landing_url)
 
 
 class OWASPDependencyCheckSecurityWarnings(OWASPDependencyCheckDependencies):
@@ -55,32 +62,40 @@ class OWASPDependencyCheckSecurityWarnings(OWASPDependencyCheckDependencies):
     def _dependencies(self, tree: Element, namespaces: Namespaces) -> List[Element]:
         """Return the vulnerable dependencies."""
         return [
-            dependency for dependency in tree.findall(".//ns:dependency", namespaces)
-            if self.__vulnerabilities(dependency, namespaces)]
+            dependency
+            for dependency in tree.findall(".//ns:dependency", namespaces)
+            if self.__vulnerabilities(dependency, namespaces)
+        ]
 
     def _parse_entity(
-            self, dependency: Element, dependency_index: int, namespaces: Namespaces, landing_url: str) -> Entity:
+        self, dependency: Element, dependency_index: int, namespaces: Namespaces, landing_url: str
+    ) -> Entity:
         """Parse the entity from the dependency."""
         entity = super()._parse_entity(dependency, dependency_index, namespaces, landing_url)
         vulnerabilities = self.__vulnerabilities(dependency, namespaces)
         severities = {
             vulnerability.findtext(".//ns:severity", default="", namespaces=namespaces).lower()
-            for vulnerability in vulnerabilities}
+            for vulnerability in vulnerabilities
+        }
         highest_severity = "low"
         for severity in ("critical", "high", "medium"):
             if severity in severities:
                 highest_severity = severity
                 break
         entity.update(
-            dict(highest_severity=highest_severity.capitalize(), nr_vulnerabilities=str(len(vulnerabilities))))
+            dict(highest_severity=highest_severity.capitalize(), nr_vulnerabilities=str(len(vulnerabilities)))
+        )
         return entity
 
     def __vulnerabilities(self, element: Element, namespaces: Namespaces) -> List[Element]:
         """Return the vulnerabilities that have one of the severities specified in the parameters."""
         severities = self._parameter("severities")
         vulnerabilities = element.findall(".//ns:vulnerabilities/ns:vulnerability", namespaces)
-        return [vulnerability for vulnerability in vulnerabilities if
-                vulnerability.findtext(".//ns:severity", default="", namespaces=namespaces).lower() in severities]
+        return [
+            vulnerability
+            for vulnerability in vulnerabilities
+            if vulnerability.findtext(".//ns:severity", default="", namespaces=namespaces).lower() in severities
+        ]
 
 
 class OWASPDependencyCheckSourceUpToDateness(OWASPDependencyCheckBase, SourceUpToDatenessCollector):

--- a/components/collector/tests/source_collectors/file_source_collectors/test_owasp_dependency_check.py
+++ b/components/collector/tests/source_collectors/file_source_collectors/test_owasp_dependency_check.py
@@ -15,15 +15,17 @@ class OWASPDependencyCheckTest(SourceCollectorTestCase):
         self.sources = dict(
             sourceid=dict(type="owasp_dependency_check", parameters=dict(url="https://owasp_dependency_check.xml"))
         )
+        self.file_name = "jquery.min.js"
+        self.file_path = f"/home/jenkins/workspace/hackazon-owaspdep/hackazon/js/{self.file_name}"
 
     async def test_warnings(self):
         """Test that the number of warnings is returned."""
-        xml = """<?xml version="1.0"?>
+        xml = f"""<?xml version="1.0"?>
         <analysis xmlns="https://jeremylong.github.io/DependencyCheck/dependency-check.2.0.xsd">
             <dependency isVirtual="false">
                 <sha1>12345</sha1>
-                <fileName>jquery.min.js</fileName>
-                <filePath>/home/jenkins/workspace/hackazon-owaspdep/hackazon/js/jquery.min.js</filePath>
+                <fileName>{self.file_name}</fileName>
+                <filePath>{self.file_path}</filePath>
                 <vulnerabilities>
                     <vulnerability source="NVD">
                         <cvssV2>
@@ -46,20 +48,20 @@ class OWASPDependencyCheckTest(SourceCollectorTestCase):
                 url="https://owasp_dependency_check.html#l1_12345",
                 highest_severity="Medium",
                 nr_vulnerabilities="2",
-                file_name="jquery.min.js",
-                file_path="/home/jenkins/workspace/hackazon-owaspdep/hackazon/js/jquery.min.js",
+                file_name=self.file_name,
+                file_path=self.file_path,
             )
         ]
         self.assert_measurement(response, value="1", entities=expected_entities)
 
     async def test_low_warnings(self):
         """Test that the number of warnings is returned."""
-        xml = """<?xml version="1.0"?>
+        xml = f"""<?xml version="1.0"?>
         <analysis xmlns="https://jeremylong.github.io/DependencyCheck/dependency-check.2.0.xsd">
             <dependency isVirtual="false">
                 <sha1>12345</sha1>
-                <fileName>jquery.min.js</fileName>
-                <filePath>/home/jenkins/workspace/hackazon-owaspdep/hackazon/js/jquery.min.js</filePath>
+                <fileName>{self.file_name}</fileName>
+                <filePath>{self.file_path}</filePath>
                 <vulnerabilities>
                     <vulnerability source="NVD">
                         <cvssV2>
@@ -77,8 +79,8 @@ class OWASPDependencyCheckTest(SourceCollectorTestCase):
                 url="https://owasp_dependency_check.html#l1_12345",
                 highest_severity="Low",
                 nr_vulnerabilities="1",
-                file_name="jquery.min.js",
-                file_path="/home/jenkins/workspace/hackazon-owaspdep/hackazon/js/jquery.min.js",
+                file_name=self.file_name,
+                file_path=self.file_path,
             )
         ]
         self.assert_measurement(response, value="1", entities=expected_entities)
@@ -152,12 +154,12 @@ AssertionError: The XML root element should be one of \
 
     async def test_dependencies(self):
         """Test that the dependencies are returned."""
-        xml = """<?xml version="1.0"?>
+        xml = f"""<?xml version="1.0"?>
         <analysis xmlns="https://jeremylong.github.io/DependencyCheck/dependency-check.2.0.xsd">
             <dependency isVirtual="false">
                 <sha1>9999</sha1>
-                <fileName>jquery.min.js</fileName>
-                <filePath>/home/jenkins/workspace/hackazon/js/jquery.min.js</filePath>
+                <fileName>{self.file_name}</fileName>
+                <filePath>{self.file_path}</filePath>
                 <vulnerabilities>
                     <vulnerability source="NVD">
                         <cvssV2>
@@ -173,8 +175,8 @@ AssertionError: The XML root element should be one of \
             dict(
                 key="9999",
                 url="https://owasp_dependency_check.html#l1_9999",
-                file_name="jquery.min.js",
-                file_path="/home/jenkins/workspace/hackazon/js/jquery.min.js",
+                file_name=self.file_name,
+                file_path=self.file_path,
             )
         ]
         self.assert_measurement(response, value="1", entities=expected_entities)

--- a/components/collector/tests/source_collectors/file_source_collectors/test_owasp_dependency_check.py
+++ b/components/collector/tests/source_collectors/file_source_collectors/test_owasp_dependency_check.py
@@ -13,7 +13,8 @@ class OWASPDependencyCheckTest(SourceCollectorTestCase):
     def setUp(self):
         super().setUp()
         self.sources = dict(
-            sourceid=dict(type="owasp_dependency_check", parameters=dict(url="https://owasp_dependency_check.xml")))
+            sourceid=dict(type="owasp_dependency_check", parameters=dict(url="https://owasp_dependency_check.xml"))
+        )
 
     async def test_warnings(self):
         """Test that the number of warnings is returned."""
@@ -40,9 +41,15 @@ class OWASPDependencyCheckTest(SourceCollectorTestCase):
         metric = dict(type="security_warnings", addition="sum", sources=self.sources)
         response = await self.collect(metric, get_request_text=xml)
         expected_entities = [
-            dict(key="12345", url="https://owasp_dependency_check.html#l1_12345",
-                 highest_severity="Medium", nr_vulnerabilities="2",
-                 file_path="/home/jenkins/workspace/hackazon-owaspdep/hackazon/js/jquery.min.js")]
+            dict(
+                key="12345",
+                url="https://owasp_dependency_check.html#l1_12345",
+                highest_severity="Medium",
+                nr_vulnerabilities="2",
+                file_name="jquery.min.js",
+                file_path="/home/jenkins/workspace/hackazon-owaspdep/hackazon/js/jquery.min.js",
+            )
+        ]
         self.assert_measurement(response, value="1", entities=expected_entities)
 
     async def test_low_warnings(self):
@@ -65,10 +72,65 @@ class OWASPDependencyCheckTest(SourceCollectorTestCase):
         metric = dict(type="security_warnings", addition="sum", sources=self.sources)
         response = await self.collect(metric, get_request_text=xml)
         expected_entities = [
-            dict(key="12345", url="https://owasp_dependency_check.html#l1_12345",
-                 highest_severity="Low", nr_vulnerabilities="1",
-                 file_path="/home/jenkins/workspace/hackazon-owaspdep/hackazon/js/jquery.min.js")]
+            dict(
+                key="12345",
+                url="https://owasp_dependency_check.html#l1_12345",
+                highest_severity="Low",
+                nr_vulnerabilities="1",
+                file_name="jquery.min.js",
+                file_path="/home/jenkins/workspace/hackazon-owaspdep/hackazon/js/jquery.min.js",
+            )
+        ]
         self.assert_measurement(response, value="1", entities=expected_entities)
+
+    async def test_multiple_warnings_with_same_filepath(self):
+        """Test that the hashes are based on both the file path and the file name."""
+        xml = """<?xml version="1.0"?>
+            <analysis xmlns="https://jeremylong.github.io/DependencyCheck/dependency-check.2.5.xsd">
+                <dependency>
+                    <fileName>CuttingEdge.Conditions:1.2.0.0</fileName>
+                    <filePath>packages.config</filePath>
+                    <vulnerabilities>
+                        <vulnerability source="NVD">
+                            <cvssV2>
+                                <severity>LOW</severity>
+                            </cvssV2>
+                        </vulnerability>
+                    </vulnerabilities>
+                </dependency>
+                <dependency>
+                    <fileName>IdentityModel:1.13.1</fileName>
+                    <filePath>packages.config</filePath>
+                    <vulnerabilities>
+                        <vulnerability source="NVD">
+                            <cvssV2>
+                                <severity>LOW</severity>
+                            </cvssV2>
+                        </vulnerability>
+                    </vulnerabilities>
+                </dependency>
+            </analysis>"""
+        metric = dict(type="security_warnings", addition="sum", sources=self.sources)
+        response = await self.collect(metric, get_request_text=xml)
+        expected_entities = [
+            dict(
+                key="498ac4bf0c766490ad58cd04a71e07a439b97fc8",
+                url="",
+                file_name="CuttingEdge.Conditions:1.2.0.0",
+                highest_severity="Low",
+                nr_vulnerabilities="1",
+                file_path="packages.config",
+            ),
+            dict(
+                key="7f5f471406d316dfeb580de2738db563f3c7ac97",
+                url="",
+                file_name="IdentityModel:1.13.1",
+                highest_severity="Low",
+                nr_vulnerabilities="1",
+                file_path="packages.config",
+            ),
+        ]
+        self.assert_measurement(response, value="2", entities=expected_entities)
 
     async def test_invalid_xml(self):
         """Test that the number of warnings is returned."""
@@ -78,11 +140,15 @@ class OWASPDependencyCheckTest(SourceCollectorTestCase):
         metric = dict(type="security_warnings", addition="sum", sources=self.sources)
         response = await self.collect(metric, get_request_text=xml)
         self.assert_measurement(
-            response, value=None, entities=[], parse_error=f"""
+            response,
+            value=None,
+            entities=[],
+            parse_error=f"""
 AssertionError: The XML root element should be one of \
 "{OWASPDependencyCheckBase.allowed_root_tags}" but is \
 "{{https://jeremylong.github.io/DependencyCheck/dependency-check.1.8.xsd}}analysis"
-""")
+""",
+        )
 
     async def test_dependencies(self):
         """Test that the dependencies are returned."""
@@ -104,8 +170,13 @@ AssertionError: The XML root element should be one of \
         metric = dict(type="dependencies", addition="sum", sources=self.sources)
         response = await self.collect(metric, get_request_text=xml)
         expected_entities = [
-            dict(key="9999", url="https://owasp_dependency_check.html#l1_9999",
-                 file_path="/home/jenkins/workspace/hackazon/js/jquery.min.js")]
+            dict(
+                key="9999",
+                url="https://owasp_dependency_check.html#l1_9999",
+                file_name="jquery.min.js",
+                file_path="/home/jenkins/workspace/hackazon/js/jquery.min.js",
+            )
+        ]
         self.assert_measurement(response, value="1", entities=expected_entities)
 
     async def test_source_up_to_dateness(self):

--- a/components/server/src/data/datamodel.json
+++ b/components/server/src/data/datamodel.json
@@ -3808,6 +3808,10 @@
                             "url": "url"
                         },
                         {
+                            "name": "File name",
+                            "key": "file_name"
+                        },
+                        {
                             "name": "Highest severity",
                             "key": "highest_severity",
                             "color": {
@@ -3831,6 +3835,10 @@
                             "name": "File path",
                             "key": "file_path",
                             "url": "url"
+                        },
+                        {
+                            "name": "File name",
+                            "key": "file_name"
                         }
                     ]
                 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The frontend would reload the change log every time the server notified the frontend about the number of measurements, causing unnecessary updates of the UI. Fixes [#1555](https://github.com/ICTU/quality-time/issues/1555).
 - When the user opens a report in the frontend, don't send unneeded data to the frontend. Fixes [#1764](https://github.com/ICTU/quality-time/issues/1764).
 - Don't crash the notifier when a metric has an unknown (white) status. Fixes [#1802](https://github.com/ICTU/quality-time/issues/1802). 
+- Some dependencies in the OWASP Dependency Check report have no hash. In those cases *Quality-time* would create a hash based on the file path of the dependency. However, file paths aren't necessarily unique across dependencies. Add the file name to the hash to make it unique. Fixes [#1819](https://github.com/ICTU/quality-time/issues/1819).
 
 ### Added
 


### PR DESCRIPTION
…In those cases Quality-time would create a hash based on the file path of the dependency. However, file paths aren't necessarily unique across dependencies. Add the file name to the hash to make it unique. Fixes #1819.