### PR TITLE
 When measuring 'missing metrics', count missing metric types per subject instead of per report

### DIFF
--- a/components/collector/src/source_collectors/quality_time/base.py
+++ b/components/collector/src/source_collectors/quality_time/base.py
@@ -21,12 +21,9 @@ class QualityTimeCollector(SourceCollector, ABC):  # skipcq: PYL-W0223
         """Get the relevant reports from the reports response."""
         report_titles_or_ids = set(self._parameter("reports"))
         response_json = await response.json()
-        reports = list((response_json)["reports"])
-        reports = (
-            [report for report in reports if (report_titles_or_ids & {report["title"], report["report_uuid"]})]
-            if report_titles_or_ids
-            else reports
-        )
+        reports = list(response_json["reports"])
+        if report_titles_or_ids:
+            reports = [report for report in reports if report_titles_or_ids & {report["title"], report["report_uuid"]}]
         if not reports:
             message = "No reports found" + (f" with title or id {report_titles_or_ids}" if report_titles_or_ids else "")
             raise SourceCollectorException(message)

--- a/components/collector/src/source_collectors/quality_time/missing_metrics.py
+++ b/components/collector/src/source_collectors/quality_time/missing_metrics.py
@@ -1,6 +1,7 @@
-"""Quality-time completeness collector."""
+"""Quality-time missing metrics collector."""
 
-from typing import Dict, Set
+from typing import cast
+
 from collector_utilities.type import URL
 from model import SourceMeasurement, SourceResponses
 from model.entity import Entities, Entity
@@ -8,35 +9,8 @@ from model.entity import Entities, Entity
 from .base import QualityTimeCollector
 
 
-Measurements = list[dict[str, dict[str, str]]]
-
-
 class QualityTimeMissingMetrics(QualityTimeCollector):
-    """Collector to get the "completeness" metric from Quality-time."""
-
-    async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
-        """Get the metric entities from the responses."""
-        datamodel_response, reports_response = responses
-        datamodel = await datamodel_response.json()
-        reports = await self._get_reports(reports_response)
-
-        entity_dict = {}
-        for report in reports:
-            report_title = report["title"]
-            subject_types = {subject["type"] for subject in report.get("subjects", {}).values()}
-            possible_metrics = self.__get_possible_metrics(datamodel, subject_types)
-            actual_metrics_types = self.__get_actual_metric_types(report)
-
-            for metric_type, entity in possible_metrics.items():
-                if metric_type not in actual_metrics_types:
-                    if metric_type not in entity_dict:
-                        entity["reports"] = report_title
-                        entity_dict[metric_type] = entity
-                    else:
-                        entity_dict[metric_type]["reports"] = entity_dict[metric_type]["reports"] + f", {report_title}"
-
-        entities = Entities(list(entity_dict.values()))
-        return SourceMeasurement(total=str(len(possible_metrics)), entities=entities)
+    """Collector to get the number of missing metrics from Quality-time."""
 
     async def _get_source_responses(self, *urls: URL, **kwargs) -> SourceResponses:
         """Get responses for reports and the datamodel."""
@@ -45,30 +19,67 @@ class QualityTimeMissingMetrics(QualityTimeCollector):
         reports_url = URL(f"{api_url}/reports")
         return await super()._get_source_responses(datamodel_url, reports_url, **kwargs)
 
