### PR TITLE
Remove individual metric trend table 

### DIFF
--- a/components/frontend/src/metric/MeasurementDetails.js
+++ b/components/frontend/src/metric/MeasurementDetails.js
@@ -11,7 +11,6 @@ import { delete_metric, set_metric_attribute } from '../api/metric';
 import { get_measurements } from '../api/measurement';
 import { ChangeLog } from '../changelog/ChangeLog';
 import { capitalize, get_source_name } from '../utils';
-import { TrendTable } from '../trend_table/TrendTable';
 
 function fetch_measurements(report_date, metric_uuid, setMeasurements) {
   get_measurements(metric_uuid, report_date)
@@ -57,26 +56,6 @@ export function MeasurementDetails(props) {
         }
       )
     }
-    panes.push(
-      {
-        menuItem: <Menu.Item key='trend_table'><FocusableTab>{'Trend table'}</FocusableTab></Menu.Item>,
-        render: () => (
-          <Tab.Pane>
-            <TrendTable
-              datamodel={props.datamodel}
-              reportDate={props.report_date}
-              metrics={{ [props.metric_uuid]: metric }}
-              showTargets={true}
-              measurements={measurements}
-              trendTableInterval={props.trendTableInterval}
-              setTrendTableInterval={props.setTrendTableInterval}
-              trendTableNrDates={props.trendTableNrDates}
-              setTrendTableNrDates={props.setTrendTableNrDates}
-            />
-          </Tab.Pane>
-        )
-      }
-    );
     const last_measurement = measurements[measurements.length - 1];
     last_measurement.sources.forEach((source) => {
       const report_source = metric.sources[source.source_uuid];

--- a/components/frontend/src/metric/MeasurementDetails.test.js
+++ b/components/frontend/src/metric/MeasurementDetails.test.js
@@ -76,8 +76,6 @@ describe("<MeasurementDetails />", () => {
         expect(wrapper.find("a.active").text()).toBe("Sources");
         await act(async () => { switch_tab(2) });
         expect(wrapper.find("a.active").text()).toBe("Trend graph");
-        await act(async () => { switch_tab(3) });
-        expect(wrapper.find("a.active").text()).toBe("Trend table");
     });
     it('calls the callback on click', async () => {
         const mockCallBack = jest.fn();

--- a/components/frontend/src/trend_table/MeasurementsRow.js
+++ b/components/frontend/src/trend_table/MeasurementsRow.js
@@ -1,12 +1,11 @@
 import { Table } from "semantic-ui-react";
-import { formatMetricScale, formatMetricUnit, format_metric_direction, format_minutes } from "../utils";
-import './TrendTable.css'
+import { formatMetricScale, formatMetricUnit, format_minutes } from "../utils";
+import './TrendTable.css';
 
 
-export function MeasurementsRow({ metricType, metricName, metric, measurements, dates, showTargetRow }) {
+export function MeasurementsRow({ metricType, metricName, metric, measurements, dates }) {
 
   const unit = formatMetricUnit(metricType, metric)
-  const targetCells = []
   const measurementCells = []
   // Sort measurements in reverse order so that if there multiple measurements on a day, we find the most recent one:
   measurements.sort((m1, m2) => m1.start < m2.start ? 1 : -1)
@@ -18,29 +17,15 @@ export function MeasurementsRow({ metricType, metricName, metric, measurements, 
     metric_value = metric_value !== "?" && metricType.unit === "minutes" && metric.scale !== "percentage" ? format_minutes(metric_value) : metric_value;
     const status = !measurement?.[metric.scale]?.status ? "unknown" : measurement[metric.scale].status;
     measurementCells.push(<Table.Cell className={status} key={date} textAlign="right">{metric_value}{formatMetricScale(metric)}</Table.Cell>)
-
-    if (showTargetRow) {
-      const target = !measurement?.[metric.scale]?.target ? "?" : measurement?.[metric.scale]?.target;
-      const direction = !measurement?.[metric.scale]?.direction ? "≤" : measurement?.[metric.scale]?.direction;
-      targetCells.push(<Table.Cell key={date} textAlign="right">{format_metric_direction(direction)} {target}</Table.Cell>)
-    }
   })
 
   const unitCell = <Table.Cell style={{ background: "#f9fafb" }}>{unit}</Table.Cell>
 
   return (
-    <>
-      <Table.Row>
-        <Table.Cell style={{ background: "#f9fafb" }}>{showTargetRow ? "Measurement" : metricName}</Table.Cell>
-        {measurementCells}
-        {unitCell}
-      </Table.Row>
-      {showTargetRow ?
-        <Table.Row>
-          <Table.Cell style={{ background: "#f9fafb" }}>Target</Table.Cell>
-          {targetCells}
-          {unitCell}
-        </Table.Row> : undefined}
-    </>
+    <Table.Row>
+      <Table.Cell style={{ background: "#f9fafb" }}>{metricName}</Table.Cell>
+      {measurementCells}
+      {unitCell}
+    </Table.Row>
   )
 }

--- a/components/frontend/src/trend_table/MeasurementsRow.test.js
+++ b/components/frontend/src/trend_table/MeasurementsRow.test.js
@@ -49,20 +49,6 @@ describe("MeasurementRow", () => {
         expect(queryAllByText("testUnit").length).toBe(1)
       });
 
-    it('Renders two rows, one with values and one with targets', () => {
-    
-        const { queryAllByText } = render(
-        <table><tbody><MeasurementsRow metricType={{}} metricName="testName" metric={metric} measurements={measurements} dates={dates} showTargetRow/></tbody></table>
-        );
-        
-        expect(queryAllByText("Measurement").length).toBe(1) // measurement name cell
-        expect(queryAllByText("Target").length).toBe(1) // target name cell
-        expect(queryAllByText("?").length).toBe(2) // first date before first measurement
-        expect(queryAllByText("0").length).toBe(2) // two cells with measurements
-        expect(queryAllByText("1").length).toBe(2) // two cells with measurements
-        expect(queryAllByText("testUnit").length).toBe(2) // measurement and target tow both have the unit
-    });
-
      it('Renders one single row with metric name, measurement values and minutes unit', () => {
     
         metric["unit"] = ""

--- a/components/frontend/src/trend_table/TrendTable.js
+++ b/components/frontend/src/trend_table/TrendTable.js
@@ -24,7 +24,6 @@ export function TrendTable({
   metrics,
   measurements,
   extraHamburgerItems,
-  showTargets,
   trendTableInterval,
   setTrendTableInterval,
   trendTableNrDates,
@@ -54,7 +53,6 @@ export function TrendTable({
               metric={metric}
               dates={dates}
               measurements={measurements.filter((measurement) => measurement.metric_uuid === metric_uuid)}
-              showTargetRow={showTargets}
             />
           )
         })

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Measuring security warnings with Anchore as source would throw a parse error if the source was an unzipped Anchore JSON file. Fixes [#2177](https://github.com/ICTU/quality-time/issues/2177).
 - When all users are allowed to edit reports, no users would be able to edit measurement entities to mark them as false positive, fixed, etc. Fixes [#2179](https://github.com/ICTU/quality-time/issues/2179).
 
+### Removed
+
+- Since subjects have a trend table view, there is little added value in also having a trend table per metric. Remove the trend table view for individual metrics. Closes [#2174](https://github.com/ICTU/quality-time/issues/2174).
+
 ## [3.21.0] - [2021-04-25]
 
 ### Fixed


### PR DESCRIPTION
Since subjects have a trend table view, there is little added value in also having a trend table per metric. Remove the trend table view for individual metrics. Closes #2174.