### PR TITLE
Show the key of OWASP Dependency Check security warnings 

### DIFF
--- a/components/collector/src/source_collectors/owasp_dependency_check/dependencies.py
+++ b/components/collector/src/source_collectors/owasp_dependency_check/dependencies.py
@@ -36,13 +36,20 @@ class OWASPDependencyCheckDependencies(OWASPDependencyCheckBase):
     ) -> Entity:
         """Parse the entity from the dependency."""
         file_path = dependency.findtext("ns:filePath", default="", namespaces=namespaces)
+        stable_file_path = self.__stable_file_path(file_path.strip())
         file_name = dependency.findtext("ns:fileName", default="", namespaces=namespaces)
         sha1 = dependency.findtext("ns:sha1", namespaces=namespaces)
         # We can only generate an entity landing url if a sha1 is present in the XML, but unfortunately not all
         # dependencies have one, so check for it:
         entity_landing_url = f"{landing_url}#l{dependency_index + 1}_{sha1}" if sha1 else ""
-        key = sha1 if sha1 else sha1_hash(self.__stable_file_path(file_path) + file_name)
-        return Entity(key=key, file_path=file_path, file_name=file_name, url=entity_landing_url)
+        key = sha1 if sha1 else sha1_hash(stable_file_path + file_name)
+        return Entity(
+            key=key,
+            file_path=file_path,
+            file_path_after_regexp=stable_file_path,
+            file_name=file_name,
+            url=entity_landing_url,
+        )
 
     def __stable_file_path(self, file_path: str) -> str:
         """Return a stable file path by excluding variable parts specified by the user."""

--- a/components/collector/tests/source_collectors/owasp_dependency_check/test_dependencies.py
+++ b/components/collector/tests/source_collectors/owasp_dependency_check/test_dependencies.py
@@ -19,6 +19,7 @@ class OWASPDependencyCheckDependenciesTest(OWASPDependencyCheckTestCase):
                 url="https://owasp_dependency_check#l1_12345",
                 file_name=self.file_name,
                 file_path=self.file_path,
+                file_path_after_regexp=self.file_path,
             )
         ]
         self.assert_measurement(response, value="1", entities=expected_entities)
@@ -27,12 +28,14 @@ class OWASPDependencyCheckDependenciesTest(OWASPDependencyCheckTestCase):
         """Test that parts of the file path can be ignored, if the secrity warning has no sha1."""
         self.set_source_parameter("variable_file_path_regexp", ["/home/[a-z]+/"])
         response = await self.collect(get_request_text=self.xml.replace("<sha1>12345</sha1>", ""))
+        file_path_after_regexp = self.file_path[len("/home/jenkins/") :]
         expected_entities = [
             dict(
-                key=sha1_hash(self.file_path[len("/home/jenkins/") :] + self.file_name),
+                key=sha1_hash(file_path_after_regexp + self.file_name),
                 url="",
                 file_name=self.file_name,
                 file_path=self.file_path,
+                file_path_after_regexp=file_path_after_regexp,
             )
         ]
         self.assert_measurement(response, value="1", entities=expected_entities)

--- a/components/collector/tests/source_collectors/owasp_dependency_check/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/owasp_dependency_check/test_security_warnings.py
@@ -21,6 +21,7 @@ class OWASPDependencyCheckSecurityWarningsTest(OWASPDependencyCheckTestCase):
                 nr_vulnerabilities="2",
                 file_name=self.file_name,
                 file_path=self.file_path,
+                file_path_after_regexp=self.file_path,
             )
         ]
         self.assert_measurement(response, value="1", entities=expected_entities)
@@ -51,6 +52,7 @@ class OWASPDependencyCheckSecurityWarningsTest(OWASPDependencyCheckTestCase):
                 nr_vulnerabilities="1",
                 file_name=self.file_name,
                 file_path=self.file_path,
+                file_path_after_regexp=self.file_path,
             )
         ]
         self.assert_measurement(response, value="1", entities=expected_entities)
