### PR TITLE
If a metric did not have sources (with all mandatory parameters configured), the status of issues would not be collected

### DIFF
--- a/components/collector/tests/base_collectors/test_collector.py
+++ b/components/collector/tests/base_collectors/test_collector.py
@@ -116,18 +116,9 @@ class CollectorTest(unittest.IsolatedAsyncioTestCase):
             json=dict(has_error=False, sources=[self._source()], metric_uuid="metric_uuid", report_uuid="report_uuid"),
         )
 
-    async def test_fetch_with_empty_sources(self):
-        """Test fetching measurement for a metric with empty sources dict."""
-        metrics = dict(metric_uuid=dict(type="metric", addition="sum", sources={}))
-        mock_async_get_request = AsyncMock()
-        mock_async_get_request.json.return_value = metrics
-        with self._patched_post() as post:
-            await self._fetch_measurements(mock_async_get_request)
-        post.assert_not_called()
-
     async def test_fetch_without_sources(self):
         """Test fetching measurement for a metric without sources."""
-        metrics = dict(metric_uuid=dict(type="metric", addition="sum"))
+        metrics = dict(metric_uuid=dict(type="metric", addition="sum", sources={}))
         mock_async_get_request = AsyncMock()
         mock_async_get_request.json.return_value = metrics
         with self._patched_post() as post:

--- a/components/collector/tests/metric_collectors/test_test_cases.py
+++ b/components/collector/tests/metric_collectors/test_test_cases.py
@@ -91,14 +91,14 @@ class TestCasesTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_no_test_report(self):
         """Test missing test report."""
-        measurement = await self.collect(dict(jira=dict(type="jira", parameters=dict(url=self.jira_url))))
+        measurement = await self.collect(dict(jira=dict(type="jira", parameters=dict(url=self.jira_url, jql="jql"))))
         self.assertDictEqual(self.jira_entity(), measurement.sources[0].entities[0])
         self.assertEqual("2", measurement.sources[0].value)
 
     async def test_matching_test_case_testng(self):
         """Test one matching test case."""
         self.response.text = AsyncMock(return_value=self.TESTNG_XML)
