### PR TITLE
Subject subtitles would partly obscure the header of their subject's metrics table

### DIFF
--- a/components/frontend/src/subject/SubjectTable.css
+++ b/components/frontend/src/subject/SubjectTable.css
@@ -1,7 +1,16 @@
-.ui.sortable.table.stickyHeader > thead > tr > th {
+.ui.sortable.table.stickyHeader > thead {
     position: sticky;  /* Make thead sticky by positioning the th's */
     top: 129px;  /* Leave room for the menu bar and the subject title */
     z-index: 1;
+}
+
+.ui.sortable.table.stickyHeader.subjectHasSubTitle > thead {
+    position: sticky;  /* Make thead sticky by positioning the th's */
+    top: 142px;  /* Leave room for the menu bar, the subject title, and the subtitle */
+    z-index: 1;
+}
+
+.ui.sortable.table.stickyHeader > thead > tr > th {
     border-top: 1px solid rgba(34,36,38,.15);  /* Apply the top table border to the th as the table border scrolls out of view */
 }
 

--- a/components/frontend/src/subject/SubjectTable.js
+++ b/components/frontend/src/subject/SubjectTable.js
@@ -41,9 +41,9 @@ export function SubjectTable({
 
     const dates = getColumnDates(reportDate, dateInterval, dateOrder, nrDates)
     const last_index = Object.entries(subject.metrics).length - 1;
-
+    const className = "stickyHeader" + (subject.subtitle ? " subjectHasSubTitle" : "")
     return (
-        <Table sortable className="stickyHeader" style={{marginTop: "0px"}}>
+        <Table sortable className={className} style={{marginTop: "0px"}}>
             <SubjectTableHeader
                 columnDates={dates}
                 handleSort={handleSort}

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Fixed
+
+- Subject subtitles would partly obscure the header of their subject's metrics table. Fixes [#3443](https://github.com/ICTU/quality-time/issues/3443).
+
 ### Added
 
 - Highlight metrics on hover to make it easier to indicate which metric is being discussed in online meetings. Closes [#3132](https://github.com/ICTU/quality-time/issues/3132).


### PR DESCRIPTION
Fixes #3443.