@@ -83,6 +85,7 @@ class OWASPDependencyCheckSecurityWarningsTest(OWASPDependencyCheckTestCase):
                 </dependency>
             </analysis>"""
         response = await self.collect(get_request_text=xml)
+        expected_file_path = "packages.config"
         expected_entities = [
             dict(
                 key="498ac4bf0c766490ad58cd04a71e07a439b97fc8",
@@ -90,7 +93,8 @@ class OWASPDependencyCheckSecurityWarningsTest(OWASPDependencyCheckTestCase):
                 file_name="CuttingEdge.Conditions:1.2.0.0",
                 highest_severity="Low",
                 nr_vulnerabilities="1",
-                file_path="packages.config",
+                file_path=expected_file_path,
+                file_path_after_regexp=expected_file_path,
             ),
             dict(
                 key="7f5f471406d316dfeb580de2738db563f3c7ac97",
@@ -98,7 +102,8 @@ class OWASPDependencyCheckSecurityWarningsTest(OWASPDependencyCheckTestCase):
                 file_name="IdentityModel:1.13.1",
                 highest_severity="Low",
                 nr_vulnerabilities="1",
-                file_path="packages.config",
+                file_path=expected_file_path,
+                file_path_after_regexp=expected_file_path,
             ),
         ]
         self.assert_measurement(response, value="2", entities=expected_entities)

--- a/components/frontend/src/source/SourceEntityAttribute.js
+++ b/components/frontend/src/source/SourceEntityAttribute.js
@@ -11,6 +11,6 @@ export function SourceEntityAttribute({ entity, entity_attribute }) {
     cell_contents = cell_contents && entity_attribute.type === "minutes" ? format_minutes(cell_contents) : cell_contents;
     cell_contents = cell_contents && entity_attribute.type === "status" ? <StatusIcon status={cell_contents} /> : cell_contents;
     cell_contents = entity[entity_attribute.url] ? <HyperLink url={entity[entity_attribute.url]}>{cell_contents}</HyperLink> : cell_contents;
-    cell_contents = entity_attribute.pre ? <pre data-testid="pre-wrapped" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{cell_contents}</pre> : cell_contents;
+    cell_contents = entity_attribute.pre ? <pre data-testid="pre-wrapped" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{cell_contents}</pre> : <div style={{wordBreak: 'break-word'}}>{cell_contents}</div>;
     return (cell_contents);
 }

--- a/components/server/src/external/data_model/sources/owasp_dependency_check.py
+++ b/components/server/src/external/data_model/sources/owasp_dependency_check.py
@@ -12,7 +12,11 @@ ALL_OWASP_DEPENDENCY_CHECK_METRICS = [
     "source_version",
 ]
 
-DEPENDENCY_ATTRIBUTES: list[object] = [dict(name="File path", url="url"), dict(name="File name")]
+DEPENDENCY_ATTRIBUTES: list[object] = [
+    dict(name="File path", url="url"),
+    dict(name="File path after applying regular expreassion", key="file_path_after_regexp"),
+    dict(name="File name"),
+]
 SECURITY_WARNING_ATTRIBUTES = [
     dict(name="Highest severity", color=dict(Critical=Color.NEGATIVE, High=Color.NEGATIVE, Medium=Color.WARNING)),
     dict(name="Number of vulnerabilities", key="nr_vulnerabilities", type=EntityAttributeType.INTEGER),

--- a/components/server/src/external/data_model/sources/owasp_dependency_check.py
+++ b/components/server/src/external/data_model/sources/owasp_dependency_check.py
@@ -14,7 +14,7 @@ ALL_OWASP_DEPENDENCY_CHECK_METRICS = [
 
 DEPENDENCY_ATTRIBUTES: list[object] = [
     dict(name="File path", url="url"),
-    dict(name="File path after applying regular expreassion", key="file_path_after_regexp"),
+    dict(name="File path after applying regular expressions", key="file_path_after_regexp"),
     dict(name="File name"),
 ]
 SECURITY_WARNING_ATTRIBUTES = [

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - Add a menu item to the settings panel to collapse all expanded metrics at once. Closes [#3133](https://github.com/ICTU/quality-time/issues/3133).
 - Allow for zooming (by scrolling) and panning (by dragging) trend graphs. Closes [#3246](https://github.com/ICTU/quality-time/issues/3246).
-- Show the key of OWASP Dependency Check security warnings in the measurement entity details to allow for verification of the regular expression used to remove variable parts from file paths. Closes [#3259](https://github.com/ICTU/quality-time/issues/3259).
+- Show the key of OWASP Dependency Check security warnings in the measurement entity details to allow for verification of the regular expressions used to remove variable parts from file paths. Closes [#3259](https://github.com/ICTU/quality-time/issues/3259).
 
 ## v3.31.0 - 2022-01-13
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,12 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
-## v3.32.0-rc.5 - 2022-01-23
+## [Unreleased]
 
 ### Fixed
 
 - If a metric did not have sources (with all mandatory parameters configured), the status of issues would not be collected. Fixes [#3221](https://github.com/ICTU/quality-time/issues/3221).
 - Allow for specifying zip files as Gatling source. Fixes [#3226](https://github.com/ICTU/quality-time/issues/3226).
+- Remove spaces from file paths in OWASP Dependency Check security warnings before applying the regular expressions to remove variable parts from the file paths. Unfortunately, this may change the key of some OWASP Dependency Check security warnings, causing the status (false positive, won't fix, etc.) of the warning in *Quality-time* to be lost. Fixed as part of [#3259](https://github.com/ICTU/quality-time/issues/3259).
 
 ### Changed
 
@@ -25,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - Add a menu item to the settings panel to collapse all expanded metrics at once. Closes [#3133](https://github.com/ICTU/quality-time/issues/3133).
 - Allow for zooming (by scrolling) and panning (by dragging) trend graphs. Closes [#3246](https://github.com/ICTU/quality-time/issues/3246).
+- Show the key of OWASP Dependency Check security warnings in the measurement entity details to allow for verification of the regular expression used to remove variable parts from file paths. Closes [#3259](https://github.com/ICTU/quality-time/issues/3259).
 
 ## v3.31.0 - 2022-01-13
 


### PR DESCRIPTION
...in the measurement entity details to allow for verification of the regular expression used to remove variable parts from file paths. Closes #3259.