### PR TITLE
When measuring the 'missing metrics' metric, *Quality-time* was still…

### DIFF
--- a/components/collector/src/source_collectors/quality_time/missing_metrics.py
+++ b/components/collector/src/source_collectors/quality_time/missing_metrics.py
@@ -16,7 +16,7 @@ class QualityTimeMissingMetrics(QualityTimeCollector):
         """Get responses for reports and the datamodel."""
         api_url = urls[0]
         datamodel_url = URL(f"{api_url}/datamodel")
-        reports_url = URL(f"{api_url}/reports")
+        reports_url = URL(f"{api_url}/report")
         return await super()._get_source_responses(datamodel_url, reports_url, **kwargs)
 
     async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Deployment notes
+
+If your currently installed *Quality-time* version is not v3.36.0, please read the v3.36.0 deployment notes.
+
+### Fixed
+
+- When measuring the 'missing metrics' metric, *Quality-time* was still using an old endpoint to get the data, resulting in a parse error. Fixes [#3855](https://github.com/ICTU/quality-time/issues/3855).
+
 ## v3.36.0 - 2022-05-16
 
 ### Deployment notes


### PR DESCRIPTION
… using an old endpoint to get the data, resulting in a parse error. Fixes #3855.