### PR TITLE
Prevent (rare) crashes of the UI when switching tabs in the metric details

### DIFF
--- a/components/frontend/src/metric/Measurement.js
+++ b/components/frontend/src/metric/Measurement.js
@@ -51,7 +51,7 @@ export function Measurement(props) {
   const metric_unit = formatMetricScaleAndUnit(metric_type, metric);
   const metric_name = get_metric_name(metric, props.datamodel);
   const details = <MeasurementDetails measurement={latest_measurement} metric_name={metric_name} scale={metric.scale} unit={formatMetricScaleAndUnit(metric_type, metric, false)} {...props} />
-  const expanded = props.visibleDetailsTabs.filter((tab) => tab.startsWith(props.metric_uuid)).length > 0;
+  const expanded = props.visibleDetailsTabs.filter((tab) => tab?.startsWith(props.metric_uuid)).length > 0;
   function onExpand(expand) {
     if (expand) {
       props.toggleVisibleDetailsTab(`${props.metric_uuid}:0`)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Prevent (rare) crashes of the UI when switching tabs in the metric details. Fixes [#1873](https://github.com/ICTU/quality-time/issues/1873).
 - Don't assume that because GitLab returns jobs sorted by ID, they are also sorted by date. Fixes [#2036](https://github.com/ICTU/quality-time/issues/2036). 
 - Prevent timeouts when collecting failed CI-jobs or unused CI-jobs from GitLab by removing the limit on open connections. Fixes [#2037](https://github.com/ICTU/quality-time/issues/2037). 
 


### PR DESCRIPTION
Fixes #1873.