### PR TITLE
When measuring 'performancetest scalability' with the Performancetest…

### DIFF
--- a/components/collector/src/source_collectors/performancetest_runner/performancetest_scalability.py
+++ b/components/collector/src/source_collectors/performancetest_runner/performancetest_scalability.py
@@ -1,7 +1,6 @@
 """Performancetest-runner performancetest scalability collector."""
 
-from collector_utilities.exceptions import CollectorException
-from collector_utilities.type import Value
+from collector_utilities.type import Response, Value
 from model import SourceResponses
 
 from .base import PerformanceTestRunnerBaseClass
@@ -12,12 +11,8 @@ class PerformanceTestRunnerScalability(PerformanceTestRunnerBaseClass):
 
     async def _parse_value(self, responses: SourceResponses) -> Value:
         """Override to parse the scalability breaking point from the responses."""
-        trend_breaks = []
-        for response in responses:
-            breaking_point = int((await self._soup(response)).find(id="trendbreak_scalability").string)
-            if breaking_point == 100:
-                raise CollectorException(
-                    "No performance scalability breaking point occurred (breaking point is at 100%, expected < 100%)"
-                )
-            trend_breaks.append(breaking_point)
-        return str(min(trend_breaks))
+        return str(min([await self.__breaking_point(response) for response in responses]))
+
+    async def __breaking_point(self, response: Response) -> int:
+        """Parse the breaking point from the response."""
+        return int((await self._soup(response)).find(id="trendbreak_scalability").string)

--- a/components/collector/tests/source_collectors/performancetest_runner/test_scalability.py
+++ b/components/collector/tests/source_collectors/performancetest_runner/test_scalability.py
@@ -21,10 +21,10 @@ class PerformanceTestRunnerScalabilityTest(PerformanceTestRunnerTestCase):
         """Test the scalability without breaking point.
 
         Test that if the percentage of the max users at which the ramp-up of throughput breaks is 100%, the metric
-        reports an error (since there is no breaking point).
+        does not report an error (despite there being no breaking point).
         """
         html = """<html><table class="config">
             <tr><td class="name">Trendbreak 'scalability' (%)</td><td id="trendbreak_scalability">100</td></tr>
             </table></html>"""
         response = await self.collect(get_request_text=html)
-        self.assert_measurement(response, parse_error="Traceback")
+        self.assert_measurement(response, value="100")

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - The data model for SonarQube contained some rules, which no longer exist. These were kept for backwards compatibility but now cause the SonarQube web interface to "freeze". These rules are removed. Fixes [#3706](https://github.com/ICTU/quality-time/issues/3706).
 - When measuring 'manual test duration', show an error if the manual test duration field name or id does not exist in Jira, instead of silently ignoring the issue and reporting zero minutes. Fixes [#3714](https://github.com/ICTU/quality-time/issues/3714).
 - When showing a historic report in combination with measurements at multiple dates, *Quality-time* would use the latest report to decide which metrics to retrieve the measurements for, instead of the report at the date shown. Fixes [#3722](https://github.com/ICTU/quality-time/issues/3722).
+- When measuring 'performancetest scalability' with the Performancetest-runner as source, don't consider a trend breakpoint of 100% to be an error. Fixes [#3787](https://github.com/ICTU/quality-time/issues/3787).
 
 ### Changed
 


### PR DESCRIPTION
…-runner as source, don't consider a trend breakpoint of 100% to be an error. Fixes #3787.