### PR TITLE
When measuring security warnings with OWASP ZAP as source, allow for …

### DIFF
--- a/components/collector/tests/source_collectors/owasp_zap/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/owasp_zap/test_security_warnings.py
@@ -48,8 +48,8 @@ class OWASPZAPSecurityWarningsTest(OWASPZAPTestCase):
     WARNING_DESCRIPTION = "The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'."
     WARNING_RISK = "Low (Medium)"
 
-    async def test_warnings(self):
-        """Test that the number of security warnings is returned."""
+    async def test_alert_instances(self):
+        """Test that the number of alert instances is returned."""
         response = await self.collect(get_request_text=self.OWASP_ZAP_XML)
         url1 = "http://www.hackazon.com/products_pictures/Ray_Ban.jpg"
         url2 = "http://www.hackazon.com/products_pictures/How_to_Marry_a_Millionaire.jpg"
@@ -74,6 +74,20 @@ class OWASPZAPSecurityWarningsTest(OWASPZAPTestCase):
             ),
         ]
         self.assert_measurement(response, value="2", entities=expected_entities)
+
+    async def test_alert_types(self):
+        """Test that the number of alert types is returned"""
+        self.set_source_parameter("alerts", "alert types")
+        response = await self.collect(get_request_text=self.OWASP_ZAP_XML)
+        expected_entities = [
+            dict(
+                key=md5_hash("X-Content-Type-Options Header Missing:10021:16:15:3"),
+                name=self.WARNING_NAME,
+                description=self.WARNING_DESCRIPTION,
+                risk=self.WARNING_RISK,
+            ),
+        ]
+        self.assert_measurement(response, value="1", entities=expected_entities)
 
     async def test_variable_url_regexp(self):
         """Test that parts of URLs can be ignored."""

--- a/components/collector/tests/source_collectors/owasp_zap/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/owasp_zap/test_security_warnings.py
@@ -76,7 +76,7 @@ class OWASPZAPSecurityWarningsTest(OWASPZAPTestCase):
         self.assert_measurement(response, value="2", entities=expected_entities)
 
     async def test_alert_types(self):
-        """Test that the number of alert types is returned"""
+        """Test that the number of alert types is returned."""
         self.set_source_parameter("alerts", "alert types")
         response = await self.collect(get_request_text=self.OWASP_ZAP_XML)
         expected_entities = [

--- a/components/server/src/data/datamodel.json
+++ b/components/server/src/data/datamodel.json
@@ -4241,6 +4241,21 @@
                         "source_up_to_dateness"
                     ]
                 },
+                "alerts": {
+                    "name": "Count alert types or alert instances",
+                    "short_name": "count alert types or instances setting",
+                    "type": "single_choice",
+                    "help": "Determine whether to count each alert type in the OWASP ZAP report as a security warning or to count each alert instance (URL).",
+                    "mandatory": false,
+                    "default_value": "alert instances",
+                    "values": [
+                        "alert types",
+                        "alert instances"
+                    ],
+                    "metrics": [
+                        "security_warnings"
+                    ]
+                },
                 "risks": {
                     "name": "Risks",
                     "short_name": "risks",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Added
+
+- When measuring security warnings with OWASP ZAP as source, allow for counting alert types as security warnings as opposed to alert instances. Closes [#1902](https://github.com/ICTU/quality-time/issues/1902).
+
 ## [3.19.1] - [2021-02-28]
 
 ### Fixed

--- a/docs/METRICS_AND_SOURCES.md
+++ b/docs/METRICS_AND_SOURCES.md
@@ -711,6 +711,7 @@ This document lists all [metrics](#metrics) that *Quality-time* can measure and 
 
 | Parameter | Type | Values | Default value | Mandatory | Help |
 | :-------- | :--- | :----- | :------------ | :-------- | :--- |
+| Count alert types or alert instances | Single choice | alert instances, alert types | alert instances | No | Determine whether to count each alert type in the OWASP ZAP report as a security warning or to count each alert instance (URL). |
 | Parts of URLs to ignore (regular expressions) | Multiple choice with addition |  |  | No | Parts of URLs to ignore can be specified by regular expression. The parts of URLs that match one or more of the regular expressions are removed. If, after applying the regular expressions, multiple warnings are the same only one is reported. |
 | Password for basic authentication | Password |  |  | No |  |
 | Private token | Password |  |  | No |  |


### PR DESCRIPTION
…counting alert types as security warnings as opposed to alert instances. Closes #1902.