### PR TITLE
Support JMeter CSV output as source for the 'performance test duration' metric 

### DIFF
--- a/components/collector/src/source_collectors/__init__.py
+++ b/components/collector/src/source_collectors/__init__.py
@@ -81,6 +81,7 @@ from .jira.test_cases import JiraTestCases
 from .jira.user_story_points import JiraUserStoryPoints
 from .jira.velocity import JiraVelocity
 
+from .jmeter_csv.performancetest_duration import JMeterCSVPerformanceTestDuration
 from .jmeter_csv.slow_transactions import JMeterCSVSlowTransactions
 from .jmeter_csv.tests import JMeterCSVTests
 

--- a/components/collector/src/source_collectors/jmeter_csv/performancetest_duration.py
+++ b/components/collector/src/source_collectors/jmeter_csv/performancetest_duration.py
@@ -1,0 +1,17 @@
+"""JMeter CSV performancetest duration collector."""
+
+from collector_utilities.type import Value
+from model import SourceResponses
+
+from .base import JMeterCSVCollector
+
+
+class JMeterCSVPerformanceTestDuration(JMeterCSVCollector):
+    """Collector for the performance test duration."""
+
+    async def _parse_value(self, responses: SourceResponses) -> Value:
+        """Override to parse the timestamps from the samples and calculate the duration in minutes."""
+        timestamps = []
+        async for samples in self._samples(responses):
+            timestamps.extend([int(sample["timeStamp"]) for sample in samples])
+        return str(round((max(timestamps) - min(timestamps)) / 60_000)) if timestamps else "0"

--- a/components/collector/tests/source_collectors/jmeter_csv/base.py
+++ b/components/collector/tests/source_collectors/jmeter_csv/base.py
@@ -17,7 +17,7 @@ class JMeterCSVTestCase(SourceCollectorTestCase):  # skipcq: PTC-W0046
     false,,61338,6131,1,1,null,540,96,38
 1638325624692,10,/home,404,Not Found,Thread Group 1-2,text,true,,\
     389,717,1,1,https://app.example.org/home,10,0,4
-1638325624752,1214,/api/search,200,OK,Thread Group 1-2,text,true,,\
+1638325734752,1214,/api/search,200,OK,Thread Group 1-2,text,true,,\
     274377,721,1,1,https://app.example.org/api/search,1207,0,0
 1638325624689,1272,Test,,"Number of samples in transaction : 2, number of failing samples : 1",Thread Group 1-2,,\
     false,,275531,6114,1,1,null,1265,11,4

--- a/components/collector/tests/source_collectors/jmeter_csv/test_performancetest_duration.py
+++ b/components/collector/tests/source_collectors/jmeter_csv/test_performancetest_duration.py
@@ -1,0 +1,19 @@
+"""Unit tests for the JMeter CSV performance test duration collector."""
+
+from .base import JMeterCSVTestCase
+
+
+class JMeterCSVPerformancetestDurationTest(JMeterCSVTestCase):
+    """Unit tests for the JMeter CSV performancetest duration collector."""
+
+    METRIC_TYPE = "performancetest_duration"
+
+    async def test_no_transactions(self):
+        """Test that the performancetest duration is 0 if there are no transactions in the CSV."""
+        response = await self.collect(get_request_text=self.JMETER_CSV.splitlines()[0])
+        self.assert_measurement(response, value="0")
+
+    async def test_all_transactions(self):
+        """Test the performancetest duration of all transactions in the CSV."""
+        response = await self.collect(get_request_text=self.JMETER_CSV)
+        self.assert_measurement(response, value="2")

