### PR TITLE
Don't render minutes as hours:minutes in the GUI, but simply as an in…

### DIFF
--- a/components/frontend/src/measurement/MeasurementTarget.js
+++ b/components/frontend/src/measurement/MeasurementTarget.js
@@ -1,20 +1,16 @@
 import { useContext } from "react";
 import { DataModel } from "../context/DataModel";
-import { format_minutes, formatMetricDirection, get_metric_target } from '../utils';
+import { formatMetricDirection, get_metric_target } from '../utils';
 
 export function MeasurementTarget({ metric }) {
     const dataModel = useContext(DataModel)
-    const metricType = dataModel.metrics[metric.type];
-    const metric_direction = formatMetricDirection(metric, dataModel)
-    let debt_end = "";
+    const metricDirection = formatMetricDirection(metric, dataModel)
+    let debtEnd = "";
     if (metric.debt_end_date) {
-        const end_date = new Date(metric.debt_end_date);
-        debt_end = ` until ${end_date.toLocaleDateString()}`;
+        const endDate = new Date(metric.debt_end_date);
+        debtEnd = ` until ${endDate.toLocaleDateString()}`;
     }
-    const debt = metric.accept_debt ? ` (debt accepted${debt_end})` : "";
-    let target = get_metric_target(metric);
-    if (target && metricType.unit === "minutes" && metric.scale !== "percentage") {
-        target = format_minutes(target)
-    }
-    return `${metric_direction} ${target}${metric.scale === "percentage" ? "%" : ""}${debt}`
+    const debt = metric.accept_debt ? ` (debt accepted${debtEnd})` : "";
+    const target = get_metric_target(metric);
+    return `${metricDirection} ${target}${metric.scale === "percentage" ? "%" : ""}${debt}`
 }

