### PR TITLE
In the settings panel under the "Sort column" setting, clicking the s…

### DIFF
--- a/components/frontend/src/AppUI.js
+++ b/components/frontend/src/AppUI.js
@@ -99,6 +99,7 @@ export function AppUI({
                         clearVisibleDetailsTabs={clearVisibleDetailsTabs}
                         dateInterval={dateInterval}
                         dateOrder={dateOrder}
+                        handleSort={handleSort}
                         hiddenColumns={hiddenColumns}
                         hideMetricsNotRequiringAction={hideMetricsNotRequiringAction}
                         nrDates={nrDates}
@@ -109,8 +110,6 @@ export function AppUI({
                         setShowIssueCreationDate={setShowIssueCreationDate}
                         setShowIssueSummary={setShowIssueSummary}
                         setShowIssueUpdateDate={setShowIssueUpdateDate}
-                        setSortColumn={setSortColumn}
-                        setSortDirection={setSortDirection}
                         setUIMode={setUIMode}
                         showIssueCreationDate={showIssueCreationDate}
                         showIssueSummary={showIssueSummary}

--- a/components/frontend/src/header_footer/ViewPanel.js
+++ b/components/frontend/src/header_footer/ViewPanel.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button, Grid, Header, Menu, Segment } from 'semantic-ui-react';
-import { Popup } from '../semantic_ui_react_wrappers';
+import { Icon, Popup } from '../semantic_ui_react_wrappers';
 import { capitalize, pluralize } from "../utils";
 import './ViewPanel.css';
 
@@ -11,6 +11,7 @@ export function ViewPanel({
     clearVisibleDetailsTabs,
     dateInterval,
     dateOrder,
+    handleSort,
     hiddenColumns,
     hideMetricsNotRequiringAction,
     nrDates,
@@ -21,8 +22,6 @@ export function ViewPanel({
     setShowIssueCreationDate,
     setShowIssueSummary,
     setShowIssueUpdateDate,
-    setSortColumn,
-    setSortDirection,
     setUIMode,
     showIssueCreationDate,
     showIssueSummary,
@@ -35,7 +34,7 @@ export function ViewPanel({
 }) {
     const multipleDateColumns = nrDates > 1
     const oneDateColumn = nrDates === 1
-    const sortOrderNotChangeable = sortColumn === null || (multipleDateColumns && ["status", "measurement", "target"].includes(sortColumn))
+    hiddenColumns = hiddenColumns ?? [];
     return (
         <Segment.Group
             horizontal
@@ -76,14 +75,13 @@ export function ViewPanel({
                                     clearVisibleDetailsTabs();
                                     setHideMetricsNotRequiringAction(false);
                                     clearHiddenColumns();
+                                    handleSort(null);
                                     setNrDates(1);
                                     setDateInterval(7);
                                     setDateOrder("descending");
                                     setShowIssueCreationDate(false);
                                     setShowIssueSummary(false);
                                     setShowIssueUpdateDate(false);
-                                    setSortColumn(null);
-                                    setSortDirection("ascending");
                                     setUIMode(null);
                                 }}
                                 inverted
@@ -126,22 +124,15 @@ export function ViewPanel({
             <Segment inverted color="black">
                 <Header size="small">Sort column</Header>
                 <Menu vertical inverted size="small">
-                    <SortColumnMenuItem column="name" sortColumn={sortColumn} setSortColumn={setSortColumn} />
-                    <SortColumnMenuItem column="status" disabled={multipleDateColumns} sortColumn={sortColumn} setSortColumn={setSortColumn} />
-                    <SortColumnMenuItem column="measurement" disabled={multipleDateColumns} sortColumn={sortColumn} setSortColumn={setSortColumn} />
-                    <SortColumnMenuItem column="target" disabled={multipleDateColumns} sortColumn={sortColumn} setSortColumn={setSortColumn} />
-                    <SortColumnMenuItem column="unit" sortColumn={sortColumn} setSortColumn={setSortColumn} />
-                    <SortColumnMenuItem column="source" sortColumn={sortColumn} setSortColumn={setSortColumn} />
-                    <SortColumnMenuItem column="comment" sortColumn={sortColumn} setSortColumn={setSortColumn} />
-                    <SortColumnMenuItem column="issues" sortColumn={sortColumn} setSortColumn={setSortColumn} />
-                    <SortColumnMenuItem column="tags" sortColumn={sortColumn} setSortColumn={setSortColumn} />
-                </Menu>
-            </Segment>
-            <Segment inverted color="black">
-                <Header size='small'>Sort direction</Header>
-                <Menu vertical inverted size="small">
-                    <SortOrderMenuItem disabled={sortOrderNotChangeable} order="ascending" sortOrder={sortDirection} setSortOrder={setSortDirection} />
-                    <SortOrderMenuItem disabled={sortOrderNotChangeable} order="descending" sortOrder={sortDirection} setSortOrder={setSortDirection} />
+                    <SortColumnMenuItem column="name" sortColumn={sortColumn} sortDirection={sortDirection} handleSort={handleSort} />
+                    <SortColumnMenuItem column="status" disabled={multipleDateColumns || hiddenColumns.includes("status")} sortColumn={sortColumn} sortDirection={sortDirection} handleSort={handleSort} />
+                    <SortColumnMenuItem column="measurement" disabled={multipleDateColumns || hiddenColumns.includes("measurement")} sortColumn={sortColumn} sortDirection={sortDirection} handleSort={handleSort} />
+                    <SortColumnMenuItem column="target" disabled={multipleDateColumns || hiddenColumns.includes("target")} sortColumn={sortColumn} sortDirection={sortDirection} handleSort={handleSort} />
+                    <SortColumnMenuItem column="unit" disabled={hiddenColumns.includes("unit")} sortColumn={sortColumn} sortDirection={sortDirection} handleSort={handleSort} />
+                    <SortColumnMenuItem column="source" disabled={hiddenColumns.includes("source")} sortColumn={sortColumn} sortDirection={sortDirection} handleSort={handleSort} />
+                    <SortColumnMenuItem column="comment" disabled={hiddenColumns.includes("comment")} sortColumn={sortColumn} sortDirection={sortDirection} handleSort={handleSort} />
+                    <SortColumnMenuItem column="issues" disabled={hiddenColumns.includes("issues")} sortColumn={sortColumn} sortDirection={sortDirection} handleSort={handleSort} />
+                    <SortColumnMenuItem column="tags" disabled={hiddenColumns.includes("tags")} sortColumn={sortColumn} sortDirection={sortDirection} handleSort={handleSort} />
                 </Menu>
             </Segment>
             <Segment inverted color="black">
@@ -208,12 +199,18 @@ function VisibleColumnMenuItem({ column, disabled, hiddenColumns, toggleHiddenCo
     )
 }
 
-function SortColumnMenuItem({ column, disabled, sortColumn, setSortColumn }) {
-    const newColumn = sortColumn === column ? null : column
+function SortColumnMenuItem({ column, disabled, sortColumn, sortDirection, handleSort }) {
+    const active = disabled ? false : sortColumn === column;
+    let sortIndicator = null;
+    if (sortColumn == column && sortDirection) {
+        // We use a triangle because the sort down and up icons are not at the same height
+        const iconDirection = sortDirection === "ascending" ? "up" : "down"
+        sortIndicator = <Icon disabled={disabled} name={`triangle ${iconDirection}`} aria-label={`sort ${sortDirection}`} />
+    }
     return (
-        <div onKeyPress={(event) => { event.preventDefault(); setSortColumn(newColumn) }} tabIndex={0}>
-            <Menu.Item active={disabled ? false : sortColumn === column} color={activeColor} disabled={disabled} onClick={() => setSortColumn(newColumn)}>
-                {capitalize(column === "name" ? "metric" : column)}
+        <div onKeyPress={(event) => { event.preventDefault(); if (!disabled) { handleSort(column) } }} tabIndex={0}>
+            <Menu.Item active={active} color={activeColor} disabled={disabled} onClick={() => handleSort(column)}>
+                {capitalize(column === "name" ? "metric" : column)} <span>{sortIndicator}</span>
             </Menu.Item>
         </div>
     )

--- a/components/frontend/src/header_footer/ViewPanel.js
+++ b/components/frontend/src/header_footer/ViewPanel.js
@@ -205,7 +205,7 @@ function SortColumnMenuItem({ column, disabled, sortColumn, sortDirection, handl
     if (sortColumn === column && sortDirection) {
         // We use a triangle because the sort down and up icons are not at the same height
         const iconDirection = sortDirection === "ascending" ? "up" : "down"
-        sortIndicator = <Icon disabled={disabled} name={`triangle ${iconDirection}`} aria-label={`sort ${sortDirection}`} />
+        sortIndicator = <Icon disabled={disabled} name={`triangle ${iconDirection}`} aria-label={`sorted ${sortDirection}`} />
     }
     return (
         <div onKeyPress={(event) => { event.preventDefault(); if (!disabled) { handleSort(column) } }} tabIndex={0}>

--- a/components/frontend/src/header_footer/ViewPanel.js
+++ b/components/frontend/src/header_footer/ViewPanel.js
@@ -202,7 +202,7 @@ function VisibleColumnMenuItem({ column, disabled, hiddenColumns, toggleHiddenCo
 function SortColumnMenuItem({ column, disabled, sortColumn, sortDirection, handleSort }) {
     const active = disabled ? false : sortColumn === column;
     let sortIndicator = null;
-    if (sortColumn == column && sortDirection) {
+    if (sortColumn === column && sortDirection) {
         // We use a triangle because the sort down and up icons are not at the same height
         const iconDirection = sortDirection === "ascending" ? "up" : "down"
         sortIndicator = <Icon disabled={disabled} name={`triangle ${iconDirection}`} aria-label={`sort ${sortDirection}`} />

--- a/components/frontend/src/header_footer/ViewPanel.test.js
+++ b/components/frontend/src/header_footer/ViewPanel.test.js
@@ -196,6 +196,15 @@ it("sorts a column", async () => {
     expect(handleSort).toHaveBeenCalledWith("comment")
 })
 
+it("sorts a column descending", async () => {
+    const handleSort = jest.fn();
+    await act(async () => {
+        render(<ViewPanel sortColumn="comment" sortDirection="ascending" handleSort={handleSort} />)
+        fireEvent.click(screen.getAllByText(/Comment/)[1])
+    });
+    expect(handleSort).toHaveBeenCalledWith("comment")
+})
+
 it("sorts a column by keypress", async () => {
     const handleSort = jest.fn();
     await act(async () => {
@@ -203,6 +212,15 @@ it("sorts a column by keypress", async () => {
         await userEvent.type(screen.getAllByText(/Comment/)[1], "{Enter}")
     });
     expect(handleSort).toHaveBeenCalledWith("comment")
+})
+
+it("ignores a keypress if the menu item is disabled", async () => {
+    const handleSort = jest.fn();
+    await act(async () => {
+        render(<ViewPanel hiddenColumns={["comment"]} handleSort={handleSort} />)
+        await userEvent.type(screen.getAllByText(/Comment/)[1], "{Enter}")
+    });
+    expect(handleSort).not.toHaveBeenCalledWith("comment")
 })
 
 it("sets the number of dates", async () => {

--- a/components/frontend/src/header_footer/ViewPanel.test.js
+++ b/components/frontend/src/header_footer/ViewPanel.test.js
@@ -24,6 +24,7 @@ function eventHandlers() {
     return {
         clearHiddenColumns: jest.fn(),
         clearVisibleDetailsTabs: jest.fn(),
+        handleSort: jest.fn(),
         setDateInterval: jest.fn(),
         setDateOrder: jest.fn(),
         setHideMetricsNotRequiringAction: jest.fn(),
@@ -31,8 +32,6 @@ function eventHandlers() {
         setShowIssueCreationDate: jest.fn(),
         setShowIssueSummary: jest.fn(),
         setShowIssueUpdateDate: jest.fn(),
-        setSortColumn: jest.fn(),
-        setSortDirection: jest.fn(),
         setUIMode: jest.fn()
     }
 }
@@ -61,6 +60,7 @@ it('resets the settings', async () => {
     });
     expect(props.clearVisibleDetailsTabs).toHaveBeenCalled()
     expect(props.clearHiddenColumns).toHaveBeenCalled()
+    expect(props.handleSort).toHaveBeenCalled()
     expect(props.setDateInterval).toHaveBeenCalled()
     expect(props.setDateOrder).toHaveBeenCalled()
     expect(props.setNrDates).toHaveBeenCalled()
@@ -68,8 +68,6 @@ it('resets the settings', async () => {
     expect(props.setShowIssueCreationDate).toHaveBeenCalledWith(false)
     expect(props.setShowIssueSummary).toHaveBeenCalledWith(false)
     expect(props.setShowIssueUpdateDate).toHaveBeenCalledWith(false)
-    expect(props.setSortColumn).toHaveBeenCalledWith(null)
-    expect(props.setSortDirection).toHaveBeenCalledWith("ascending")
     expect(props.setUIMode).toHaveBeenCalledWith(null)
 })
 
@@ -97,6 +95,7 @@ it('does not reset the settings when all have the default value', async () => {
     });
     expect(props.clearVisibleDetailsTabs).not.toHaveBeenCalled()
     expect(props.clearHiddenColumns).not.toHaveBeenCalled()
+    expect(props.handleSort).not.toHaveBeenCalled()
     expect(props.setDateInterval).not.toHaveBeenCalled()
     expect(props.setDateOrder).not.toHaveBeenCalled()
     expect(props.setNrDates).not.toHaveBeenCalled()
@@ -104,8 +103,6 @@ it('does not reset the settings when all have the default value', async () => {
     expect(props.setShowIssueCreationDate).not.toHaveBeenCalled()
     expect(props.setShowIssueSummary).not.toHaveBeenCalled()
     expect(props.setShowIssueUpdateDate).not.toHaveBeenCalled()
-    expect(props.setSortColumn).not.toHaveBeenCalled()
-    expect(props.setSortDirection).not.toHaveBeenCalled()
     expect(props.setUIMode).not.toHaveBeenCalled()
 })
 
@@ -191,39 +188,21 @@ it("shows a column", async () => {
 })
 
 it("sorts a column", async () => {
-    const setSortColumn = jest.fn();
+    const handleSort = jest.fn();
     await act(async () => {
-        render(<ViewPanel setSortColumn={setSortColumn} />)
+        render(<ViewPanel handleSort={handleSort} />)
         fireEvent.click(screen.getAllByText(/Comment/)[1])
     });
-    expect(setSortColumn).toHaveBeenCalledWith("comment")
-})
-
-it("unsorts a column", async () => {
-    const setSortColumn = jest.fn();
-    await act(async () => {
-        render(<ViewPanel setSortColumn={setSortColumn} sortColumn="comment" />)
-        fireEvent.click(screen.getAllByText(/Comment/)[1])
-    });
-    expect(setSortColumn).toHaveBeenCalledWith(null)
+    expect(handleSort).toHaveBeenCalledWith("comment")
 })
 
 it("sorts a column by keypress", async () => {
-    const setSortColumn = jest.fn();
+    const handleSort = jest.fn();
     await act(async () => {
-        render(<ViewPanel setSortColumn={setSortColumn} />)
+        render(<ViewPanel handleSort={handleSort} />)
         await userEvent.type(screen.getAllByText(/Comment/)[1], "{Enter}")
     });
-    expect(setSortColumn).toHaveBeenCalledWith("comment")
-})
-
-it("unsorts a column by keypress", async () => {
-    const setSortColumn = jest.fn();
-    await act(async () => {
-        render(<ViewPanel setSortColumn={setSortColumn} sortColumn="comment" />)
-        await userEvent.type(screen.getAllByText(/Comment/)[1], "{Enter}")
-    });
-    expect(setSortColumn).toHaveBeenCalledWith(null)
+    expect(handleSort).toHaveBeenCalledWith("comment")
 })
 
 it("sets the number of dates", async () => {
@@ -275,7 +254,7 @@ it("sorts the dates descending", async () => {
     const setDateOrder = jest.fn();
     await act(async () => {
         render(<ViewPanel dateOrder="ascending" setDateOrder={setDateOrder} />)
-        fireEvent.click(screen.getAllByText(/Descending/)[1])
+        fireEvent.click(screen.getByText(/Descending/))
     });
     expect(setDateOrder).toHaveBeenCalledWith("descending")
 })
@@ -284,7 +263,7 @@ it("sorts the dates ascending by keypress", async () => {
     const setDateOrder = jest.fn();
     await act(async () => {
         render(<ViewPanel dateOrder="descending" setDateOrder={setDateOrder} />)
-        await userEvent.type(screen.getAllByText(/Ascending/)[1], "{Enter}")
+        await userEvent.type(screen.getByText(/Ascending/), "{Enter}")
     });
     expect(setDateOrder).toHaveBeenCalledWith("ascending")
 })

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,12 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
-## v3.35.0-rc.2 - 2022-04-06
+## [Unreleased]
 
 ### Fixed
 
 - When using Axe CVS as source for the accessibility violations metric, the "nested-interactive" violation type would be ignored by *Quality-time*. Fixes [#3628](https://github.com/ICTU/quality-time/issues/3628).
 - When using Gatling as source for the source version metric, the source version would not be found, when the version number was not present on the first line of the simulation.log. Fixes [#3661](https://github.com/ICTU/quality-time/issues/3661).
+
+### Changed
+
+- In the settings panel under the "Sort column" setting, clicking the same column multiple times now alternates between ascending and descending sort order. This makes the setting consistent with how column headers behave. It also removes the need for a separate "Sort direction" setting in the settings panel. Closes [#3646](https://github.com/ICTU/quality-time/issues/3646).
 
 ### Removed
 


### PR DESCRIPTION
…ame column multiple times now alternates between ascending and descending sort order. This makes the setting consistent with how column headers behave. It also removes the need for a separate "Sort direction" setting in the settings panel. Closes #3646.