### PR TITLE
Quality-time was using a broken and deprecated API endpoint to collect data for the 'metrics' metric

### DIFF
--- a/components/collector/src/source_collectors/quality_time/metrics.py
+++ b/components/collector/src/source_collectors/quality_time/metrics.py
@@ -19,7 +19,7 @@ class QualityTimeMetrics(QualityTimeCollector):
         """Extend to add the reports API path."""
         parts = parse.urlsplit(await super()._api_url())
         netloc = f"{parts.netloc.split(':')[0]}"
-        return URL(parse.urlunsplit((parts.scheme, netloc, f"{parts.path}/reports", "", "")))
+        return URL(parse.urlunsplit((parts.scheme, netloc, f"{parts.path}/report", "", "")))
 
     async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
         """Get the metric entities from the responses."""

--- a/components/collector/tests/source_collectors/quality_time/test_metrics.py
+++ b/components/collector/tests/source_collectors/quality_time/test_metrics.py
@@ -11,7 +11,7 @@ class QualityTimeMetricsTest(QualityTimeTestCase):
     def setUp(self):
         """Set up test data."""
         super().setUp()
-        self.api_url = f"{self.url}/api/v3/reports"
+        self.api_url = f"{self.url}/api/v3/report"
 
     async def test_nr_of_metrics(self):
         """Test that the number of metrics is returned."""

--- a/components/server/src/routes/external/reports_overview.py
+++ b/components/server/src/routes/external/reports_overview.py
@@ -28,9 +28,8 @@ def get_reports(database: Database):  # pragma: no cover
     data_model = latest_datamodel(database, date_time)
     overview = latest_reports_overview(database, date_time)
     overview["reports"] = []
-    recent_measurements = recent_measurements_by_metric_uuid(data_model, database, date_time)
     for report in latest_reports(database, date_time):
-        summarize_report(report, database, recent_measurements, data_model)
+        summarize_report(report, database, data_model, date_time)
         overview["reports"].append(report)
     hide_credentials(data_model, *overview["reports"])
     return overview

--- a/components/server/src/routes/external/reports_overview.py
+++ b/components/server/src/routes/external/reports_overview.py
@@ -5,7 +5,6 @@ from pymongo.database import Database
 
 from database import sessions
 from database.datamodels import latest_datamodel
-from database.measurements import recent_measurements_by_metric_uuid
 from database.reports import insert_new_reports_overview, latest_reports, latest_reports_overview
 from model.transformations import hide_credentials, summarize_report
 from routes.plugins.auth_plugin import EDIT_REPORT_PERMISSION

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
-## v3.28.0-rc.4 - 2021-11-21
+## [Unreleased]
 
 ### Fixed
 
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - The ARIA (Rich Internet Application Accessibility) label of status pie charts would report the wrong number of red metrics. Fixes [#2779](https://github.com/ICTU/quality-time/issues/2779).
 - The security warnings in OWASP ZAP reports do not have unique keys. However, *Quality-time* needs security warnings to be uniquely identifiable to detect whether the list of warnings changes between measurements. Therefore, *Quality-time* generates keys for OWASP ZAP security warnings itself. Unfortunately, the key that *Quality-time* generated, was not guaranteed to be unique. Fixes [#2852](https://github.com/ICTU/quality-time/issues/2852).
 - Multiple edits with the same description would show up as one entry in the changelog. Fixes [#2893](https://github.com/ICTU/quality-time/issues/2893).
+- *Quality-time* was using a broken and deprecated API endpoint to collect data for the 'metrics' metric. Fixes [#2897](https://github.com/ICTU/quality-time/issues/2897).
 
 ### Added
 


### PR DESCRIPTION
Fixes #2897.