### PR TITLE
Duplicate the get data model route in the internal package and move t…

### DIFF
--- a/components/external_server/src/internal/routes/__init__.py
+++ b/components/external_server/src/internal/routes/__init__.py
@@ -1,4 +1,5 @@
 """Internal routes."""
 
+from .datamodel import get_data_model
 from .measurement import post_measurement
 from .metric import get_metrics

--- a/components/external_server/src/internal/routes/datamodel.py
+++ b/components/external_server/src/internal/routes/datamodel.py
@@ -6,7 +6,7 @@ from pymongo.database import Database
 from shared.routes import get_data_model as get_data_model_implementation
 
 
-@bottle.get("/api/v3/datamodel", authentication_required=False)
+@bottle.get("/internal-api/v3/datamodel", authentication_required=False)
 def get_data_model(database: Database):
     """Return the data model."""
     return get_data_model_implementation(database)  # pragma: no cover

--- a/components/external_server/tests/routes/test_datamodel.py
+++ b/components/external_server/tests/routes/test_datamodel.py
@@ -1,14 +1,9 @@
 """Unit tests for the datamodel routes."""
 
 import unittest
-from unittest.mock import Mock, patch
-
-import bottle
-
-from shared.utils.functions import md5_hash
+from unittest.mock import Mock
 
 from database.datamodels import default_source_parameters, default_subject_attributes, insert_new_datamodel
-from routes import get_data_model
 
 
 class DataModelTest(unittest.TestCase):
@@ -17,23 +12,6 @@ class DataModelTest(unittest.TestCase):
     def setUp(self):
         """Override to set up the database."""
         self.database = Mock()
-
-    def test_get_data_model(self):
-        """Test that the data model can be retrieved."""
-        data_model = self.database.datamodels.find_one.return_value = dict(_id=123, timestamp="now")
-        self.assertEqual(data_model, get_data_model(self.database))
-
-    def test_get_data_model_missing(self):
-        """Test that the data model is None if it's not there."""
-        self.database.datamodels.find_one.return_value = None
-        self.assertEqual({}, get_data_model(self.database))
-
-    @patch("bottle.request")
-    def test_get_data_model_unchanged(self, mocked_request):
-        """Test that a 304 is returned when the data model is unchanged."""
-        mocked_request.headers = {"If-None-Match": "W/" + md5_hash("now")}
-        self.database.datamodels.find_one.return_value = dict(_id=123, timestamp="now")
-        self.assertRaises(bottle.HTTPError, get_data_model, self.database)
 
     def test_insert_data_model_with_id(self):
         """Test that a new data model can be inserted."""

--- a/components/shared_python/src/shared/routes/__init__.py
+++ b/components/shared_python/src/shared/routes/__init__.py
@@ -1,0 +1,3 @@
+"""Routes."""
+
+from .datamodel import get_data_model

--- a/components/shared_python/src/shared/routes/datamodel.py
+++ b/components/shared_python/src/shared/routes/datamodel.py
@@ -1,0 +1,18 @@
+"""Data model routes."""
+
+import bottle
+from pymongo.database import Database
+
+from shared.database.datamodels import latest_datamodel
+from shared.utils.functions import md5_hash, report_date_time
+
+
+def get_data_model(database: Database):
+    """Return the data model."""
+    data_model = latest_datamodel(database, report_date_time())
+    if data_model:
+        md5 = md5_hash(data_model["timestamp"])
+        if "W/" + md5 == bottle.request.headers.get("If-None-Match"):  # pylint: disable=no-member
+            bottle.abort(304)  # Data model unchanged
+        bottle.response.set_header("ETag", md5)
+    return data_model

--- a/components/shared_python/tests/shared/routes/test_datamodel.py
+++ b/components/shared_python/tests/shared/routes/test_datamodel.py
@@ -1,0 +1,34 @@
+"""Unit tests for the datamodel routes."""
+
+import unittest
+from unittest.mock import Mock, patch
+
+import bottle
+
+from shared.utils.functions import md5_hash
+from shared.routes import get_data_model
+
+
+class DataModelTest(unittest.TestCase):
+    """Unit tests for the data model route."""
+
+    def setUp(self):
+        """Override to set up the database."""
+        self.database = Mock()
+
+    def test_get_data_model(self):
+        """Test that the data model can be retrieved."""
+        data_model = self.database.datamodels.find_one.return_value = dict(_id=123, timestamp="now")
+        self.assertEqual(data_model, get_data_model(self.database))
+
+    def test_get_data_model_missing(self):
+        """Test that the data model is None if it's not there."""
+        self.database.datamodels.find_one.return_value = None
+        self.assertEqual({}, get_data_model(self.database))
+
+    @patch("bottle.request")
+    def test_get_data_model_unchanged(self, mocked_request):
+        """Test that a 304 is returned when the data model is unchanged."""
+        mocked_request.headers = {"If-None-Match": "W/" + md5_hash("now")}
+        self.database.datamodels.find_one.return_value = dict(_id=123, timestamp="now")
+        self.assertRaises(bottle.HTTPError, get_data_model, self.database)


### PR DESCRIPTION
…he implementation of the route to the shared python component.