### PR TITLE
 When showing a historic report in combination with measurements at mu…

### DIFF
--- a/components/server/src/external/database/reports.py
+++ b/components/server/src/external/database/reports.py
@@ -64,7 +64,7 @@ def metrics_of_subject(database: Database, subject_uuid: SubjectId, max_iso_time
         report_filter["last"] = True
     projection: dict = {"_id": False, f"subjects.{subject_uuid}.metrics": True}
     report = database.reports.find_one(report_filter, projection=projection)
-    return list(report["subjects"][subject_uuid]["metrics"].keys())
+    return list(report["subjects"][subject_uuid]["metrics"].keys()) if report else []
 
 
 def insert_new_report(database: Database, delta_description: str, uuids, *reports) -> dict[str, Any]:

--- a/components/server/src/external/database/reports.py
+++ b/components/server/src/external/database/reports.py
@@ -55,9 +55,13 @@ def _get_change_key(change: Change) -> str:
     return key
 
 
-def metrics_of_subject(database: Database, subject_uuid: SubjectId) -> list[MetricId]:
+def metrics_of_subject(database: Database, subject_uuid: SubjectId, max_iso_timestamp: str = "") -> list[MetricId]:
     """Return all metric uuid's for one subject, without the entities, except for the most recent one."""
-    report_filter: dict = {f"subjects.{subject_uuid}": DOES_EXIST, "last": True}
+    report_filter = {f"subjects.{subject_uuid}": DOES_EXIST}
+    if max_iso_timestamp and max_iso_timestamp < iso_timestamp():
+        report_filter["timestamp"] = {"$lt": max_iso_timestamp}
+    else:
+        report_filter["last"] = True
     projection: dict = {"_id": False, f"subjects.{subject_uuid}.metrics": True}
     report = database.reports.find_one(report_filter, projection=projection)
     return list(report["subjects"][subject_uuid]["metrics"].keys())

--- a/components/server/src/external/routes/subject.py
+++ b/components/server/src/external/routes/subject.py
@@ -111,17 +111,18 @@ def post_subject_attribute(subject_uuid: SubjectId, subject_attribute: str, data
 
 @bottle.get("/api/v3/subject/<subject_uuid>/measurements", authentication_required=False)
 def get_subject_measurements(subject_uuid: SubjectId, database: Database):
-    """Return all measurements for the subjects within the last 28 weeks."""
-    metric_uuids: list[MetricId] = metrics_of_subject(database, subject_uuid)
+    """Return all measurements for the subject within the last 28 weeks."""
+    date_time = report_date_time()
+    metric_uuids: list[MetricId] = metrics_of_subject(database, subject_uuid, date_time)
 
-    report_timestamp = datetime.fromisoformat(report_date_time()) if report_date_time() else datetime.now(timezone.utc)
+    report_timestamp = datetime.fromisoformat(date_time) if date_time else datetime.now(timezone.utc)
     min_datetime = report_timestamp - timedelta(weeks=28)
     min_iso_timestamp = min_datetime.isoformat()
 
     return dict(
         measurements=list(
             measurements_by_metric(
-                database, *metric_uuids, min_iso_timestamp=min_iso_timestamp, max_iso_timestamp=report_date_time()
+                database, *metric_uuids, min_iso_timestamp=min_iso_timestamp, max_iso_timestamp=date_time
             )
         )
     )

--- a/components/server/tests/external/routes/test_subject.py
+++ b/components/server/tests/external/routes/test_subject.py
@@ -36,6 +36,19 @@ class GetSubjectTest(unittest.TestCase):
             dict(measurements=[dict(start="0"), dict(start="1")]), get_subject_measurements(SUBJECT_ID, self.database)
         )
 
+    @patch("bottle.request")
+    def test_get_subject_measurements_with_time_travel(self, request):
+        """Tests that the measurements for the requested metric are returned for past reports."""
+        request.query = dict(report_date="2022-04-19T23:59:59.000Z")
+        # Mock reports collection
+        self.database.reports.find_one.return_value = {"subjects": {SUBJECT_ID: {"metrics": {METRIC_ID: {}}}}}
+        # Mock measurements collection
+        self.database.measurements.find_one.return_value = dict(start="1")
+        self.database.measurements.find.return_value = [dict(start="0"), dict(start="1")]
+        self.assertEqual(
+            dict(measurements=[dict(start="0"), dict(start="1")]), get_subject_measurements(SUBJECT_ID, self.database)
+        )
+
 
 @patch("bottle.request")
 class PostSubjectAttributeTest(unittest.TestCase):

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
-## v3.35.0-rc.6 - 2022-04-20
+## [Unreleased]
 
 ### Fixed
 
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - When using Gatling as source for the source version metric, the source version would not be found, when the version number was not present on the first line of the simulation.log. Fixes [#3661](https://github.com/ICTU/quality-time/issues/3661).
 - The data model for SonarQube contained some rules, which no longer exist. These were kept for backwards compatibility but now cause the SonarQube web interface to "freeze". These rules are removed. Fixes [#3706](https://github.com/ICTU/quality-time/issues/3706).
 - When measuring 'manual test duration', show an error if the manual test duration field name or id does not exist in Jira, instead of silently ignoring the issue and reporting zero minutes. Fixes [#3714](https://github.com/ICTU/quality-time/issues/3714).
+- When showing a historic report in combination with measurements at multiple dates, *Quality-time* would use the latest report to decide which metrics to retrieve the measurements for, instead of the report at the date shown. Fixes [#3722](https://github.com/ICTU/quality-time/issues/3722).
 
 ### Changed
 

--- a/tests/feature_tests/steps/subject.py
+++ b/tests/feature_tests/steps/subject.py
@@ -8,6 +8,5 @@ def get_measurements(context, has_or_had, expected_number):
     if has_or_had == "had":
         context.report_date = "2020-11-17T10:00:00Z"
 
-    assert_equal(
-        int(expected_number), len(context.get(f"subject/{context.uuid['subject']}/measurements")["measurements"])
-    )
+    response = context.get(f"subject/{context.uuid['subject']}/measurements")
+    assert_equal(int(expected_number), len(response["measurements"]))


### PR DESCRIPTION
…ltiple dates, Quality-time would use the latest report to decide which metrics to retrieve the measurements for, instead of the report at the date shown. Fixes #3722.