### PR TITLE
The security warnings in OWASP ZAP reports do not have unique keys. H…

### DIFF
--- a/components/collector/src/source_collectors/owasp_zap/security_warnings.py
+++ b/components/collector/src/source_collectors/owasp_zap/security_warnings.py
@@ -40,8 +40,8 @@ class OWASPZAPSecurityWarnings(XMLFileSourceCollector):
         """Create an alert instance entity."""
         method = alert_instance.findtext("method", default="")
         uri = self.__stable_url(hashless(URL(alert_instance.findtext("uri", default=""))))
-        key = md5_hash(f"{':'.join(ids)}:{method}:{uri}")
-        old_key = md5_hash(f"{':'.join(ids[1:])}:{method}:{uri}")
+        key = md5_hash(f"{':'.join(ids[:-1])}:{method}:{uri}")
+        old_key = md5_hash(f"{':'.join(ids)}:{method}:{uri}")
         location = f"{method} {uri}"
         return Entity(key=key, old_key=old_key, uri=uri, location=location, **entity_kwargs)
 

--- a/components/collector/tests/source_collectors/owasp_zap/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/owasp_zap/test_security_warnings.py
@@ -55,8 +55,8 @@ class OWASPZAPSecurityWarningsTest(OWASPZAPTestCase):
         url2 = "http://www.hackazon.com/products_pictures/How_to_Marry_a_Millionaire.jpg"
         expected_entities = [
             dict(
-                key=md5_hash(f"X-Content-Type-Options Header Missing:10021:16:15:3:GET:{url1}"),
-                old_key=md5_hash(f"10021:16:15:3:GET:{url1}"),
+                key=md5_hash(f"X-Content-Type-Options Header Missing:10021:16:15:GET:{url1}"),
+                old_key=md5_hash(f"X-Content-Type-Options Header Missing:10021:16:15:3:GET:{url1}"),
                 name=self.WARNING_NAME,
                 description=self.WARNING_DESCRIPTION,
                 location=f"GET {url1}",
@@ -64,8 +64,8 @@ class OWASPZAPSecurityWarningsTest(OWASPZAPTestCase):
                 risk=self.WARNING_RISK,
             ),
             dict(
-                key=md5_hash(f"X-Content-Type-Options Header Missing:10021:16:15:3:GET:{url2}"),
-                old_key=md5_hash(f"10021:16:15:3:GET:{url2}"),
+                key=md5_hash(f"X-Content-Type-Options Header Missing:10021:16:15:GET:{url2}"),
+                old_key=md5_hash(f"X-Content-Type-Options Header Missing:10021:16:15:3:GET:{url2}"),
                 name=self.WARNING_NAME,
                 description=self.WARNING_DESCRIPTION,
                 location=f"GET {url2}",
@@ -96,8 +96,8 @@ class OWASPZAPSecurityWarningsTest(OWASPZAPTestCase):
         stable_url = "http://www.hackazon.com/products_pictures/variable-part-removed"
         expected_entities = [
             dict(
-                key=md5_hash(f"X-Content-Type-Options Header Missing:10021:16:15:3:GET:{stable_url}"),
-                old_key=md5_hash(f"10021:16:15:3:GET:{stable_url}"),
+                key=md5_hash(f"X-Content-Type-Options Header Missing:10021:16:15:GET:{stable_url}"),
+                old_key=md5_hash(f"X-Content-Type-Options Header Missing:10021:16:15:3:GET:{stable_url}"),
                 name=self.WARNING_NAME,
                 uri=stable_url,
                 description=self.WARNING_DESCRIPTION,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - When measuring 'missing metrics', count missing metric types per subject instead of per report. Fixes [#2352](https://github.com/ICTU/quality-time/issues/2352).
 - Add subject name to metrics in MS Teams notifications, so it's clear which metric changed status when different subjects have metrics with the same name. Fixes [#2353](https://github.com/ICTU/quality-time/issues/2353).
 - After reloading a report, edit controls are shown even when the user has no edit permission. Fixes [#2373](https://github.com/ICTU/quality-time/issues/2373).
+- The security warnings in OWASP ZAP reports do not have unique keys. However, *Quality-time* needs security warnings to be uniquely identifiable to detect whether the list of warnings changes between measurements. Therefore, *Quality-time* generates keys for OWASP ZAP security warnings itself. Unfortunately, the key that *Quality-time* generated, was not guaranteed to be unique. Fixes [#2429](https://github.com/ICTU/quality-time/issues/2429).
 
 ### Added
 


### PR DESCRIPTION
…owever, *Quality-time* needs security warnings to be uniquely identifiable to detect whether the list of warnings changes between measurements. Therefore, *Quality-time* generates keys for OWASP ZAP security warnings itself. Unfortunately, the key that *Quality-time* generated, was not guaranteed to be unique. Fixes #2429.