### PR TITLE
Use estimated_document_count() to count the number of measurements in…

### DIFF
--- a/components/server/src/database/measurements.py
+++ b/components/server/src/database/measurements.py
@@ -66,7 +66,7 @@ def measurements_by_metric(
 
 def count_measurements(database: Database) -> int:
     """Return the number of measurements."""
-    return int(database.measurements.count_documents(filter={}))
+    return int(database.measurements.estimated_document_count())
 
 
 def update_measurement_end(database: Database, measurement_id: MeasurementId):

--- a/components/server/tests/routes/test_measurement.py
+++ b/components/server/tests/routes/test_measurement.py
@@ -468,7 +468,7 @@ class StreamNrMeasurementsTest(unittest.TestCase):
             return seconds
 
         database = Mock()
-        database.measurements.count_documents.side_effect = [42, 42, 42, 43, 43, 43, 43, 43, 43, 43, 43]
+        database.measurements.estimated_document_count.side_effect = [42, 42, 42, 43, 43, 43, 43, 43, 43, 43, 43]
         with patch("time.sleep", sleep):
             stream = stream_nr_measurements(database)
             try:


### PR DESCRIPTION
…stead of document_count() as the former is O(1) and the latter O(n).