### PR TITLE
Make #<metric_id> scroll correctly to the metric 

### DIFF
--- a/components/frontend/src/App.css
+++ b/components/frontend/src/App.css
@@ -10,3 +10,7 @@
         margin-top: 0em;
     }
 }
+
+html {
+    scroll-padding-top: 70px; /* height of sticky header */
+}


### PR DESCRIPTION
In other words, prevent the target metric from being overlapped by the menu bar. Partially addresses #2925. 