### PR TITLE
Upgrade MongoDB to version 4.4. 

### DIFF
--- a/components/database/Dockerfile
+++ b/components/database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:4.2.17
+FROM mongo:4.4.10
 
 LABEL maintainer="Frank Niessink <frank.niessink@ictu.nl>"
 LABEL description="Quality-time database"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 
 - More flexible parsing of Axe-core JSON files to account for the different ways people aggregate Axe-core output into one JSON file, for the 'source up-to-dateness' and 'version' metrics. Closes [#2910](https://github.com/ICTU/quality-time/issues/2910).
+- Upgrade MongoDB to version 4.4. Note that to upgrade to this version of *Quality-time* your previous version needs to be at least version 3.24.0. Closes [#2911](https://github.com/ICTU/quality-time/issues/2911).
 
 ## v3.28.0 - 2021-11-22
 


### PR DESCRIPTION
Note that to upgrade to this version of *Quality-time* your previous version needs to be at least version 3.24.0. Closes #2911.