+    async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
+        """Get the metric entities from the responses."""
+        datamodel_response, reports_response = responses
+        data_model = await datamodel_response.json()
+        reports = await self._get_reports(reports_response)
+        landing_url = await self._landing_url(responses)
+        total = self.__nr_of_possible_metric_types(data_model, reports)
+        entities = self.__missing_metric_type_entities(data_model, reports, landing_url)
+        return SourceMeasurement(total=str(total), entities=entities)
+
+    def __nr_of_possible_metric_types(self, data_model: dict, reports: list[dict]) -> int:
+        """Return the number of possible metric types in the reports."""
+        return sum(self.__report_nr_of_possible_metric_types(data_model, report) for report in reports)
+
+    def __report_nr_of_possible_metric_types(self, data_model: dict, report: dict) -> int:
+        """Return the number of possible metric types in the report."""
+        subjects = report.get("subjects", {}).values()
+        return sum(len(self.__subject_possible_metric_types(data_model, subject)) for subject in subjects)
+
+    def __missing_metric_type_entities(self, data_model: dict, reports: list[dict], landing_url: URL) -> Entities:
+        """Return the reports' missing metric types as entities."""
+        entities = Entities()
+        for report in reports:
+            entities.extend(self.__report_missing_metric_type_entities(data_model, report, landing_url))
+        return entities
+
+    def __report_missing_metric_type_entities(self, data_model: dict, report: dict, landing_url: URL) -> Entities:
+        """Return the report's missing metric types as entities."""
+        entities = Entities()
+        for subject_uuid in report.get("subjects", {}):
+            entities.extend(self.__subject_missing_metric_type_entities(data_model, report, subject_uuid, landing_url))
+        return entities
+
+    def __subject_missing_metric_type_entities(
+        self, data_model: dict, report: dict, subject_uuid: str, landing_url: URL
+    ) -> Entities:
+        """Return the subject's missing metric types as entities."""
+        report_uuid = report["report_uuid"]
+        report_url = f"{landing_url}/{report_uuid}"
+        subject = report["subjects"][subject_uuid]
+        subject_type_name = data_model["subjects"][subject["type"]]["name"]
+        return Entities(
+            Entity(
+                key=f"{report_uuid}:{subject_uuid}:{metric_type}",
+                report=report["title"],
+                report_url=report_url,
+                subject=subject.get("name", subject_type_name),
+                subject_url=f"{report_url}#{subject_uuid}",
+                subject_type=subject_type_name,
+                metric_type=data_model["metrics"][metric_type]["name"],
+            )
+            for metric_type in self.__subject_missing_metric_types(data_model, subject)
+        )
+
+    def __subject_missing_metric_types(self, data_model: dict, subject: dict) -> list[str]:
+        """Return the subject's missing metric types."""
+        possible_types = self.__subject_possible_metric_types(data_model, subject)
+        actual_types = set(metric["type"] for metric in subject.get("metrics", {}).values())
+        return [metric_type for metric_type in possible_types if metric_type not in actual_types]
+
     @staticmethod
-    def __get_possible_metrics(datamodel: Dict, subject_types: Set) -> Dict:
-        """Get the relevant metrics from the reports response."""
-        possible_metrics = {}
-        for subject_type in subject_types:
-            subject_name = datamodel["subjects"][subject_type]["name"]
-            for metric_type in datamodel["subjects"][subject_type]["metrics"]:
-                metric_name = datamodel["metrics"][metric_type]["name"]
-                entity = Entity(
-                    key=metric_type,
-                    metric_type=metric_name,
-                    subject_type=subject_name,
-                    reports=[],
-                )
-                possible_metrics[metric_type] = entity
-
-        return possible_metrics
-
-    @staticmethod
-    def __get_actual_metric_types(report: Dict) -> Set[str]:
-        """Get the relevant metrics from the reports response."""
-        metric_types = set()
-        for subject in report.get("subjects", {}).values():
-            for metric in subject.get("metrics", {}).values():
-                metric_types.add(metric["type"])
-
-        return metric_types
+    def __subject_possible_metric_types(data_model: dict, subject: dict) -> list[str]:
+        """Return the subject's possible metric types."""
+        return cast(list[str], data_model["subjects"][subject["type"]]["metrics"])

--- a/components/collector/src/source_collectors/quality_time/missing_metrics.py
+++ b/components/collector/src/source_collectors/quality_time/missing_metrics.py
@@ -76,7 +76,7 @@ class QualityTimeMissingMetrics(QualityTimeCollector):
     def __subject_missing_metric_types(self, data_model: dict, subject: dict) -> list[str]:
         """Return the subject's missing metric types."""
         possible_types = self.__subject_possible_metric_types(data_model, subject)
-        actual_types = set(metric["type"] for metric in subject.get("metrics", {}).values())
+        actual_types = {metric["type"] for metric in subject.get("metrics", {}).values()}
         return [metric_type for metric_type in possible_types if metric_type not in actual_types]
 
     @staticmethod

