### PR TITLE
Give metric.get('sources') {} as default return value 

### DIFF
--- a/components/collector/src/base_collectors/collector.py
+++ b/components/collector/src/base_collectors/collector.py
@@ -143,7 +143,7 @@ class Collector:
 
     def __can_collect(self, metric) -> bool:
         """Return whether the user has specified all mandatory parameters for all sources."""
-        sources = metric.get("sources")
+        sources = metric.get("sources", {})
         for source in sources.values():
             parameters = self.data_model.get("sources", {}).get(source["type"], {}).get("parameters", {})
             for parameter_key, parameter in parameters.items():

--- a/components/collector/src/base_collectors/collector.py
+++ b/components/collector/src/base_collectors/collector.py
@@ -122,7 +122,9 @@ class Collector:
                 tasks.append(self.collect_metric(session, metric_uuid, metric, next_fetch))
         await asyncio.gather(*tasks)
 
-    async def collect_metric(self, session: aiohttp.ClientSession, metric_uuid, metric, next_fetch: datetime) -> None:
+    async def collect_metric(
+        self, session: aiohttp.ClientSession, metric_uuid: str, metric: dict, next_fetch: datetime
+    ) -> None:
         """Collect measurements for the metric and post it to the server."""
         self.__previous_metrics[metric_uuid] = metric
         self.next_fetch[metric_uuid] = next_fetch
@@ -137,11 +139,11 @@ class Collector:
         """First return the edited metrics, then the rest."""
         return sorted(metrics.items(), key=lambda item: bool(self.__previous_metrics.get(item[0]) == item[1]))
 
-    def __can_and_should_collect(self, metric_uuid: str, metric) -> bool:
+    def __can_and_should_collect(self, metric_uuid: str, metric: dict) -> bool:
         """Return whether the metric can and needs to be measured."""
         return self.__should_collect(metric_uuid, metric) if self.__can_collect(metric) else False
 
-    def __can_collect(self, metric) -> bool:
+    def __can_collect(self, metric: dict) -> bool:
         """Return whether the user has specified all mandatory parameters for all sources."""
         sources = metric.get("sources", {})
         for source in sources.values():
@@ -156,7 +158,7 @@ class Collector:
                     return False
         return bool(sources)
 
-    def __should_collect(self, metric_uuid: str, metric) -> bool:
+    def __should_collect(self, metric_uuid: str, metric: dict) -> bool:
         """Return whether the metric should be collected.
 
         Metric should be collected when the user changes the configuration or when it has been collected too long ago.

--- a/components/collector/tests/base_collectors/test_collector.py
+++ b/components/collector/tests/base_collectors/test_collector.py
@@ -114,9 +114,18 @@ class CollectorTest(unittest.IsolatedAsyncioTestCase):
             json=dict(has_error=False, sources=[self._source()], metric_uuid="metric_uuid"),
         )
 
+    async def test_fetch_with_empty_sources(self):
+        """Test fetching measurement for a metric with empty sources dict."""
+        metrics = dict(metric_uuid=dict(type="metric", addition="sum", sources={}))
+        mock_async_get_request = AsyncMock()
+        mock_async_get_request.json.return_value = metrics
+        with self._patched_post() as post:
+            await self._fetch_measurements(mock_async_get_request)
+        post.assert_not_called()
+
     async def test_fetch_without_sources(self):
         """Test fetching measurement for a metric without sources."""
-        metrics = dict(metric_uuid=dict(type="metric", addition="sum", sources={}))
+        metrics = dict(metric_uuid=dict(type="metric", addition="sum"))
         mock_async_get_request = AsyncMock()
         mock_async_get_request.json.return_value = metrics
         with self._patched_post() as post:


### PR DESCRIPTION
This ensures that calling values() on the return value of get() can't fail.