### PR TITLE
Set measurement's connection error at a more logical place. 

### DIFF
--- a/components/collector/src/model/measurement.py
+++ b/components/collector/src/model/measurement.py
@@ -13,13 +13,19 @@ class SourceMeasurement:  # pylint: disable=too-few-public-methods,too-many-inst
     MAX_ENTITIES = 100  # The maximum number of entities (e.g. violations, warnings) to send to the server
 
     def __init__(
-        self, *, value: Value = None, total: Value = "100", entities: Entities = None, parse_error: ErrorMessage = None
+        self,
+        *,
+        value: Value = None,
+        total: Value = "100",
+        entities: Entities = None,
+        connection_error: ErrorMessage = None,
+        parse_error: ErrorMessage = None,
     ) -> None:
         self.value = str(len(entities)) if value is None and entities is not None else value
-        self.total = total
         self.entities = Entities() if entities is None else entities
         self.parse_error = parse_error
-        self.connection_error: ErrorMessage = None
+        self.connection_error = connection_error
+        self.total = None if self.has_error() else total
         self.api_url: Optional[URL] = None
         self.landing_url: Optional[URL] = None
         self.source_uuid: Optional[str] = None
@@ -34,8 +40,8 @@ class SourceMeasurement:  # pylint: disable=too-few-public-methods,too-many-inst
             value=self.value,
             total=self.total,
             entities=self.entities[: self.MAX_ENTITIES],
-            parse_error=self.parse_error,
             connection_error=self.connection_error,
+            parse_error=self.parse_error,
             api_url=self.api_url,
             landing_url=self.landing_url,
             source_uuid=self.source_uuid,

--- a/components/collector/tests/source_collectors/azure_devops/test_unmerged_branches.py
+++ b/components/collector/tests/source_collectors/azure_devops/test_unmerged_branches.py
@@ -56,6 +56,5 @@ class AzureDevopsUnmergedBranchesTest(AzureDevopsTestCase):
         self.assert_measurement(
             response,
             landing_url=f"{self.url}/_git/wrong_repo/branches",
-            entities=[],
             connection_error="Repository 'wrong_repo' not found",
         )

--- a/components/collector/tests/source_collectors/jacoco/base.py
+++ b/components/collector/tests/source_collectors/jacoco/base.py
@@ -19,7 +19,7 @@ class JaCoCoCommonTestsMixin:  # pylint: disable=too-few-public-methods
             ("jacoco.html", "<html><body><p>Oops, user included the HTML instead of the XML</p></body></html>")
         )
         response = await self.collect(get_request_content=report)
-        self.assert_measurement(response, value=None, connection_error="Zipfile contains no files with extension xml")
+        self.assert_measurement(response, connection_error="Zipfile contains no files with extension xml")
 
 
 class JaCoCoCommonCoverageTestsMixin:

--- a/components/collector/tests/source_collectors/jira/test_velocity.py
+++ b/components/collector/tests/source_collectors/jira/test_velocity.py
@@ -108,5 +108,5 @@ class JiraVelocityTest(JiraTestCase):
         boards_json = dict(startAt=0, maxResults=50, isLast=True, values=[dict(id=1, name="Board 1")])
         response = await self.collect(get_request_json_side_effect=[boards_json])
         self.assert_measurement(
-            response, value=None, connection_error="Could not find a Jira board with id or name", landing_url=self.url
+            response, connection_error="Could not find a Jira board with id or name", landing_url=self.url
         )

