### PR TITLE
Replace semantic-ui.css with fomantic-ui.css

### DIFF
--- a/components/frontend/package-lock.json
+++ b/components/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "quality-time-app",
       "version": "3.32.0",
       "dependencies": {
+        "fomantic-ui-css": "^2.8.8",
         "history": "^5.2.0",
         "md5": "^2.3.0",
         "react": "^17.0.2",
@@ -18,7 +19,6 @@
         "react-timeago": "^6.2.1",
         "react-toastify": "^8.1.0",
         "semantic-ui-calendar-react-17": "^0.16.1",
-        "semantic-ui-css": "^2.4.1",
         "semantic-ui-react": "^2.1.0",
         "victory": "^36.2.0"
       },
@@ -9341,6 +9341,14 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fomantic-ui-css": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/fomantic-ui-css/-/fomantic-ui-css-2.8.8.tgz",
+      "integrity": "sha512-mVzOha6ApNT0yolKHTt5MHla1aR7w8EKkk/B6FLaa8Bia48qhO1MDFKZriT93eS1RHOZzrN42GcNpT/mH6qMVA==",
+      "dependencies": {
+        "jquery": "^3.4.0"
       }
     },
     "node_modules/for-in": {
@@ -19025,14 +19033,6 @@
         "react": "^16.8.0 || ^17.0.2",
         "react-dom": "^16.8.0 || ^17.0.2",
         "semantic-ui-react": "^2.0.3"
-      }
-    },
-    "node_modules/semantic-ui-css": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.4.1.tgz",
-      "integrity": "sha512-Pkp0p9oWOxlH0kODx7qFpIRYpK1T4WJOO4lNnpNPOoWKCrYsfHqYSKgk5fHfQtnWnsAKy7nLJMW02bgDWWFZFg==",
-      "dependencies": {
-        "jquery": "x.*"
       }
     },
     "node_modules/semantic-ui-react": {
@@ -31745,6 +31745,14 @@
       "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "dev": true
     },
+    "fomantic-ui-css": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/fomantic-ui-css/-/fomantic-ui-css-2.8.8.tgz",
+      "integrity": "sha512-mVzOha6ApNT0yolKHTt5MHla1aR7w8EKkk/B6FLaa8Bia48qhO1MDFKZriT93eS1RHOZzrN42GcNpT/mH6qMVA==",
+      "requires": {
+        "jquery": "^3.4.0"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -39737,14 +39745,6 @@
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
         "prop-types": "^15.7.2"
-      }
-    },
-    "semantic-ui-css": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.4.1.tgz",
-      "integrity": "sha512-Pkp0p9oWOxlH0kODx7qFpIRYpK1T4WJOO4lNnpNPOoWKCrYsfHqYSKgk5fHfQtnWnsAKy7nLJMW02bgDWWFZFg==",
-      "requires": {
-        "jquery": "x.*"
       }
     },
     "semantic-ui-react": {

--- a/components/frontend/package.json
+++ b/components/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "proxy": "http://localhost:5001",
   "dependencies": {
+    "fomantic-ui-css": "^2.8.8",
     "history": "^5.2.0",
     "md5": "^2.3.0",
     "react": "^17.0.2",
@@ -14,7 +15,6 @@
     "react-timeago": "^6.2.1",
     "react-toastify": "^8.1.0",
     "semantic-ui-calendar-react-17": "^0.16.1",
-    "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^2.1.0",
     "victory": "^36.2.0"
   },

--- a/components/frontend/src/index.js
+++ b/components/frontend/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import 'semantic-ui-css/semantic.min.css'
+import 'fomantic-ui-css/semantic.min.css'
 import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
 import App from './App';


### PR DESCRIPTION
It's a drop-in replacement that hopefully works around the issue in semantic-ui.css that prevents upgrading to CRA v5.