--- a/components/frontend/src/measurement/MeasurementTarget.test.js
+++ b/components/frontend/src/measurement/MeasurementTarget.test.js
@@ -18,7 +18,7 @@ it('renders the target with minutes', () => {
             <MeasurementTarget metric={{ type: "duration" }} />
         </DataModel.Provider>
     )
-    expect(screen.getAllByText(/≦ 0:00/).length).toBe(1)
+    expect(screen.getAllByText(/≦ 0/).length).toBe(1)
 })
 
 it('renders the target with minutes percentage', () => {

--- a/components/frontend/src/measurement/MeasurementValue.js
+++ b/components/frontend/src/measurement/MeasurementValue.js
@@ -1,14 +1,10 @@
-import { useContext } from "react";
 import { Popup } from "../semantic_ui_react_wrappers";
-import { DataModel } from "../context/DataModel";
 import { TimeAgoWithDate } from '../widgets/TimeAgoWithDate';
-import { format_minutes, get_metric_value } from '../utils';
+import { get_metric_value } from '../utils';
 
 export function MeasurementValue({ metric }) {
-    const dataModel = useContext(DataModel)
-    const metricType = dataModel.metrics[metric.type];
     const metricValue = get_metric_value(metric)
-    let value = metricValue && metricType.unit === "minutes" && metric.scale !== "percentage" ? format_minutes(metricValue) : metricValue || "?";
+    let value = metricValue || "?";
     if (metric.scale === "percentage") { value += "%" }
     if (metric.latest_measurement) {
         return (

--- a/components/frontend/src/measurement/MeasurementValue.test.js
+++ b/components/frontend/src/measurement/MeasurementValue.test.js
@@ -37,7 +37,7 @@ it('renders a minutes value', () => {
             <MeasurementValue metric={{ type: "duration", scale: "count", unit: null, latest_measurement: { count: { value: "42" } } }} />
         </DataModel.Provider>
     )
-    expect(screen.getAllByText(/0:42/).length).toBe(1)
+    expect(screen.getAllByText(/42/).length).toBe(1)
 })
 
 it('renders an unknown minutes value', () => {

--- a/components/frontend/src/metric/TrendGraph.js
+++ b/components/frontend/src/metric/TrendGraph.js
@@ -23,7 +23,7 @@ export function TrendGraph({ metric, measurements }) {
     const darkMode = useContext(DarkMode)
     const metricName = get_metric_name(metric, dataModel);
     const metricType = dataModel.metrics[metric.type];
-    const unit = capitalize(formatMetricScaleAndUnit(metricType, metric, false));
+    const unit = capitalize(formatMetricScaleAndUnit(metricType, metric));
     let measurement_values = [];
     let target_values = [];
     let near_target_values = [];

--- a/components/frontend/src/source/SourceEntityAttribute.js
+++ b/components/frontend/src/source/SourceEntityAttribute.js
@@ -2,13 +2,12 @@ import React from 'react';
 import { StatusIcon } from '../measurement/StatusIcon';
 import { HyperLink } from '../widgets/HyperLink';
 import { TimeAgoWithDate } from '../widgets/TimeAgoWithDate';
-import { format_minutes } from '../utils';
 
 export function SourceEntityAttribute({ entity, entity_attribute }) {
     let cell_contents = entity[entity_attribute.key] ?? "";
     cell_contents = cell_contents && entity_attribute.type === "datetime" ? <TimeAgoWithDate dateFirst date={cell_contents} /> : cell_contents;
     cell_contents = cell_contents && entity_attribute.type === "date" ? <TimeAgoWithDate dateFirst noTime date={cell_contents} /> : cell_contents;
-    cell_contents = cell_contents && entity_attribute.type === "minutes" ? format_minutes(cell_contents) : cell_contents;
+    cell_contents = cell_contents && entity_attribute.type === "integer" ? Math.round(cell_contents) : cell_contents;
     cell_contents = cell_contents && entity_attribute.type === "status" ? <StatusIcon status={cell_contents} /> : cell_contents;
     cell_contents = entity[entity_attribute.url] ? <HyperLink url={entity[entity_attribute.url]}>{cell_contents}</HyperLink> : cell_contents;
     cell_contents = entity_attribute.pre ? <pre data-testid="pre-wrapped" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{cell_contents}</pre> : <div style={{wordBreak: 'break-word'}}>{cell_contents}</div>;

--- a/components/frontend/src/source/SourceEntityAttribute.test.js
+++ b/components/frontend/src/source/SourceEntityAttribute.test.js
@@ -35,7 +35,7 @@ it('renders a date', () => {
 
 it('renders minutes', () => {
     renderSourceEntityAttribute({ duration: "42" }, { key: "duration", type: "minutes"})
-    expect(screen.getAllByText(/0:42/).length).toBe(1)
+    expect(screen.getAllByText(/42/).length).toBe(1)
 })
 
 it('renders a status icon', () => {

--- a/components/frontend/src/subject/SubjectTable.js
+++ b/components/frontend/src/subject/SubjectTable.js
@@ -11,14 +11,12 @@ import { TrendSparkline } from '../measurement/TrendSparkline';
 import { StatusIcon } from '../measurement/StatusIcon';
 import { TableRowWithDetails } from '../widgets/TableRowWithDetails';
 import { Tag } from '../widgets/Tag';
-import { formatMetricScale, format_minutes, get_metric_name, get_metric_tags, getMetricUnit } from '../utils';
+import { formatMetricScale, get_metric_name, get_metric_tags, getMetricUnit } from '../utils';
 import { SubjectTableFooter } from './SubjectTableFooter';
 import { SubjectTableHeader } from './SubjectTableHeader';
 import "./SubjectTable.css"
 
 function MeasurementCells({dates, metric, metric_uuid, measurements}) {
-    const dataModel = useContext(DataModel);
-    const metricType = dataModel.metrics[metric.type];
     return (
         <>
             {
@@ -26,7 +24,6 @@ function MeasurementCells({dates, metric, metric_uuid, measurements}) {
                     const iso_date_string = date.toISOString().split("T")[0];
                     const measurement = measurements?.find((m) => { return m.metric_uuid === metric_uuid && m.start.split("T")[0] <= iso_date_string && iso_date_string <= m.end.split("T")[0] })
                     let metric_value = measurement?.[metric.scale]?.value ?? "?";
-                    metric_value = metric_value !== "?" && metricType.unit === "minutes" && metric.scale !== "percentage" ? format_minutes(metric_value) : metric_value;
                     const status = measurement?.[metric.scale]?.status ?? "unknown";
                     return (
                         <Table.Cell className={status} key={date} textAlign="right">{metric_value}{formatMetricScale(metric)}</Table.Cell>

--- a/components/frontend/src/utils.js
+++ b/components/frontend/src/utils.js
@@ -87,28 +87,17 @@ export function scaled_number(number) {
     return (number / Math.pow(1000, exponent)).toFixed(0) + scale[exponent];
 }
 
-export function format_minutes(number) {
-    const hours = Math.floor(number / 60);
-    const minutes = number - hours * 60;
-    const leading_zero = minutes < 10 ? "0" : "";
-    return `${hours}:${leading_zero}${minutes}`
-}
-
-export function formatMetricUnit(metricType, metric, withMultiple = true) {
-    let metric_type_unit = metricType.unit;
-    if (withMultiple) {
-        metric_type_unit = metricType.unit === 'minutes' && metric.scale !== 'percentage' ? 'hours' : metricType.unit;
-    }
-    return `${metric.unit || metric_type_unit}`;
+function formatMetricUnit(metricType, metric) {
+    return `${metric.unit || metricType.unit}`;
 }
 
 export function formatMetricScale(metric) {
     return metric.scale === "percentage" ? "%" : "";
 }
 
-export function formatMetricScaleAndUnit(metricType, metric, withMultiple = true) {
+export function formatMetricScaleAndUnit(metricType, metric) {
     const scale = formatMetricScale(metric);
-    const unit = formatMetricUnit(metricType, metric, withMultiple);
+    const unit = formatMetricUnit(metricType, metric);
     const sep = unit ? " " : "";
     return `${scale}${sep}${unit}`;
 }

--- a/components/frontend/src/utils.test.js
+++ b/components/frontend/src/utils.test.js
@@ -2,7 +2,7 @@ import { renderHook, act } from '@testing-library/react-hooks'
 import { createMemoryHistory } from 'history';
 import {
     getUserPermissions, get_metric_tags, get_metric_target, get_source_name, get_subject_name, nice_number,
-    scaled_number, format_minutes, registeredURLSearchParams, userPrefersDarkMode, useURLSearchQuery
+    scaled_number, registeredURLSearchParams, userPrefersDarkMode, useURLSearchQuery
 } from './utils';
 import { EDIT_REPORT_PERMISSION, EDIT_ENTITY_PERMISSION } from './context/Permissions';
 
@@ -28,16 +28,6 @@ it('adds a scale', () => {
     expect(scaled_number(1234567)).toBe("1m");
     expect(scaled_number(12345678)).toBe("12m");
     expect(scaled_number(123456789)).toBe("123m");
-});
-
-it('formats minutes', () => {
-    expect(format_minutes(0)).toBe("0:00");
-    expect(format_minutes(1)).toBe("0:01");
-    expect(format_minutes(10)).toBe("0:10");
-    expect(format_minutes(59)).toBe("0:59");
-    expect(format_minutes(60)).toBe("1:00");
-    expect(format_minutes(61)).toBe("1:01");
-    expect(format_minutes(600)).toBe("10:00");
 });
 
 it('gives users all permissions if permissions have not been limited', () => {

--- a/components/server/src/external/data_model/meta/entity.py
+++ b/components/server/src/external/data_model/meta/entity.py
@@ -27,7 +27,6 @@ class EntityAttributeType(str, Enum):
     DATE = "date"
     DATETIME = "datetime"
     FLOAT = "float"
-    MINUTES = "minutes"
     INTEGER = "integer"
     STATUS = "status"
 
@@ -72,11 +71,7 @@ class Entity(BaseModel):  # pylint: disable=too-few-public-methods
             raise ValueError(
                 f"Measured attribute {measured_attribute} is not an attribute of entity {values.get('name')}"
             )
-        if attributes[measured_attribute] not in (
-            EntityAttributeType.FLOAT,
-            EntityAttributeType.INTEGER,
-            EntityAttributeType.MINUTES,
-        ):
+        if attributes[measured_attribute] not in (EntityAttributeType.FLOAT, EntityAttributeType.INTEGER):
             raise ValueError(f"Measured attribute {measured_attribute} does not have a number type")
         return measured_attribute
 

--- a/components/server/src/external/data_model/sources/sonarqube.py
+++ b/components/server/src/external/data_model/sources/sonarqube.py
@@ -302,7 +302,7 @@ SONARQUBE = Source.parse_obj(
                 measured_attribute="effort",
                 attributes=[
                     dict(name="Effort type", url="url"),
-                    dict(name="Effort (minutes)", key="effort", type=EntityAttributeType.MINUTES),
+                    dict(name="Effort (minutes)", key="effort", type=EntityAttributeType.INTEGER),
                 ],
             ),
             security_warnings=dict(

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,8 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Changed
 
+- Don't render minutes as hours:minutes in the GUI, but simply as an integer, to prevent confusion about what each number represents (hours, minutes, seconds?). Closes [#3577](https://github.com/ICTU/quality-time/issues/3577).
 - In the settings panel under the "Sort column" setting, clicking the same column multiple times now alternates between ascending and descending sort order. This makes the setting consistent with how column headers behave. It also removes the need for a separate "Sort direction" setting in the settings panel. Closes [#3646](https://github.com/ICTU/quality-time/issues/3646).
-- The database component was ugraded to MongoDB 5.0.7. **Note that to upgrade to this version of *Quality-time* your previous version needs to be at least version 3.32.0**. Closes [#3647](https://github.com/ICTU/quality-time/issues/3647).
+- The database component was upgraded to MongoDB 5.0.7. **Note that to upgrade to this version of *Quality-time* your previous version needs to be at least version 3.32.0**. Closes [#3647](https://github.com/ICTU/quality-time/issues/3647).
 - The proxy component uses Nginx instead of Caddy. Closes [#3687](https://github.com/ICTU/quality-time/issues/3687).
 
 ### Removed


### PR DESCRIPTION
…teger, to prevent confusion about what each number represents (hours, minutes, seconds?). Closes #3577.