--- a/components/server/src/data_model/metrics.py
+++ b/components/server/src/data_model/metrics.py
@@ -137,7 +137,8 @@ METRICS = Metrics.parse_obj(
             direction=Direction.MORE_IS_BETTER,
             target="30",
             near_target="25",
-            sources=["manual_number", "performancetest_runner"],
+            default_source="jmeter_csv",
+            sources=["jmeter_csv", "manual_number", "performancetest_runner"],
             tags=[Tag.PERFORMANCE],
         ),
         performancetest_stability=dict(
@@ -178,7 +179,7 @@ METRICS = Metrics.parse_obj(
             description="The number of transactions slower than their performance threshold.",
             unit=Unit.TRANSACTIONS,
             near_target="5",
-            default_source="jmeter_json",
+            default_source="jmeter_csv",
             sources=["manual_number", "jmeter_csv", "jmeter_json", "performancetest_runner"],
             tags=[Tag.PERFORMANCE],
         ),

--- a/components/server/src/data_model/sources/jmeter.py
+++ b/components/server/src/data_model/sources/jmeter.py
@@ -11,7 +11,8 @@ from ..parameters import (
 )
 
 
-ALL_JMETER_METRICS = ["slow_transactions", "tests"]
+TRANSACTION_METRICS = ["slow_transactions", "tests"]
+ALL_JMETER_METRICS = TRANSACTION_METRICS + ["performancetest_duration"]
 
 JMETER_URL = "https://jmeter.apache.org"
 
@@ -24,7 +25,7 @@ TRANSACTIONS_TO_IGNORE = MultipleChoiceWithAdditionParameter(
     name="Transactions to ignore (regular expressions or transaction names)",
     short_name="transactions to ignore",
     help="Transactions to ignore can be specified by transaction name or by regular expression.",
-    metrics=ALL_JMETER_METRICS,
+    metrics=TRANSACTION_METRICS,
 )
 
 TRANSACTIONS_TO_INCLUDE = MultipleChoiceWithAdditionParameter(
@@ -32,7 +33,7 @@ TRANSACTIONS_TO_INCLUDE = MultipleChoiceWithAdditionParameter(
     short_name="transactions to include",
     help="Transactions to include can be specified by transaction name or by regular expression.",
     placeholder="all",
-    metrics=ALL_JMETER_METRICS,
+    metrics=TRANSACTION_METRICS,
 )
 
 TARGET_RESPONSE_TIME = IntegerParameter(
@@ -119,7 +120,7 @@ JMETER_JSON = Source(
         transaction_specific_target_response_times=TRANSACTION_SPECIFIC_TARGET_RESPONSE_TIMES,
         transactions_to_ignore=TRANSACTIONS_TO_IGNORE,
         transactions_to_include=TRANSACTIONS_TO_INCLUDE,
-        **access_parameters(ALL_JMETER_METRICS, source_type="JMeter report", source_type_format="JSON")
+        **access_parameters(TRANSACTION_METRICS, source_type="JMeter report", source_type_format="JSON")
     ),
     entities=ENTITIES,
 )

--- a/components/server/src/data_model/sources/performancetest_runner.py
+++ b/components/server/src/data_model/sources/performancetest_runner.py
@@ -10,13 +10,12 @@ from ..parameters import (
 )
 
 
-ALL_PERFORMANCETEST_RUNNER_METRICS = [
+TRANSACTION_METRICS = ["slow_transactions", "tests"]
+ALL_PERFORMANCETEST_RUNNER_METRICS = TRANSACTION_METRICS + [
     "performancetest_duration",
     "performancetest_stability",
     "scalability",
-    "slow_transactions",
     "source_up_to_dateness",
-    "tests",
 ]
 
 PERFORMANCETEST_RUNNER = Source(
@@ -37,14 +36,14 @@ PERFORMANCETEST_RUNNER = Source(
             name="Transactions to ignore (regular expressions or transaction names)",
             short_name="transactions to ignore",
             help="Transactions to ignore can be specified by transaction name or by regular expression.",
-            metrics=["slow_transactions", "tests"],
+            metrics=TRANSACTION_METRICS,
         ),
         transactions_to_include=MultipleChoiceWithAdditionParameter(
             name="Transactions to include (regular expressions or transaction names)",
             short_name="transactions to include",
             help="Transactions to include can be specified by transaction name or by regular expression.",
             placeholder="all",
-            metrics=["slow_transactions", "tests"],
+            metrics=TRANSACTION_METRICS,
         ),
         **access_parameters(
             ALL_PERFORMANCETEST_RUNNER_METRICS,

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
-## v3.30.0-rc.2 - 2021-12-09
+## [Unreleased]
 
 ### Fixed
 
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
-- Support JMeter CSV output as source for the 'slow transactions' and 'tests' metrics. Closes [#2966](https://github.com/ICTU/quality-time/issues/2966) and [#2967](https://github.com/ICTU/quality-time/issues/2967).
+- Support JMeter CSV output as source for the 'performance test duration', 'slow transactions' and 'tests' metrics. Closes [#2965](https://github.com/ICTU/quality-time/issues/2965), [#2966](https://github.com/ICTU/quality-time/issues/2966) and [#2967](https://github.com/ICTU/quality-time/issues/2967).
 
 ## v3.29.0 - 2021-12-03
 


### PR DESCRIPTION
Closes #2965.