### PR TITLE
To prevent overloading Quality-time, the collector now measures at mo…

### DIFF
--- a/components/collector/src/base_collectors/metrics_collector.py
+++ b/components/collector/src/base_collectors/metrics_collector.py
@@ -49,7 +49,8 @@ class MetricsCollector:
     """Collect measurements for all metrics."""
 
     API_VERSION = "v3"
-    MAX_SLEEP_DURATION = int(os.environ.get("COLLECTOR_SLEEP_DURATION", 60))
+    MAX_SLEEP_DURATION = int(os.environ.get("COLLECTOR_SLEEP_DURATION", 20))
+    MAX_METRICS_PER_WAKEUP = 30
     MEASUREMENT_FREQUENCY = int(os.environ.get("COLLECTOR_MEASUREMENT_FREQUENCY", 15 * 60))
 
     def __init__(self) -> None:
@@ -118,7 +119,7 @@ class MetricsCollector:
             self.collect_metric(session, metric_uuid, metric, next_fetch)
             for metric_uuid, metric in metrics.items()
             if self.__can_and_should_collect(metric_uuid, metric)
-        ]
+        ][: self.MAX_METRICS_PER_WAKEUP]
         await asyncio.gather(*tasks)
 
     async def collect_metric(self, session: aiohttp.ClientSession, metric_uuid, metric, next_fetch: datetime) -> None:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,11 +8,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
-## [3.23.2-rc.8] - [2021-06-15]
+## [Unreleased]
 
 ### Changed
 
-- Added more logging to the server measurements endpoint to investigate why storing measurements is sometimes very slow.
+- To prevent overloading *Quality-time*, the collector now measures at most 30 metrics each time it wakes up. To compensate, it by default wakes up every 20 seconds (was 60 seconds) to see whether metrics need measuring.
 
 ## [3.23.1] - [2021-06-13]
 


### PR DESCRIPTION
…st 30 metrics each time it wakes up. To compensate, it by default wakes up every 20 seconds (was 60 seconds) to see whether metrics need measuring.