### PR TITLE
The trend table view would format durations incorrectly, e.g. 5 minut…

### DIFF
--- a/components/frontend/src/trend_table/MeasurementsRow.js
+++ b/components/frontend/src/trend_table/MeasurementsRow.js
@@ -1,5 +1,5 @@
 import { Table } from "semantic-ui-react";
-import { formatMetricScale, formatMetricUnit, format_metric_direction } from "../utils";
+import { formatMetricScale, formatMetricUnit, format_metric_direction, format_minutes } from "../utils";
 import './TrendTable.css'
 
 
@@ -14,7 +14,8 @@ export function MeasurementsRow({ metricType, metricName, metric, measurements, 
   dates.forEach((date) => {
     const iso_date_string = date.toISOString().split("T")[0];
     const measurement = measurements?.find((m) => { return m.start.split("T")[0] <= iso_date_string && iso_date_string <= m.end.split("T")[0] })
-    const metric_value = !measurement?.[metric.scale]?.value ? "?" : measurement[metric.scale].value;
+    let metric_value = !measurement?.[metric.scale]?.value ? "?" : measurement[metric.scale].value;
+    metric_value = metric_value !== "?" && metricType.unit === "minutes" && metric.scale !== "percentage" ? format_minutes(metric_value) : metric_value;
     const status = !measurement?.[metric.scale]?.status ? "unknown" : measurement[metric.scale].status;
     measurementCells.push(<Table.Cell className={status} key={date} textAlign="right">{metric_value}{formatMetricScale(metric)}</Table.Cell>)
 

--- a/components/frontend/src/trend_table/MeasurementsRow.test.js
+++ b/components/frontend/src/trend_table/MeasurementsRow.test.js
@@ -14,9 +14,9 @@ describe("MeasurementRow", () => {
             start: "2020-01-06T00:00:00+00:00",
             end: "2020-01-09T00:00:00+00:00",
             count: {
-                value: "value 1",
+                value: "1",
                 status: "near_target_met",
-                target: "target 1",
+                target: "1",
             }
         },
         {
@@ -24,9 +24,9 @@ describe("MeasurementRow", () => {
             start: "2020-01-04T00:00:00+00:00",
             end: "2020-01-06T00:00:00+00:00",
             count: {
-                value: "value 0",
+                value: "0",
                 status: "near_target_met",
-                target: "target 0",
+                target: "0",
             }
         },
     ]
@@ -44,8 +44,8 @@ describe("MeasurementRow", () => {
     
         expect(queryAllByText("testName").length).toBe(1) // measurement name cell
         expect(queryAllByText("?").length).toBe(1) // first date before first measurement
-        expect(queryAllByText("value 0").length).toBe(1) // two cells with measurements
-        expect(queryAllByText("value 1").length).toBe(1) // two cells with measurements
+        expect(queryAllByText("0").length).toBe(1) // two cells with measurements
+        expect(queryAllByText("1").length).toBe(1) // two cells with measurements
         expect(queryAllByText("testUnit").length).toBe(1)
       });
 
@@ -58,10 +58,23 @@ describe("MeasurementRow", () => {
         expect(queryAllByText("Measurement").length).toBe(1) // measurement name cell
         expect(queryAllByText("Target").length).toBe(1) // target name cell
         expect(queryAllByText("?").length).toBe(2) // first date before first measurement
-        expect(queryAllByText("value 0").length).toBe(1) // two cells with measurements
-        expect(queryAllByText("value 1").length).toBe(1) // two cells with measurements
-        expect(queryAllByText("target 0").length).toBe(1) // two cells with targets
-        expect(queryAllByText("target 1").length).toBe(1) // two cells with targets
-        expect(queryAllByText("testUnit").length).toBe(2)
+        expect(queryAllByText("0").length).toBe(2) // two cells with measurements
+        expect(queryAllByText("1").length).toBe(2) // two cells with measurements
+        expect(queryAllByText("testUnit").length).toBe(2) // measurement and target tow both have the unit
     });
+
+     it('Renders one single row with metric name, measurement values and minutes unit', () => {
+    
+        metric["unit"] = ""
+
+        const { queryAllByText } = render(
+          <table><tbody><MeasurementsRow metricType={{unit: "minutes"}} metricName="testName" metric={metric} measurements={measurements} dates={dates} /></tbody></table>
+        );
+    
+        expect(queryAllByText("testName").length).toBe(1) // measurement name cell
+        expect(queryAllByText("?").length).toBe(1) // first date before first measurement
+        expect(queryAllByText("0:00").length).toBe(1) // two cells with measurements
+        expect(queryAllByText("0:01").length).toBe(1) // two cells with measurements
+        expect(queryAllByText("hours").length).toBe(1)
+      });
 })

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - When measuring size (lines of code) with SonarQube as source, some languages couldn't be ignored. Fixes [#1818](https://github.com/ICTU/quality-time/issues/1818).
+- The trend table view would format durations incorrectly, e.g. 5 minutes would be displayed as '5 hours'. Fixes [#1900](https://github.com/ICTU/quality-time/issues/1900).
 - Anchore security warnings have no hash. *Quality-time* would create a hash based on the security warning's CVE and affected package. However, if the Anchore source consists of a zip file with multiple reports, multiple combinations of the same CVE and package may be present. Add the report filename to the hash to make it unique. Fixes [#1907](https://github.com/ICTU/quality-time/issues/1907).
 - When measuring security warnings with SonarQube as source, allow for filtering security hotspots by review priority. Fixes [#1910](https://github.com/ICTU/quality-time/issues/1910).
 - The trend table view would sometimes, erroneously, show recent data as missing. Fixes [#1924](https://github.com/ICTU/quality-time/issues/1924).


### PR DESCRIPTION
…es would be displayed as '5 hours'. Fixes #1900.