### PR TITLE
When using Gatling as source for the source version metric, the sourc…

### DIFF
--- a/components/collector/src/source_collectors/gatling/source_version.py
+++ b/components/collector/src/source_collectors/gatling/source_version.py
@@ -14,8 +14,11 @@ class GatlingSourceVersion(GatlingLogCollector, SourceVersionCollector):
     async def _parse_source_response_version(self, response: Response) -> Version:
         """Override to parse the version from the XML."""
         text = await response.text()
-        if lines := text.splitlines():
-            version_number_text = lines[0].strip().split()[-1]  # Version number is the last string on the first line
+        for line in text.splitlines():
+            words = line.strip().split()
+            if words[0] == "RUN":
+                version_number_text = words[-1]  # Version number is the last string on the line that starts with RUN
+                break
         else:
             version_number_text = "0"
         return Version(version_number_text)

--- a/components/collector/tests/source_collectors/gatling/base.py
+++ b/components/collector/tests/source_collectors/gatling/base.py
@@ -39,7 +39,8 @@ class GatlingTestCase(SourceCollectorTestCase):  # skipcq: PTC-W0046
             ),
         )
     )
-    GATLING_LOG = """RUN     api.CombinedSimulations combinedsimulations     1638907423554           3.3.1
+    GATLING_LOG = """ASSERTION AAECAAIBAAAAAAAAACRA
+    RUN     api.CombinedSimulations combinedsimulations     1638907423554           3.3.1
     USER    Get Token       1       START   1638907424543   1638907424543
     REQUEST 1               GetToken        1638907424608   1638907424842   OK
     USER    Get Token       1       END     1638907424543   1638907424919

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 
 - When using Axe CVS as source for the accessibility violations metric, the "nested-interactive" violation type would be ignored by *Quality-time*. Fixes [#3628](https://github.com/ICTU/quality-time/issues/3628).
+- When using Gatling as source for the source version metric, the source version would not be found, when the version number was not present on the first line of the simulation.log. Fixes [#3661](https://github.com/ICTU/quality-time/issues/3661).
 
 ### Removed
 


### PR DESCRIPTION
…e version would not be found, when the version number was not present on the first line of the simulation.log. Fixes #3661.