### PR TITLE
Prevent summary card labels from overflowing

### DIFF
--- a/components/frontend/src/dashboard/MetricSummaryCard.css
+++ b/components/frontend/src/dashboard/MetricSummaryCard.css
@@ -8,4 +8,8 @@
         border-radius: .28571429rem;
         box-shadow: none !important;
     }
+    .ui.card .header {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
 }

--- a/components/frontend/src/dashboard/MetricSummaryCard.js
+++ b/components/frontend/src/dashboard/MetricSummaryCard.js
@@ -8,7 +8,7 @@ export function MetricSummaryCard(props) {
         <Card style={{ height: '200px' }} onClick={props.onClick} onKeyPress={props.onClick} tabIndex="0">
             <StatusPieChart {...props} />
             <Card.Content>
-                <Card.Header textAlign='center'>{props.header}</Card.Header>
+                <Card.Header title={props.header} textAlign='center'>{props.header}</Card.Header>
             </Card.Content>
         </Card>
     );


### PR DESCRIPTION
This change clips labels and adds ellipsis to show the fact that content is clipped.
Added a title to the HTML element to allow user to see full name by hovering the card label (in most browsers).