--- a/components/collector/tests/source_collectors/owasp_dependency_check/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/owasp_dependency_check/test_security_warnings.py
@@ -111,8 +111,6 @@ class OWASPDependencyCheckSecurityWarningsTest(OWASPDependencyCheckTestCase):
         response = await self.collect(get_request_text=xml)
         self.assert_measurement(
             response,
-            value=None,
-            entities=[],
             parse_error=f"""
 AssertionError: The XML root element should be one of \
 "{OWASPDependencyCheckBase.allowed_root_tags}" but is \

--- a/components/collector/tests/source_collectors/performancetest_runner/test_scalability.py
+++ b/components/collector/tests/source_collectors/performancetest_runner/test_scalability.py
@@ -27,4 +27,4 @@ class PerformanceTestRunnerScalabilityTest(PerformanceTestRunnerTestCase):
             <tr><td class="name">Trendbreak 'scalability' (%)</td><td id="trendbreak_scalability">100</td></tr>
             </table></html>"""
         response = await self.collect(get_request_text=html)
-        self.assert_measurement(response, value=None, parse_error="Traceback")
+        self.assert_measurement(response, parse_error="Traceback")

--- a/components/collector/tests/source_collectors/quality_time/test_metrics.py
+++ b/components/collector/tests/source_collectors/quality_time/test_metrics.py
@@ -43,15 +43,13 @@ class QualityTimeMetricsTest(QualityTimeTestCase):
         """Test that the number of metrics is returned."""
         self.set_source_parameter("reports", [])
         response = await self.collect(get_request_json_return_value=dict(reports=[]))
-        self.assert_measurement(response, value=None, total="100", parse_error="No reports found", entities=[])
+        self.assert_measurement(response, parse_error="No reports found")
 
     async def test_nr_of_metrics_without_correct_report(self):
         """Test that the number of metrics is returned."""
         self.reports["reports"].pop(0)
         response = await self.collect(get_request_json_return_value=self.reports)
-        self.assert_measurement(
-            response, value=None, total="100", parse_error="No reports found with title or id", entities=[]
-        )
+        self.assert_measurement(response, parse_error="No reports found with title or id")
 
     def assert_measurement(self, measurement, *, source_index: int = 0, **attributes) -> None:
         """Override to pass the api and landing URLs."""

--- a/components/collector/tests/source_collectors/quality_time/test_missing_metrics.py
+++ b/components/collector/tests/source_collectors/quality_time/test_missing_metrics.py
@@ -84,4 +84,4 @@ class QualityTimeMissingMetricsTest(QualityTimeTestCase):
         """Test that an error is thrown for reports that don't exist."""
         self.reports["reports"] = []
         response = await self.collect(get_request_json_side_effect=[self.data_model, self.reports])
-        self.assert_measurement(response, value=None, parse_error="No reports found with title or id", entities=[])
+        self.assert_measurement(response, parse_error="No reports found with title or id")

--- a/components/collector/tests/source_collectors/sonarqube/test_tests.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_tests.py
@@ -32,10 +32,10 @@ class SonarQubeTestsTest(SonarQubeTestCase):
         """Test that the collector throws an exception if there are no tests."""
         json = dict(component=dict(measures=[]))
         response = await self.collect(get_request_json_return_value=json)
-        self.assert_measurement(response, value=None, total="100", parse_error="KeyError")
+        self.assert_measurement(response, parse_error="KeyError")
 
     async def test_nr_of_tests_with_faulty_component(self):
         """Test that the measurement fails if the component does not exist."""
         json = dict(errors=[dict(msg="No such component")])
         response = await self.collect(get_request_json_return_value=json)
-        self.assert_measurement(response, value=None, total=None, connection_error="No such component")
+        self.assert_measurement(response, connection_error="No such component")

--- a/components/collector/tests/source_collectors/source_collector_test_case.py
+++ b/components/collector/tests/source_collectors/source_collector_test_case.py
@@ -95,6 +95,7 @@ class SourceCollectorTestCase(unittest.IsolatedAsyncioTestCase):  # skipcq: PTC-
         """Assert that the measurement has the expected attributes."""
         for attribute_key in ("connection_error", "parse_error"):
             if (attribute_value := attributes.get(attribute_key)) is not None:
+                attributes.update(value=None, total=None, entities=[])
                 self.assertIn(attribute_value, getattr(measurement.sources[source_index], attribute_key))
             else:
                 self.assertIsNone(getattr(measurement.sources[source_index], attribute_key))


### PR DESCRIPTION
Assure measurement value, total, and entities are None if there's an error.