### PR TITLE
GitLab job artifacts archives downloaded via the GitLab API would not be recognized as zipped archives

### DIFF
--- a/components/collector/src/base_collectors/file_source_collector.py
+++ b/components/collector/src/base_collectors/file_source_collector.py
@@ -74,7 +74,11 @@ class FileSourceCollector(SourceCollector, ABC):  # pylint: disable=abstract-met
     @staticmethod
     def __is_zipped(url: URL, response: Response) -> bool:
         """Return whether the responses are zipped."""
-        return urlparse(str(url)).path.endswith(".zip") or response.content_type == "application/zip"
+        return (
+            urlparse(str(url)).path.endswith(".zip")
+            or response.content_type == "application/zip"
+            or ".zip" in str(response.content_disposition)
+        )
 
 
 class CSVFileSourceCollector(FileSourceCollector, ABC):  # pylint: disable=abstract-method

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 
 - Subject subtitles would partly obscure the header of their subject's metrics table. Fixes [#3443](https://github.com/ICTU/quality-time/issues/3443).
+- GitLab job artifacts archives downloaded via the GitLab API would not be recognized as zipped archives. Fixes [#3478](https://github.com/ICTU/quality-time/issues/3478).
 
 ### Added
 


### PR DESCRIPTION
Closes #3478.