### PR TITLE
Quality-time wouldn't recognize zip files in URLs with query strings …

### DIFF
--- a/components/collector/src/base_collectors/file_source_collector.py
+++ b/components/collector/src/base_collectors/file_source_collector.py
@@ -8,6 +8,7 @@ import zipfile
 from abc import ABC
 from http import HTTPStatus
 from typing import cast
+from urllib.parse import urlparse
 
 from collector_utilities.type import JSON, URL, Response, Responses
 from source_model import SourceResponses
@@ -42,7 +43,7 @@ class FileSourceCollector(SourceCollector, ABC):  # pylint: disable=abstract-met
     async def _get_source_responses(self, *urls: URL) -> SourceResponses:
         """Extend to unzip any zipped responses."""
         responses = await super()._get_source_responses(*urls)
-        if urls[0].endswith(".zip"):
+        if urlparse(str(urls[0])).path.endswith(".zip"):
             unzipped_responses = await asyncio.gather(*[self.__unzip(response) for response in responses])
             responses[:] = list(itertools.chain(*unzipped_responses))
         return responses

--- a/components/collector/tests/source_collectors/axe_csv/test_accessibility.py
+++ b/components/collector/tests/source_collectors/axe_csv/test_accessibility.py
@@ -65,7 +65,7 @@ class AxeCSVAccessibilityTest(SourceCollectorTestCase):
 
     async def test_zipped_csv(self):
         """Test that a zip archive with CSV files is processed correctly."""
-        self.set_source_parameter("url", "https://axecsv.zip")
+        self.set_source_parameter("url", "https://example.org/axecsv.zip")
         zipfile = self.zipped_report(*[(f"axe{index}.csv", self.csv) for index in range(2)])
         response = await self.collect(get_request_content=zipfile)
         self.assert_measurement(response, value="4", entities=self.expected_entities + self.expected_entities)

--- a/components/collector/tests/source_collectors/cobertura/base.py
+++ b/components/collector/tests/source_collectors/cobertura/base.py
@@ -21,6 +21,6 @@ class CoberturaCoverageTestsMixin:
 
     async def test_zipped_report(self):
         """Test that a zipped report can be read."""
-        self.set_source_parameter("url", "https://cobertura.zip")
+        self.set_source_parameter("url", "https://example.org/cobertura.zip")
         response = await self.collect(get_request_content=self.zipped_report(("cobertura.xml", self.COBERTURA_XML)))
         self.assert_measurement(response, value="4", total="10")

--- a/components/collector/tests/source_collectors/cobertura/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/cobertura/test_source_up_to_dateness.py
@@ -24,6 +24,6 @@ class CoberturaSourceUpToDatenessTest(CoberturaTestCase):
 
     async def test_zipped_report(self):
         """Test that a zipped report can be read."""
-        self.set_source_parameter("url", "https://cobertura.zip")
+        self.set_source_parameter("url", "https://example.org/cobertura.zip")
         response = await self.collect(get_request_content=self.zipped_report(("cobertura.xml", self.COBERTURA_XML)))
         self.assert_measurement(response, value=self.expected_age)

--- a/components/collector/tests/source_collectors/cobertura/test_source_version.py
+++ b/components/collector/tests/source_collectors/cobertura/test_source_version.py
@@ -17,6 +17,6 @@ class CoberturaSourceVersionTest(CoberturaTestCase):
 
     async def test_zipped_report(self):
         """Test that a zipped report can be read."""
-        self.set_source_parameter("url", "https://cobertura.zip")
+        self.set_source_parameter("url", "https://example.org/cobertura.zip")
         response = await self.collect(get_request_content=self.zipped_report(("cobertura.xml", self.COBERTURA_XML)))
         self.assert_measurement(response, value="2.1.3")

--- a/components/collector/tests/source_collectors/jacoco/base.py
+++ b/components/collector/tests/source_collectors/jacoco/base.py
@@ -14,7 +14,7 @@ class JaCoCoCommonTestsMixin:  # pylint: disable=too-few-public-methods
 
     async def test_zipped_report_without_xml(self):
         """Test that a zip file without xml files throws an exception."""
