### PR TITLE
When sorting metrics by status, order by how urgent action is require…

### DIFF
--- a/components/frontend/src/subject/SubjectDetails.js
+++ b/components/frontend/src/subject/SubjectDetails.js
@@ -68,7 +68,7 @@ function SubjectTableHeader({ hiddenColumns, toggleHiddenColumn, sortColumn, sor
 }
 
 function sortMetrics(datamodel, metrics, sortDirection, sortColumn) {
-    const status_order = { "": "0", target_not_met: "1", debt_target_met: "2", near_target_met: "3", target_met: "4" };
+    const status_order = { "": "0", target_not_met: "1", near_target_met: "2", debt_target_met: "3", target_met: "4" };
     const sorters = {
         name: (m1, m2) => {
             const attribute1 = get_metric_name(m1[1], datamodel);

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,13 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
-## v3.31.0-rc.5 - 2022-01-06
+## [Unreleased]
 
 ### Fixed
 
 - The dropdown menu for determining the scope of parameter changes (Apply change to source/metric/etc.) would not appear when clicking the "Apply change to" part of the label. Fixes [#3112](https://github.com/ICTU/quality-time/issues/3112).
 - OWASP ZAP uses a non-standard versioning scheme (D-year-month-day) for its weekly versions, be prepared. Fixes [#3117](https://github.com/ICTU/quality-time/issues/3117).
 - Show a more informative error message if no merge request information can be retrieved from GitLab for the 'merge requests' metric. Fixes [#3166](https://github.com/ICTU/quality-time/issues/3166).
+- When sorting metrics by status, order by how urgent action is required: 'unknown' (white), 'target not met' (red), 'near target met' (yellow), 'technical debt accepted' (grey), 'target met' (green). Fixes [#3184](https://github.com/ICTU/quality-time/issues/3184).
 
 ### Changed
 


### PR DESCRIPTION
…d: 'unknown' (white), 'target not met' (red), 'near target met' (yellow), 'technical debt accepted' (grey), 'target met' (green). Fixes #3184.