### PR TITLE
When measuring size (lines of code) with SonarQube as source, some la…

### DIFF
--- a/components/collector/src/source_collectors/api_source_collectors/sonarqube/loc.py
+++ b/components/collector/src/source_collectors/api_source_collectors/sonarqube/loc.py
@@ -71,9 +71,10 @@ class SonarQubeLOC(SonarQubeMetricsBaseClass):
 
     def __language_ncloc(self, metrics: Dict[str, str]) -> List[List[str]]:
         """Return the languages and non-commented lines of code per language, ignoring languages if so specified."""
-        languages_to_ignore = self._parameter("languages_to_ignore")
+        languages_to_ignore = [language.lower() for language in self._parameter("languages_to_ignore")]
+        keys_to_ignore = [key for key, language in self.LANGUAGES.items() if language.lower() in languages_to_ignore]
         return [
             language_count.split("=")
             for language_count in metrics["ncloc_language_distribution"].split(";")
-            if not match_string_or_regular_expression(language_count.split("=")[0], languages_to_ignore)
+            if not match_string_or_regular_expression(language_count.split("=")[0], keys_to_ignore)
         ]

--- a/components/collector/tests/source_collectors/api_source_collectors/sonarqube/test_loc.py
+++ b/components/collector/tests/source_collectors/api_source_collectors/sonarqube/test_loc.py
@@ -48,7 +48,7 @@ class SonarQubeLOCTest(SonarQubeTestCase):
 
     async def test_loc_ignore_languages(self):
         """Test that languages can be ignored."""
-        self.sources["source_id"]["parameters"]["languages_to_ignore"] = ["js"]
+        self.sources["source_id"]["parameters"]["languages_to_ignore"] = ["JavaScript"]
         json = dict(
             component=dict(
                 measures=[

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- When measuring size (lines of code) with SonarQube as source, some languages couldn't be ignored. Fixes [#1818](https://github.com/ICTU/quality-time/issues/1818).
 - Anchore security warnings have no hash. *Quality-time* would create a hash based on the security warning's CVE and affected package. However, if the Anchore source consists of a zip file with multiple reports, multiple combinations of the same CVE and package may be present. Add the report filename to the hash to make it unique. Fixes [#1907](https://github.com/ICTU/quality-time/issues/1907).
 
 ## [3.18.0] - [2021-02-03]


### PR DESCRIPTION
…nguages couldn't be ignored. Fixes #1818.