--- a/components/collector/tests/source_collectors/quality_time/test_missing_metrics.py
+++ b/components/collector/tests/source_collectors/quality_time/test_missing_metrics.py
@@ -11,12 +11,12 @@ class QualityTimeMissingMetricsTest(QualityTimeTestCase):
     def setUp(self):
         """Set up test data."""
         super().setUp()
-        self.set_source_parameter("reports", ["r1", "r2"])
-        self.expected_software_metrics = str(len(self.data_model["subjects"]["software"]["metrics"]))
+        self.set_source_parameter("reports", ["r1", "r3"])
+        self.expected_software_metrics = str(2 * len(self.data_model["subjects"]["software"]["metrics"]))
         self.reports["reports"].append(
             dict(
-                title="R2",
-                report_uuid="r2",
+                title="R3",
+                report_uuid="r3",
                 subjects=dict(
                     s2=dict(
                         type="software",
@@ -48,26 +48,28 @@ class QualityTimeMissingMetricsTest(QualityTimeTestCase):
                 ),
             ),
         )
-
-        self.entities = [
-            dict(
-                key=metric_type,
-                metric_type=self.data_model["metrics"][metric_type]["name"],
-                reports="R1, R2",
-                subject_type="Software",
-            )
-            for metric_type in self.data_model["subjects"]["software"]["metrics"]
-            if metric_type not in ["violations", "accessibility", "loc"]
-        ]
+        self.entities = []
+        for report in self.reports["reports"]:
+            for subject_uuid, subject in report.get("subjects", {}).items():
+                for metric_type in self.data_model["subjects"]["software"]["metrics"]:
+                    if metric_type not in ["violations", "accessibility", "loc"]:
+                        self.entities.append(
+                            dict(
+                                key=f"{report['report_uuid']}:{subject_uuid}:{metric_type}",
+                                report=report["title"],
+                                report_url=f"https://quality_time/{report['report_uuid']}",
+                                subject=subject["name"],
+                                subject_url=f"https://quality_time/{report['report_uuid']}#{subject_uuid}",
+                                subject_type=self.data_model["subjects"][subject["type"]]["name"],
+                                metric_type=self.data_model["metrics"][metric_type]["name"],
+                            )
+                        )
 
     async def test_nr_of_metrics(self):
-        """Test that the number of missing_metrics is returned."""
+        """Test that the number of missing metrics is returned."""
         response = await self.collect(get_request_json_side_effect=[self.data_model, self.reports])
         self.assert_measurement(
-            response,
-            value=str(len(self.entities)),
-            total=self.expected_software_metrics,
-            entities=self.entities,
+            response, value=str(len(self.entities)), total=self.expected_software_metrics, entities=self.entities
         )
 
     async def test_nr_of_missing_metrics_without_reports(self):

--- a/components/server/src/data_model/sources/quality_time.py
+++ b/components/server/src/data_model/sources/quality_time.py
@@ -235,9 +235,10 @@ QUALITY_TIME = Source(
         missing_metrics=dict(
             name="metric type",
             attributes=[
+                dict(name="Report", url="report_url"),
+                dict(name="Subject", url="subject_url"),
                 dict(name="Subject type"),
                 dict(name="Metric type"),
-                dict(name="Missing from reports", key="reports"),
             ],
         ),
     ),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 
 - In addition to "low", "medium", "high", and "critical", the OWASP Dependency Check may report vulnerabilities with severity "moderate". Allow for using this severity for filtering vulnerabilities. Fixes [#2337](https://github.com/ICTU/quality-time/issues/2337).
+- When measuring 'missing metrics', count missing metric types per subject instead of per report. Fixes [#2352](https://github.com/ICTU/quality-time/issues/2352).
 - Add subject name to metrics in MS Teams notifications, so it's clear which metric changed status when different subjects have metrics with the same name. Fixes [#2353](https://github.com/ICTU/quality-time/issues/2353).
 - After reloading a report, edit controls are shown even when the user has no edit permission. Fixes [#2373](https://github.com/ICTU/quality-time/issues/2373).
 


### PR DESCRIPTION
Fixes #2352.