-        jira = dict(type="jira", parameters=dict(url=self.jira_url))
+        jira = dict(type="jira", parameters=dict(url=self.jira_url, jql="jql"))
         testng = dict(type="testng", parameters=dict(url=self.test_report_url))
         measurement = await self.collect(dict(jira=jira, testng=testng))
         self.assertListEqual(
@@ -110,7 +110,7 @@ class TestCasesTest(unittest.IsolatedAsyncioTestCase):
     async def test_matching_test_case_junit(self):
         """Test one matching test case."""
         self.response.text = AsyncMock(return_value=self.JUNIT_XML)
-        jira = dict(type="jira", parameters=dict(url=self.jira_url))
+        jira = dict(type="jira", parameters=dict(url=self.jira_url, jql="jql"))
         junit = dict(type="junit", parameters=dict(url=self.test_report_url))
         measurement = await self.collect(dict(jira=jira, junit=junit))
         self.assertListEqual(
@@ -122,7 +122,7 @@ class TestCasesTest(unittest.IsolatedAsyncioTestCase):
     async def test_matching_test_case_robot_framework(self):
         """Test one matching test case."""
         self.response.text = AsyncMock(return_value=self.ROBOT_FRAMEWORK_XML_V4)
-        jira = dict(type="jira", parameters=dict(url=self.jira_url))
+        jira = dict(type="jira", parameters=dict(url=self.jira_url, jql="jql"))
         robot_framework = dict(type="robot_framework", parameters=dict(url=self.test_report_url))
         measurement = await self.collect(dict(jira=jira, robot_framework=robot_framework))
         self.assertListEqual(
@@ -146,7 +146,7 @@ class TestCasesTest(unittest.IsolatedAsyncioTestCase):
             ],
         )
         self.response.json = AsyncMock(side_effect=[[], jenkins_json, self.test_cases_json, self.test_cases_json])
-        jira = dict(type="jira", parameters=dict(url=self.jira_url))
+        jira = dict(type="jira", parameters=dict(url=self.jira_url, jql="jql"))
         jenkins_test_report = dict(type="jenkins_test_report", parameters=dict(url=self.test_report_url))
         measurement = await self.collect(dict(jira=jira, jenkins_test_report=jenkins_test_report))
         self.assertListEqual(
@@ -158,7 +158,7 @@ class TestCasesTest(unittest.IsolatedAsyncioTestCase):
     async def test_filter_by_test_result(self):
         """Test that test cases can be filtered by test result."""
         self.response.text = AsyncMock(return_value=self.TESTNG_XML)
-        jira = dict(type="jira", parameters=dict(url=self.jira_url, test_result=["untested"]))
+        jira = dict(type="jira", parameters=dict(url=self.jira_url, jql="jql", test_result=["untested"]))
         testng = dict(type="testng", parameters=dict(url=self.test_report_url))
         measurement = await self.collect(dict(jira=jira, testng=testng))
         self.assertListEqual([self.jira_entity("key-2")], measurement.sources[0].entities)

--- a/components/collector/tests/source_collectors/azure_devops/base.py
+++ b/components/collector/tests/source_collectors/azure_devops/base.py
@@ -14,6 +14,7 @@ class AzureDevopsTestCase(SourceCollectorTestCase):  # skipcq: PTC-W0046
         self.url = "https://azure_devops/org/project"
         self.work_item_url = "https://work_item"
         self.set_source_parameter("url", self.url)
+        self.set_source_parameter("wiql", "wiql")
         self.work_item = dict(
             id="id",
             url=self.work_item_url,

--- a/components/collector/tests/source_collectors/cxsast/base.py
+++ b/components/collector/tests/source_collectors/cxsast/base.py
@@ -12,3 +12,5 @@ class CxSASTTestCase(SourceCollectorTestCase):  # skipcq: PTC-W0046
         """Extend to add a CxSAST source fixture."""
         super().setUp()
         self.set_source_parameter("project", "project")
+        self.set_source_parameter("username", "username")
+        self.set_source_parameter("password", "password")

--- a/components/collector/tests/source_collectors/jira/base.py
+++ b/components/collector/tests/source_collectors/jira/base.py
@@ -12,6 +12,7 @@ class JiraTestCase(SourceCollectorTestCase):  # skipcq: PTC-W0046
         """Extend to create sources and a metric of type METRIC_TYPE."""
         super().setUp()
         self.url = "https://jira"
+        self.set_source_parameter("jql", "project = abc")
         self.set_source_parameter("story_points_field", "field")
         self.set_source_parameter("manual_test_execution_frequency_field", "desired_test_frequency")
         self.set_source_parameter("manual_test_duration_field", "field")

--- a/components/server/src/shared/model/measurement.py
+++ b/components/server/src/shared/model/measurement.py
@@ -233,9 +233,8 @@ class Measurement(dict):  # lgtm [py/missing-equals]
         return bool(sources) and not any(source["parse_error"] or source["connection_error"] for source in sources)
 
     def sources_exist(self) -> bool:
-        """Return whether the measurement has sources and they exist in the metric."""
-        sources = self.sources()
-        return bool(sources) and all(source["source_uuid"] in self.metric.sources() for source in sources)
+        """Return whether all measurement sources exist in the metric."""
+        return all(source["source_uuid"] in self.metric.sources() for source in self.sources())
 
     def sources(self) -> Sequence[Source]:
         """Return the measurement's sources."""

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
-- If a metric did not have sources (with all mandatory parameters configured), the status of issues would not be collected. Fixes [#3321](https://github.com/ICTU/quality-time/issues/3321).
+- If a metric did not have sources (with all mandatory parameters configured), the status of issues would not be collected. Fixes [#3221](https://github.com/ICTU/quality-time/issues/3221).
 
 ## v3.31.0 - 2022-01-13
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- If a metric did not have sources (with all mandatory parameters configured), the status of issues would not be collected. Fixes [#3321](https://github.com/ICTU/quality-time/issues/3321).
+
 ## v3.31.0 - 2022-01-13
 
 ### Fixed


### PR DESCRIPTION
Fixes #3221.