### PR TITLE
Evaluate the URL query string when the user clicks the 'Export to PDF…

### DIFF
--- a/components/frontend/src/report/ReportTitle.js
+++ b/components/frontend/src/report/ReportTitle.js
@@ -55,7 +55,7 @@ function ButtonRow(props) {
     return (
         <Grid.Row>
             <Grid.Column>
-                <DownloadAsPDFButton report_uuid={props.report_uuid} query_string={props.query_string} />
+                <DownloadAsPDFButton report_uuid={props.report_uuid} history={props.history} />
                 <ReadOnlyOrEditable editableComponent={
                     <DeleteButton
                         item_type='report'
@@ -75,7 +75,7 @@ export function ReportTitle(props) {
                 <ReportAttributesRow report_uuid={report_uuid} reload={props.reload} title={props.report.title} subtitle={props.report.subtitle} />
                 <NotificationDestinationsRow destinations={props.report.notification_destinations || {}} report_uuid={report_uuid} reload={props.reload} />
                 <ChangeLogRow report_uuid={report_uuid} timestamp={props.report.timestamp} />
-                <ButtonRow report_uuid={report_uuid} go_home={props.go_home} query_string={props.history.location.search} />
+                <ButtonRow report_uuid={report_uuid} go_home={props.go_home} history={props.history} />
             </Grid>
         </HeaderWithDetails>
     )

--- a/components/frontend/src/widgets/Button.js
+++ b/components/frontend/src/widgets/Button.js
@@ -55,7 +55,7 @@ function download_pdf(report_uuid, query_string, callback) {
 
 export function DownloadAsPDFButton(props) {
   const [loading, setLoading] = useState(false);
-  const { report_uuid, query_string, ...otherProps } = props;
+  const { report_uuid, history, ...otherProps } = props;
   return (
     <ActionButton
       action='Download'
@@ -65,7 +65,7 @@ export function DownloadAsPDFButton(props) {
       onClick={() => {
         if (!loading) {
           setLoading(true);
-          download_pdf(report_uuid, query_string, () => { setLoading(false) })
+          download_pdf(report_uuid, history.location.search, () => { setLoading(false) })
         }
       }}
       {...otherProps}

--- a/components/frontend/src/widgets/Button.test.js
+++ b/components/frontend/src/widgets/Button.test.js
@@ -30,7 +30,7 @@ describe('<CopyButton />', () => {
     it('can be used to select an item', () => {
         item_types.forEach((item_type) => {
             const mockCallBack = jest.fn();
-            const wrapper = mount(<CopyButton item_type={item_type} onChange={mockCallBack} get_options={() => { return [{key: "1", text: "Report", value: "1"}] }} />);
+            const wrapper = mount(<CopyButton item_type={item_type} onChange={mockCallBack} get_options={() => { return [{ key: "1", text: "Report", value: "1" }] }} />);
             wrapper.find("div.button").simulate("click");
             wrapper.find("DropdownItem").simulate("click");
             expect(mockCallBack).toHaveBeenCalledWith("1");
@@ -40,7 +40,7 @@ describe('<CopyButton />', () => {
         item_types.forEach((item_type) => {
             const mockCallBack = jest.fn();
             let get_options_called = 0;
-            const wrapper = mount(<CopyButton item_type={item_type} onChange={mockCallBack} get_options={() => { get_options_called++; return [{key: "1", text: "Report", value: "1"}] }} />);
+            const wrapper = mount(<CopyButton item_type={item_type} onChange={mockCallBack} get_options={() => { get_options_called++; return [{ key: "1", text: "Report", value: "1" }] }} />);
             wrapper.find("div.button").simulate("click");
             wrapper.find("DropdownItem").simulate("click");
             wrapper.find("div.button").simulate("click");
@@ -60,7 +60,7 @@ describe('<MoveButton />', () => {
     it('can be used to select an item', () => {
         item_types.forEach((item_type) => {
             const mockCallBack = jest.fn();
-            const wrapper = mount(<MoveButton item_type={item_type} onChange={mockCallBack} get_options={() => { return [{key: "1", text: "Report", value: "1"}] }} />);
+            const wrapper = mount(<MoveButton item_type={item_type} onChange={mockCallBack} get_options={() => { return [{ key: "1", text: "Report", value: "1" }] }} />);
             wrapper.find("div.button").simulate("click");
             wrapper.find("DropdownItem").simulate("click");
             expect(mockCallBack).toHaveBeenCalledWith("1");
@@ -85,13 +85,13 @@ const test_report = {
 describe("<DownloadAsPDFButton/>", () => {
     it('indicates loading on click', () => {
         fetch_server_api.fetch_server_api = jest.fn().mockReturnValue({ then: jest.fn().mockReturnValue({ finally: jest.fn() }) });
-        const wrapper = mount(<DownloadAsPDFButton report={test_report} />);
+        const wrapper = mount(<DownloadAsPDFButton report={test_report} history={{ location: { search: "" } }} />);
         wrapper.find("button").simulate("click");
         expect(wrapper.find("button").hasClass("loading")).toBe(true);
     });
     it('ignores a second click', () => {
         fetch_server_api.fetch_server_api = jest.fn().mockReturnValue({ then: jest.fn().mockReturnValue({ finally: jest.fn() }) });
-        const wrapper = mount(<DownloadAsPDFButton report={test_report} />);
+        const wrapper = mount(<DownloadAsPDFButton report={test_report} history={{ location: { search: "" } }} />);
         wrapper.find("button").simulate("click");
         wrapper.find("button").simulate("click");
         expect(wrapper.find("button").hasClass("loading")).toBe(true);
@@ -101,7 +101,7 @@ describe("<DownloadAsPDFButton/>", () => {
         window.URL.createObjectURL = jest.fn();
         let wrapper;
         await act(async () => {
-            wrapper = mount(<DownloadAsPDFButton report={test_report} />);
+            wrapper = mount(<DownloadAsPDFButton report={test_report} history={{ location: { search: "" } }} />);
             wrapper.find("button").simulate("click");
         });
         expect(wrapper.find("button").hasClass("loading")).toBe(false);
@@ -110,7 +110,7 @@ describe("<DownloadAsPDFButton/>", () => {
         fetch_server_api.fetch_server_api = jest.fn().mockResolvedValue({ ok: false });
         let wrapper;
         await act(async () => {
-            wrapper = mount(<DownloadAsPDFButton report={test_report} />);
+            wrapper = mount(<DownloadAsPDFButton report={test_report} history={{ location: { search: "" } }} />);
             wrapper.find("button").simulate("click");
         });
         expect(wrapper.find("button").hasClass("loading")).toBe(false);


### PR DESCRIPTION
…' button, not when opening the report title.