### PR TITLE
Work around a bug in aiohttp (https://github.com/aio-libs/aiohttp/iss…

### DIFF
--- a/components/collector/src/source_collectors/gitlab/base.py
+++ b/components/collector/src/source_collectors/gitlab/base.py
@@ -19,6 +19,10 @@ class GitLabBase(SourceCollector, ABC):  # pylint: disable=abstract-method
         """Extend to follow GitLab pagination links, if necessary."""
         all_responses = responses = await super()._get_source_responses(*urls, **kwargs)
         while next_urls := self.__next_urls(responses):
+            # Retrieving consecutive big responses without reading the response hangs the client, see
+            # https://github.com/aio-libs/aiohttp/issues/2217
+            for response in responses:
+                await response.read()
             all_responses.extend(responses := await super()._get_source_responses(*next_urls, **kwargs))
         return all_responses
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 
+- Work around a [bug in aiohttp](https://github.com/aio-libs/aiohttp/issues/2217) that causes GitLab connections to hang and timeout when the GitLab data is paginated. Fixes [#2231](https://github.com/ICTU/quality-time/issues/2231).
 - The report dashboard layout couldn't be changed. Fixes [#2305](https://github.com/ICTU/quality-time/issues/2305).
 
 ## [3.23.2] - [2021-06-17]


### PR DESCRIPTION
…ues/2217) that causes GitLab connections to hang and timeout when the GitLab data is paginated. Fixes #2231, hopefully