### PR TITLE
Use elapsed field from JMeter CSV files instead of the latency field.

### DIFF
--- a/components/collector/src/source_collectors/jmeter_csv/slow_transactions.py
+++ b/components/collector/src/source_collectors/jmeter_csv/slow_transactions.py
@@ -28,7 +28,7 @@ class JMeterCSVSlowTransactions(CSVFileSourceCollector):
             label = samples[0]["label"]
             sample_count = len(samples)
             error_count = len([sample for sample in samples if sample["success"] == "false"])
-            latencies = [int(sample["Latency"]) for sample in samples]
+            latencies = [int(sample["elapsed"]) for sample in samples]
             entity = TransactionEntity(
                 key=label,
                 name=label,

--- a/components/collector/tests/source_collectors/jmeter_csv/test_slow_transactions.py
+++ b/components/collector/tests/source_collectors/jmeter_csv/test_slow_transactions.py
@@ -11,8 +11,8 @@ class JMeterCSVSlowTransactionsTest(JMeterCSVTestCase):
     def setUp(self):
         """Extend to set the expected entities."""
         super().setUp()
-        search_endpoint_mean_response_time = search_endpoint_median_response_time = round((1207 + 359) / 2, 1)
-        home_endpoint_mean_response_time = home_endpoint_median_response_time = round((10 + 54) / 2, 1)
+        search_endpoint_mean_response_time = search_endpoint_median_response_time = round((360 + 1214) / 2, 1)
+        home_endpoint_mean_response_time = home_endpoint_median_response_time = round((57 + 10) / 2, 1)
         self.expected_entities = [
             dict(
                 key="-api-search",
@@ -22,9 +22,9 @@ class JMeterCSVSlowTransactionsTest(JMeterCSVTestCase):
                 error_percentage=0.0,
                 mean_response_time=search_endpoint_mean_response_time,
                 median_response_time=search_endpoint_median_response_time,
-                min_response_time=359.0,
-                max_response_time=1207.0,
-                percentile_90_response_time=1800.6,
+                min_response_time=360.0,
+                max_response_time=1214.0,
+                percentile_90_response_time=1811.8,
             ),
             dict(
                 key="-home",
@@ -35,8 +35,8 @@ class JMeterCSVSlowTransactionsTest(JMeterCSVTestCase):
                 mean_response_time=home_endpoint_mean_response_time,
                 median_response_time=home_endpoint_median_response_time,
                 min_response_time=10.0,
-                max_response_time=54.0,
-                percentile_90_response_time=84.8,
+                max_response_time=57.0,
+                percentile_90_response_time=89.9,
             ),
         ]
         self.set_source_parameter("target_response_time", "10")

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
-## v3.30.0-rc.1 - 2021-12-07
+## [Unreleased]
 
 ### Added
 


### PR DESCRIPTION
Closes #2966.