### PR TITLE
Allow Robot Framework reports as source for the test cases metric. 

### DIFF
--- a/components/collector/src/source_collectors/__init__.py
+++ b/components/collector/src/source_collectors/__init__.py
@@ -122,6 +122,7 @@ from .quality_time.source_version import QualityTimeSourceVersion
 
 from .robot_framework.source_up_to_dateness import RobotFrameworkSourceUpToDateness
 from .robot_framework.source_version import RobotFrameworkSourceVersion
+from .robot_framework.test_cases import RobotFrameworkTestCases
 from .robot_framework.tests import RobotFrameworkTests
 
 from .robot_framework_jenkins_plugin.source_up_to_dateness import RobotFrameworkJenkinsPluginSourceUpToDateness

--- a/components/collector/src/source_collectors/robot_framework/test_cases.py
+++ b/components/collector/src/source_collectors/robot_framework/test_cases.py
@@ -1,0 +1,7 @@
+"""Robot Framework test cases collector."""
+
+from .tests import RobotFrameworkTests
+
+
+class RobotFrameworkTestCases(RobotFrameworkTests):
+    """Collector for Robot Framework test cases."""

--- a/components/collector/tests/source_collectors/robot_framework/base.py
+++ b/components/collector/tests/source_collectors/robot_framework/base.py
@@ -34,7 +34,7 @@ class RobotFrameworkTestCase(SourceCollectorTestCase):  # skipcq: PTC-W0046
                     <status status="PASS"></status>
                 </test>
             </suite>
-             <statistics>
+            <statistics>
                 <total>
                     <stat pass="1" fail="1" skip="0">All Tests</stat>
                 </total>
@@ -53,7 +53,7 @@ class RobotFrameworkTestCase(SourceCollectorTestCase):  # skipcq: PTC-W0046
                     <status status="SKIP"></status>
                 </test>
             </suite>
-             <statistics>
+            <statistics>
                 <total>
                     <stat pass="1" fail="1" skip="1">All Tests</stat>
                 </total>

--- a/components/server/src/data_model/metrics.py
+++ b/components/server/src/data_model/metrics.py
@@ -283,7 +283,7 @@ METRICS = Metrics.parse_obj(
             direction=Direction.MORE_IS_BETTER,
             near_target="0",
             default_source="jira",
-            sources=["jira", "junit", "manual_number", "testng"],
+            sources=["jira", "junit", "manual_number", "robot_framework", "testng"],
             tags=[Tag.TEST_QUALITY],
         ),
         tests=dict(

--- a/components/server/src/data_model/sources/robot_framework.py
+++ b/components/server/src/data_model/sources/robot_framework.py
@@ -7,7 +7,7 @@ from ..parameters import access_parameters, TestResult
 from .jenkins import jenkins_access_parameters
 
 
-ALL_ROBOT_FRAMEWORK_METRICS = ["source_up_to_dateness", "source_version", "tests"]
+ALL_ROBOT_FRAMEWORK_METRICS = ["source_up_to_dateness", "source_version", "test_cases", "tests"]
 
 ROBOT_FRAMEWORK = Source(
     name="Robot Framework",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- Allow Robot Framework reports as source for the test cases metric. Closes [#2534](https://github.com/ICTU/quality-time/issues/2534).
+
 ### Removed
 
 - Don't send notifications about metrics having the same status for three weeks: it's not useful enough. Closes [#2529](https://github.com/ICTU/quality-time/issues/2529).

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -243,7 +243,7 @@ Note that when the "Metrics" metric is itself part of the set of metrics it coun
 
 The test cases metric reports on the number of test cases, and their test results. The test case metric is different than other metrics because it combines data from two types of sources: it needs one or more sources for the test cases, and one or more sources for the test results. The test case metric then matches the test results with the test cases.
 
-Currently, only {index}`Jira` is supported as source for the test cases. {index}`JUnit` and {index}`TestNG` are supported as source for the test results. So, to configure the test cases metric, you need to add at least one Jira source and one JUnit or one TestNG source. In addition, to allow the test case metric to match test cases from Jira with test results from the JUnit and/or TestNG XML files, the test results should mention Jira issue keys in their title or description.
+Currently, only {index}`Jira` is supported as source for the test cases. {index}`JUnit`, {index}`TestNG`, and {index}`Robot Framework` are supported as source for the test results. So, to configure the test cases metric, you need to add at least one Jira source and one JUnit, TestNG, Robot Framework source. In addition, to allow the test case metric to match test cases from Jira with test results from the JUnit, TestNG, or Robot Framework XML files, the test results should mention Jira issue keys in their title or description.
 
 Suppose you have configured Jira with the query: `project = "My Project" and type = "Logical Test Case"` and this results in these test cases:
 
@@ -279,7 +279,7 @@ The test case metric will combine the JUnit XML file with the test cases from Ji
 | MP-2 | Test case 2 | skipped     |
 | MP-3 | Test case 3 | passed      |
 
-If multiple test results in the JUnit or TestNG XML file map to one Jira test case (as with MP-1 and MP-3 above), the "worst" test result is reported. Possible test results from worst to best are: errored, failed, skipped, and passed.
+If multiple test results in the JUnit, TestNG, or Robot Framework XML file map to one Jira test case (as with MP-1 and MP-3 above), the "worst" test result is reported. Possible test results from worst to best are: errored, failed, skipped, and passed.
 
 ```{index} Unmerged branches
 ```


### PR DESCRIPTION
Closes #2534.