### PR TITLE
More flexible parsing of Axe-core JSON files...

### DIFF
--- a/components/collector/src/source_collectors/axe_core/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/axe_core/source_up_to_dateness.py
@@ -13,4 +13,7 @@ class AxeCoreSourceUpToDateness(JSONFileSourceCollector, SourceUpToDatenessColle
 
     async def _parse_source_response_date_time(self, response: Response) -> datetime:
         """Override to parse the timestamp from the response."""
-        return parse((await response.json(content_type=None))["timestamp"])
+        json = await response.json(content_type=None)
+        if isinstance(json, list):
+            json = json[0]  # The JSON consists of several Axe-core JSONs in a list, assume they have the same timestamp
+        return parse(json["timestamp"])

--- a/components/collector/src/source_collectors/axe_core/source_version.py
+++ b/components/collector/src/source_collectors/axe_core/source_version.py
@@ -11,4 +11,7 @@ class AxeCoreSourceVersion(JSONFileSourceCollector, SourceVersionCollector):
 
     async def _parse_source_response_version(self, response: Response) -> Version:
         """Override to parse the version from the response."""
-        return Version((await response.json(content_type=None))["testEngine"]["version"])
+        json = await response.json(content_type=None)
+        if isinstance(json, list):
+            json = json[0]  # The JSON consists of several Axe-core JSONs in a list, assume they have the same version
+        return Version(json["testEngine"]["version"])

--- a/components/collector/tests/source_collectors/axe_core/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/axe_core/test_source_up_to_dateness.py
@@ -10,10 +10,21 @@ class AxeCoreSourceUpToDatenessTest(AxeCoreTestCase):
 
     METRIC_TYPE = "source_up_to_dateness"
     METRIC_ADDITION = "max"
+    TIMESTAMP = "2020-09-01T14:07:09.445Z"
+
+    def setUp(self):
+        """Extend to set up test fixtures."""
+        super().setUp()
+        self.expected_age = (datetime.now(tz=timezone.utc) - datetime(2020, 9, 1, 14, 6, 9, tzinfo=timezone.utc)).days
 
     async def test_source_up_to_dateness(self):
         """Test that the source age in days is returned."""
-        axe_json = dict(timestamp="2020-09-01T14:07:09.445Z")
+        axe_json = dict(timestamp=self.TIMESTAMP)
         response = await self.collect(get_request_json_return_value=axe_json)
-        expected_age = (datetime.now(tz=timezone.utc) - datetime(2020, 9, 1, 14, 6, 9, tzinfo=timezone.utc)).days
-        self.assert_measurement(response, value=str(expected_age))
+        self.assert_measurement(response, value=str(self.expected_age))
+
+    async def test_source_up_to_dateness_in_list(self):
+        """Test that the source age in days is returned."""
+        axe_json = [dict(timestamp=self.TIMESTAMP)]
+        response = await self.collect(get_request_json_return_value=axe_json)
+        self.assert_measurement(response, value=str(self.expected_age))

--- a/components/collector/tests/source_collectors/axe_core/test_source_version.py
+++ b/components/collector/tests/source_collectors/axe_core/test_source_version.py
@@ -14,3 +14,9 @@ class AxeCoreSourceVersionTest(AxeCoreTestCase):
         axe_json = dict(testEngine=dict(version="4.1.3"))
         response = await self.collect(get_request_json_return_value=axe_json)
         self.assert_measurement(response, value="4.1.3")
+
+    async def test_source_version_in_list(self):
+        """Test that the Axe-core version is returned."""
+        axe_json = [dict(testEngine=dict(version="4.2.4"))]
+        response = await self.collect(get_request_json_return_value=axe_json)
+        self.assert_measurement(response, value="4.2.4")

--- a/components/collector/tests/source_collectors/axe_core/test_source_version.py
+++ b/components/collector/tests/source_collectors/axe_core/test_source_version.py
@@ -8,15 +8,16 @@ class AxeCoreSourceVersionTest(AxeCoreTestCase):
 
     METRIC_TYPE = "source_version"
     METRIC_ADDITION = "min"
+    AXE_VERSION = "4.1.3"
 
     async def test_source_version(self):
         """Test that the Axe-core version is returned."""
-        axe_json = dict(testEngine=dict(version="4.1.3"))
+        axe_json = dict(testEngine=dict(version=self.AXE_VERSION))
         response = await self.collect(get_request_json_return_value=axe_json)
-        self.assert_measurement(response, value="4.1.3")
+        self.assert_measurement(response, value=self.AXE_VERSION)
 
     async def test_source_version_in_list(self):
         """Test that the Axe-core version is returned."""
-        axe_json = [dict(testEngine=dict(version="4.2.4"))]
+        axe_json = [dict(testEngine=dict(version=self.AXE_VERSION))]
         response = await self.collect(get_request_json_return_value=axe_json)
-        self.assert_measurement(response, value="4.2.4")
+        self.assert_measurement(response, value=self.AXE_VERSION)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Changed
+
+- More flexible parsing of Axe-core JSON files to account for the different ways people aggregate Axe-core output into one JSON file, for the 'source up-to-dateness' and 'version' metrics. Closes [#2910](https://github.com/ICTU/quality-time/issues/2910).
+
 ## v3.28.0 - 2021-11-22
 
 ### Fixed


### PR DESCRIPTION
...to account for the different ways people aggregate Axe-core output into one JSON file, for the 'source up-to-dateness' and 'version' metrics. Closes #2910.