### PR TITLE
OWASP ZAP uses a non-standard versioning scheme for its weekly versions, be prepared

### DIFF
--- a/components/collector/src/source_collectors/owasp_zap/source_version.py
+++ b/components/collector/src/source_collectors/owasp_zap/source_version.py
@@ -12,4 +12,7 @@ class OWASPZAPSourceVersion(XMLFileSourceCollector, SourceVersionCollector):
 
     async def _parse_source_response_version(self, response: Response) -> Version:
         """Override to parse the version from the XML."""
-        return Version((await parse_source_response_xml(response)).get("version") or "0")
+        version_text = (await parse_source_response_xml(response)).get("version") or "0"
+        if version_text.startswith("D-"):
+            version_text = version_text.removeprefix("D-").replace("-", ".")
+        return Version(version_text)

--- a/components/collector/tests/source_collectors/owasp_zap/test_source_version.py
+++ b/components/collector/tests/source_collectors/owasp_zap/test_source_version.py
@@ -13,3 +13,9 @@ class OWASPZAPSourceVersionTest(OWASPZAPTestCase):
         xml = """<?xml version="1.0"?><OWASPZAPReport version="2.7.0"></OWASPZAPReport>"""
         response = await self.collect(get_request_text=xml)
         self.assert_measurement(response, value="2.7.0")
+
+    async def test_source_version_zap_weekly(self):
+        """Test that the source version is returned."""
+        xml = """<?xml version="1.0"?><OWASPZAPReport version="D-2022-01-01"></OWASPZAPReport>"""
+        response = await self.collect(get_request_text=xml)
+        self.assert_measurement(response, value="2022.1.1")

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,11 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
-## v3.31.0-rc.3 - 2022-01-01
+## [Unreleased]
+
+### Fixed
+
+- OWASP ZAP uses a non-standard versioning scheme (D-<year>-<month>-<day>) for its weekly versions, be prepared. Fixes [#3117](https://github.com/ICTU/quality-time/issues/3117).
 
 ### Added
 
-- Allow for adding comments to the report overview, to reports and to subjects. Expand the title of the report overwiew, report, or subject to enter comments. Entered comments are shown below the title of the report overview, report, or subject. Simple HTML (headers, bold, italic, links, etc.) is allowed. Closes [#2926](https://github.com/ICTU/quality-time/issues/2926).
+- Allow for adding comments to the report overview, to reports and to subjects. Expand the title of the report overview, report, or subject to enter comments. Entered comments are shown below the title of the report overview, report, or subject. Simple HTML (headers, bold, italic, links, etc.) is allowed. Closes [#2926](https://github.com/ICTU/quality-time/issues/2926).
 - Explain in the [documentation](https://quality-time.readthedocs.io/en/latest/usage.html#via-the-api) how to include the correct report URL in the footer when exporting reports to PDF via the API. Closes [#2954](https://github.com/ICTU/quality-time/issues/2954).
 - In addition to the 90th percentile, also allow for evaluating the 95th and 99th percentile transaction response time when using JMeter CSV or JSON as source for the 'slow transactions' metric. Closes [#3084](https://github.com/ICTU/quality-time/issues/3084).
 - Add support for Gatling as source for the 'slow transactions', 'tests', 'performancetest duration', 'source up-to-dateness', and 'source version' metrics. Closes [#3085](https://github.com/ICTU/quality-time/issues/3085), [#3086](https://github.com/ICTU/quality-time/issues/3086), [#3087](https://github.com/ICTU/quality-time/issues/3087), [#3088](https://github.com/ICTU/quality-time/issues/3088), and [#3089](https://github.com/ICTU/quality-time/issues/3089).

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
-- OWASP ZAP uses a non-standard versioning scheme (D-<year>-<month>-<day>) for its weekly versions, be prepared. Fixes [#3117](https://github.com/ICTU/quality-time/issues/3117).
+- OWASP ZAP uses a non-standard versioning scheme (D-year-month-day) for its weekly versions, be prepared. Fixes [#3117](https://github.com/ICTU/quality-time/issues/3117).
 
 ### Added
 


### PR DESCRIPTION
 Fixes #3117.