-        self.set_source_parameter("url", "https://jacoco.zip")
+        self.set_source_parameter("url", "https://example.org/jacoco.zip")
         report = self.zipped_report(
             ("jacoco.html", "<html><body><p>Oops, user included the HTML instead of the XML</p></body></html>")
         )
@@ -34,6 +34,6 @@ class JaCoCoCommonCoverageTestsMixin:
 
     async def test_zipped_report(self):
         """Test that a zipped report can be read."""
-        self.set_source_parameter("url", "https://jacoco.zip")
+        self.set_source_parameter("url", "https://example.org/jacoco.zip")
         response = await self.collect(get_request_content=self.zipped_report(("jacoco.xml", self.JACOCO_XML)))
         self.assert_measurement(response, value="2", total="6")

--- a/components/collector/tests/source_collectors/jacoco/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/jacoco/test_source_up_to_dateness.py
@@ -24,6 +24,6 @@ class JaCoCoSourceUpToDatenessTest(JaCoCoCommonTestsMixin, JaCoCoTestCase):
 
     async def test_zipped_report(self):
         """Test that a zipped report can be read."""
-        self.set_source_parameter("url", "https://jacoco.zip")
+        self.set_source_parameter("url", "https://example.org/jacoco.zip")
         response = await self.collect(get_request_content=self.zipped_report(("jacoco.xml", self.JACOCO_XML)))
         self.assert_measurement(response, value=str(self.expected_age))

--- a/components/collector/tests/source_collectors/ncover/test_uncovered_branches.py
+++ b/components/collector/tests/source_collectors/ncover/test_uncovered_branches.py
@@ -27,6 +27,6 @@ class NCoverUncoveredBranchesTest(NCoverTestCase):
 
     async def test_zipped_report(self):
         """Test that the coverage can be read from a zip with NCover reports."""
-        self.set_source_parameter("url", "https://report.zip")
+        self.set_source_parameter("url", "https://example.org/report.zip")
         response = await self.collect(get_request_content=self.zipped_report(("ncover.html", self.NCOVER_HTML)))
         self.assert_measurement(response, value=f"{12034-9767}", total="12034")

--- a/components/collector/tests/source_collectors/ncover/test_uncovered_lines.py
+++ b/components/collector/tests/source_collectors/ncover/test_uncovered_lines.py
@@ -26,6 +26,6 @@ class NCoverUncoveredLinesTest(NCoverTestCase):
 
     async def test_zipped_report(self):
         """Test that the coverage can be read from a zip with NCover reports."""
-        self.set_source_parameter("url", "https://report.zip")
+        self.set_source_parameter("url", "https://example.org/report.zip?parameter=should_not_matter")
         response = await self.collect(get_request_content=self.zipped_report(("ncover.html", self.NCOVER_HTML)))
         self.assert_measurement(response, value=f"{17153-14070}", total="17153")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the ci/release.py script with the new release version and release date. -->
 
-## [3.21.0-rc.1] - [2021-04-22]
+## [Unreleased]
 
 ### Fixed
 
 - Prevent (rare) crashes of the UI when switching tabs in the metric details. Fixes [#1873](https://github.com/ICTU/quality-time/issues/1873).
 - Don't assume that because GitLab returns jobs sorted by ID, they are also sorted by date. Fixes [#2036](https://github.com/ICTU/quality-time/issues/2036). 
 - Prevent timeouts when collecting failed CI-jobs or unused CI-jobs from GitLab by removing the limit on open connections. Fixes [#2037](https://github.com/ICTU/quality-time/issues/2037). 
+- *Quality-time* wouldn't recognize zip files in URLs with query strings (e.g. https://git.example.org/foo.zip?job=bar). Fixes [#2057](https://github.com/ICTU/quality-time/issues/2057). 
 
 ### Added
 


### PR DESCRIPTION
…(e.g. https://git.example.org/foo.zip?job=bar). Fixes #2057.