### PR TITLE
GitLab uses non-standard version numbers like 14.5.2-ee; be prepared.

### DIFF
--- a/components/collector/src/source_collectors/gitlab/source_version.py
+++ b/components/collector/src/source_collectors/gitlab/source_version.py
@@ -1,6 +1,6 @@
 """GitLab source version collector."""
 
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 
 from base_collectors import SourceVersionCollector
 from collector_utilities.type import Response, URL
@@ -17,4 +17,8 @@ class GitLabSourceVersion(GitLabBase, SourceVersionCollector):
 
     async def _parse_source_response_version(self, response: Response) -> Version:
         """Override to return the GitLab version."""
-        return Version((await response.json())["version"])
+        version_string = (await response.json())["version"]
+        try:
+            return Version(version_string)
+        except InvalidVersion:
+            return Version(version_string.split("-")[0])

--- a/components/collector/tests/source_collectors/gitlab/test_source_version.py
+++ b/components/collector/tests/source_collectors/gitlab/test_source_version.py
@@ -12,3 +12,8 @@ class GitLabSourceVersionTest(GitLabTestCase):
         """Test that the GitLab version is returned."""
         response = await self.collect(get_request_json_return_value=dict(version="13.7.4"))
         self.assert_measurement(response, value="13.7.4")
+
+    async def test_ee_version(self):
+        """Test that the GitLab Enterprise Edition version is returned."""
+        response = await self.collect(get_request_json_return_value=dict(version="14.5.4-ee"))
+        self.assert_measurement(response, value="14.5.4")

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,12 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
-## v3.34.0-rc.6 - 2022-03-21
+## [Unreleased]
 
 ### Fixed
 
 - Subject subtitles would partly obscure the header of their subject's metrics table. Fixes [#3443](https://github.com/ICTU/quality-time/issues/3443).
 - GitLab job artifacts archives downloaded via the GitLab API would not be recognized as zipped archives. Fixes [#3478](https://github.com/ICTU/quality-time/issues/3478).
+- GitLab uses non-standard version numbers like "14.5.2-ee"; be prepared. Fixes [#3519](https://github.com/ICTU/quality-time/issues/3519).
 - Multiple choice fields such as fields for tags and issue identifiers would not save newly entered items on focus loss. Fixes [#3560](https://github.com/ICTU/quality-time/issues/3560).
 
 ### Added


### PR DESCRIPTION
Fixes #3519.