### PR TITLE
When measuring 'manual test duration', show an error if the manual te…

### DIFF
--- a/components/collector/tests/source_collectors/jira/base.py
+++ b/components/collector/tests/source_collectors/jira/base.py
@@ -40,4 +40,6 @@ class JiraTestCase(SourceCollectorTestCase):  # skipcq: PTC-W0046
 
     async def get_response(self, issues_json, fields_json=None):
         """Get the collector's response."""
-        return await self.collect(get_request_json_side_effect=[fields_json or [], issues_json, issues_json])
+        return await self.collect(
+            get_request_json_side_effect=[fields_json or [dict(id="field", name="Field")], issues_json, issues_json]
+        )

--- a/components/collector/tests/source_collectors/jira/test_manual_test_execution.py
+++ b/components/collector/tests/source_collectors/jira/test_manual_test_execution.py
@@ -30,7 +30,8 @@ class JiraManualTestExecutionTest(JiraTestCase):
                 ),
             ]
         )
-        response = await self.get_response(test_cases_json)
+        fields_json = [dict(name="Desired test frequency", id="desired_test_frequency")]
+        response = await self.get_response(test_cases_json, fields_json)
         self.assert_measurement(
             response,
             value="2",

--- a/components/collector/tests/source_collectors/jira/test_user_story_points.py
+++ b/components/collector/tests/source_collectors/jira/test_user_story_points.py
@@ -24,7 +24,7 @@ class JiraUserStoryPointsTest(JiraTestCase):
                 self.issue(key="2", field=32, custom_field_001=None),
             ]
         )
-        fields_json = [dict(name="Sprint", id="custom_field_001")]
+        fields_json = [dict(name="Field", id="field"), dict(name="Sprint", id="custom_field_001")]
         response = await self.get_response(user_stories_json, fields_json)
         self.assert_measurement(
             response,

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,13 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
-## v3.35.0-rc.5 - 2022-04-13
+## [Unreleased]
 
 ### Fixed
 
 - When using Axe CVS as source for the accessibility violations metric, the "nested-interactive" violation type would be ignored by *Quality-time*. Fixes [#3628](https://github.com/ICTU/quality-time/issues/3628).
 - When using Gatling as source for the source version metric, the source version would not be found, when the version number was not present on the first line of the simulation.log. Fixes [#3661](https://github.com/ICTU/quality-time/issues/3661).
 - The data model for SonarQube contained some rules, which no longer exist. These were kept for backwards compatibility but now cause the SonarQube web interface to "freeze". These rules are removed. Fixes [#3706](https://github.com/ICTU/quality-time/issues/3706).
+- When measuring 'manual test duration', show an error if the manual test duration field name or id does not exist in Jira, instead of silently ignoring the issue and reporting zero minutes. Fixes [#3714](https://github.com/ICTU/quality-time/issues/3714).
 
 ### Changed
 


### PR DESCRIPTION
…st duration field name or id does not exist in Jira, instead of silently ignoring the issue and reporting zero minutes. Fixes #3714.