### PR TITLE
2179 edit entities 

### DIFF
--- a/components/frontend/src/App.js
+++ b/components/frontend/src/App.js
@@ -69,7 +69,7 @@ class App extends Component {
     const show_error = () => show_message("error", "Server unreachable", "Couldn't load data from the server. Please try again later.");
     if (this.state.report_uuid === "") {
       this.reload_reports(report_date, show_error)
-    } else if (this.state.report_uuid.slice(0, 4) === "tag-") {
+    } else if (this.current_report_is_tag_report()) {
       this.reload_tag_report(report_date, show_error);
     } else {
       this.reload_report(report_date, show_error)
@@ -207,6 +207,10 @@ class App extends Component {
     return report_date;
   }
 
+  current_report_is_tag_report() {
+    return this.state.report_uuid.slice(0, 4) === "tag-"
+  }
+
   login_forwardauth() {
     let self = this;
     login("", "")
@@ -237,7 +241,7 @@ class App extends Component {
     const report_date = this.report_date();
     const current_report = this.state.reports.filter((report) => report.report_uuid === this.state.report_uuid)[0] || null;
     const permissions = this.state.reports_overview.permissions || {};
-    const user_permissions = getUserPermissions(this.state.user, this.state.email, permissions)
+    const user_permissions = getUserPermissions(this.state.user, this.state.email, this.current_report_is_tag_report(), report_date, permissions)
     const props = {
       reload: (json) => this.reload(json), report_date: report_date, reports: this.state.reports, history: this.history
     };

--- a/components/frontend/src/context/ReadOnly.js
+++ b/components/frontend/src/context/ReadOnly.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 export const EDIT_REPORT_PERMISSION = "edit_reports"
 export const EDIT_ENTITY_PERMISSION = "edit_entities"
+export const PERMISSIONS = [EDIT_REPORT_PERMISSION, EDIT_ENTITY_PERMISSION]
 
 export const ReadOnlyContext = React.createContext(null);
 

--- a/components/frontend/src/utils.js
+++ b/components/frontend/src/utils.js
@@ -1,7 +1,7 @@
 import { parse, stringify } from 'query-string';
 import React, { useEffect, useState } from 'react';
 import { toast } from 'react-semantic-toasts';
-import { EDIT_REPORT_PERMISSION, EDIT_ENTITY_PERMISSION } from './context/ReadOnly';
+import { PERMISSIONS } from './context/ReadOnly';
 
 export function get_metric_direction(metric, data_model) {
     return format_metric_direction(metric.direction || data_model.metrics[metric.type].direction);
@@ -151,13 +151,10 @@ export function isValidDate_YYYYMMDD(string) {
     return false
 }
 
-export function getUserPermissions(username, email, permissions) {
-    const allPermissions = [EDIT_REPORT_PERMISSION, EDIT_ENTITY_PERMISSION];
-    if ((permissions?.[EDIT_REPORT_PERMISSION] ?? []).length === 0) {
-        return allPermissions  // Edit report permisions are not limited, so every user gets all permissions
-    }
-    return allPermissions.filter((permission) => {
+export function getUserPermissions(username, email, current_report_is_tag_report, report_date, permissions) {
+    if (username === null || report_date !== null || current_report_is_tag_report) { return [] }
+    return PERMISSIONS.filter((permission) => {
         const permittedUsers = permissions?.[permission] ?? [];
-        return permittedUsers.includes(username) || permittedUsers.includes(email)
+        return permittedUsers.length === 0 ? true : permittedUsers.includes(username) || permittedUsers.includes(email)
     });
 }

--- a/components/frontend/src/utils.js
+++ b/components/frontend/src/utils.js
@@ -1,7 +1,7 @@
 import { parse, stringify } from 'query-string';
 import React, { useEffect, useState } from 'react';
 import { toast } from 'react-semantic-toasts';
-import { EDIT_REPORT_PERMISSION, EDIT_ENTITY_PERMISSION, ReadOnlyOrEditable } from './context/ReadOnly';
+import { EDIT_REPORT_PERMISSION, EDIT_ENTITY_PERMISSION } from './context/ReadOnly';
 
 export function get_metric_direction(metric, data_model) {
     return format_metric_direction(metric.direction || data_model.metrics[metric.type].direction);

--- a/components/frontend/src/utils.js
+++ b/components/frontend/src/utils.js
@@ -1,7 +1,7 @@
 import { parse, stringify } from 'query-string';
 import React, { useEffect, useState } from 'react';
 import { toast } from 'react-semantic-toasts';
-import { EDIT_REPORT_PERMISSION, EDIT_ENTITY_PERMISSION } from './context/ReadOnly';
+import { EDIT_REPORT_PERMISSION, EDIT_ENTITY_PERMISSION, ReadOnlyOrEditable } from './context/ReadOnly';
 
 export function get_metric_direction(metric, data_model) {
     return format_metric_direction(metric.direction || data_model.metrics[metric.type].direction);
@@ -152,19 +152,12 @@ export function isValidDate_YYYYMMDD(string) {
 }
 
 export function getUserPermissions(username, email, permissions) {
-    const userPermissions = []
-    if (permissions[EDIT_REPORT_PERMISSION] === undefined
-        || permissions[EDIT_REPORT_PERMISSION].length === 0
-        || permissions[EDIT_REPORT_PERMISSION].includes(username)
-        || permissions[EDIT_REPORT_PERMISSION].includes(email)) {
-
-        userPermissions.push(EDIT_REPORT_PERMISSION)
+    const allPermissions = [EDIT_REPORT_PERMISSION, EDIT_ENTITY_PERMISSION];
+    if ((permissions?.[EDIT_REPORT_PERMISSION] ?? []).length === 0) {
+        return allPermissions  // Edit report permisions are not limited, so every user gets all permissions
     }
-    if (permissions[EDIT_ENTITY_PERMISSION] !== undefined
-        && (permissions[EDIT_ENTITY_PERMISSION].includes(username)
-        || permissions[EDIT_ENTITY_PERMISSION].includes(email))) {
-
-        userPermissions.push(EDIT_ENTITY_PERMISSION)
-    }
-    return userPermissions
+    return allPermissions.filter((permission) => {
+        const permittedUsers = permissions?.[permission] ?? [];
+        return permittedUsers.includes(username) || permittedUsers.includes(email)
+    });
 }

--- a/components/frontend/src/utils.test.js
+++ b/components/frontend/src/utils.test.js
@@ -1,5 +1,6 @@
-import { nice_number, scaled_number, show_message, format_minutes } from './utils';
 import * as react_semantic_toast from 'react-semantic-toasts';
+import { getUserPermissions, nice_number, scaled_number, show_message, format_minutes } from './utils';
+import { EDIT_REPORT_PERMISSION, EDIT_ENTITY_PERMISSION } from './context/ReadOnly';
 
 jest.mock("react-semantic-toasts");
 
@@ -41,4 +42,19 @@ it('formats minutes', () => {
   expect(format_minutes(60)).toBe("1:00");
   expect(format_minutes(61)).toBe("1:01");
   expect(format_minutes(600)).toBe("10:00");
+});
+
+it('gives users all permissions if permissions have not been limited', () => {
+  const permissions = getUserPermissions("jodoe", "john.doe@example.org", {});
+  expect(permissions).toStrictEqual([EDIT_REPORT_PERMISSION, EDIT_ENTITY_PERMISSION]);
+});
+
+it('gives users edit report permissions if edit report permissions have been granted', () => {
+  const permissions = getUserPermissions("jodoe", "john.doe@example.org", {[EDIT_REPORT_PERMISSION]: ["jodoe"]});
+  expect(permissions).toStrictEqual([EDIT_REPORT_PERMISSION]);
+});
+
+it('gives users edit entity permissions if edit entity permissions have been granted', () => {
+  const permissions = getUserPermissions("jodoe", "john.doe@example.org", {[EDIT_REPORT_PERMISSION]: ["jadoe"], [EDIT_ENTITY_PERMISSION]: ["jodoe"]});
+  expect(permissions).toStrictEqual([EDIT_ENTITY_PERMISSION]);
 });

--- a/components/frontend/src/utils.test.js
+++ b/components/frontend/src/utils.test.js
@@ -45,16 +45,31 @@ it('formats minutes', () => {
 });
 
 it('gives users all permissions if permissions have not been limited', () => {
-  const permissions = getUserPermissions("jodoe", "john.doe@example.org", {});
+  const permissions = getUserPermissions("jodoe", "john.doe@example.org", false, null, {});
   expect(permissions).toStrictEqual([EDIT_REPORT_PERMISSION, EDIT_ENTITY_PERMISSION]);
 });
 
 it('gives users edit report permissions if edit report permissions have been granted', () => {
-  const permissions = getUserPermissions("jodoe", "john.doe@example.org", {[EDIT_REPORT_PERMISSION]: ["jodoe"]});
+  const permissions = getUserPermissions("jodoe", "john.doe@example.org", false, null, {[EDIT_REPORT_PERMISSION]: ["jodoe"], [EDIT_ENTITY_PERMISSION]: ["jadoe"]});
   expect(permissions).toStrictEqual([EDIT_REPORT_PERMISSION]);
 });
 
 it('gives users edit entity permissions if edit entity permissions have been granted', () => {
-  const permissions = getUserPermissions("jodoe", "john.doe@example.org", {[EDIT_REPORT_PERMISSION]: ["jadoe"], [EDIT_ENTITY_PERMISSION]: ["jodoe"]});
+  const permissions = getUserPermissions("jodoe", "john.doe@example.org", false, null, {[EDIT_REPORT_PERMISSION]: ["jadoe"], [EDIT_ENTITY_PERMISSION]: ["jodoe"]});
   expect(permissions).toStrictEqual([EDIT_ENTITY_PERMISSION]);
+});
+
+it('gives users no permissions if they have not logged in', () => {
+  const permissions = getUserPermissions(null, null, false, null, {});
+  expect(permissions).toStrictEqual([]);
+});
+
+it('gives users no permissions if the report date is in the past', () => {
+  const permissions = getUserPermissions("jodoe", "john.doe@example.org", false, new Date(), {});
+  expect(permissions).toStrictEqual([]);
+});
+
+it('gives users no permissions if the report is a tag report', () => {
+  const permissions = getUserPermissions("jodoe", "john.doe@example.org", true, null, {});
+  expect(permissions).toStrictEqual([]);
 });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - When the collector posts new measurements to the server, the server looks up previous measurements in the database to see if the measurement value has changed. This lookup was slow due to a missing index on the measurements collection. Fixes [#2155](https://github.com/ICTU/quality-time/issues/2155).
+- Edit controls were not hidden or made read-only in the UI when time traveling and after logout. Fixes [#2170](https://github.com/ICTU/quality-time/issues/2170).
 - Measuring security warnings with Anchore as source would throw a parse error if the source was an unzipped Anchore JSON file. Fixes [#2177](https://github.com/ICTU/quality-time/issues/2177).
 - When all users are allowed to edit reports, no users would be able to edit measurement entities to mark them as false positive, fixed, etc. Fixes [#2179](https://github.com/ICTU/quality-time/issues/2179).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - When the collector posts new measurements to the server, the server looks up previous measurements in the database to see if the measurement value has changed. This lookup was slow due to a missing index on the measurements collection. Fixes [#2155](https://github.com/ICTU/quality-time/issues/2155).
 - Measuring security warnings with Anchore as source would throw a parse error if the source was an unzipped Anchore JSON file. Fixes [#2177](https://github.com/ICTU/quality-time/issues/2177).
+- When all users are allowed to edit reports, no users would be able to edit measurement entities to mark them as false positive, fixed, etc. Fixes [#2179](https://github.com/ICTU/quality-time/issues/2179).
 
 ## [3.21.0] - [2021-04-25]
 


### PR DESCRIPTION
When all users are allowed to edit reports, no users would be able to edit measurement entities to mark them as false positive, fixed, etc. Fixes #2179. Fixes #2170.