### PR TITLE
The [Performancetest-runner](https://github.com/ICTU/performancetest-…

### DIFF
--- a/components/collector/src/source_collectors/performancetest_runner/performancetest_scalability.py
+++ b/components/collector/src/source_collectors/performancetest_runner/performancetest_scalability.py
@@ -11,9 +11,24 @@ class PerformanceTestRunnerScalability(PerformanceTestRunnerBaseClass):
 
     async def _parse_value(self, responses: SourceResponses) -> Value:
         """Override to parse the scalability breaking point from the responses."""
-        breaking_points = [await self.__breaking_point(response) for response in responses]
+        breaking_points = [await self.__breaking_point_vusers(response) for response in responses]
         return str(min(breaking_points))
 
-    async def __breaking_point(self, response: Response) -> int:
+    async def _parse_total(self, responses: SourceResponses) -> Value:
+        """Override to compute the total number of vusers from the responses."""
+        breaking_points = [
+            (await self.__breaking_point_vusers(response), await self.__breaking_point_percentage(response))
+            for response in responses
+        ]
+        smallest_breaking_point_vusers, smallest_breaking_point_percentage = min(breaking_points)
+        if smallest_breaking_point_percentage == 0:
+            return "0"
+        return str(round((smallest_breaking_point_vusers * 100) / smallest_breaking_point_percentage))
+
+    async def __breaking_point_vusers(self, response: Response) -> int:
         """Parse the breaking point from the response."""
+        return int((await self._soup(response)).find(id="trendbreak_scalability_vusers").string)
+
+    async def __breaking_point_percentage(self, response: Response) -> int:
+        """Parse the breaking point percentage from the response."""
         return int((await self._soup(response)).find(id="trendbreak_scalability").string)

--- a/components/collector/tests/source_collectors/performancetest_runner/test_scalability.py
+++ b/components/collector/tests/source_collectors/performancetest_runner/test_scalability.py
@@ -3,6 +3,21 @@
 from .base import PerformanceTestRunnerTestCase
 
 
+PERFORMANCETEST_RUNNER_HTML = """
+<html>
+    <table class="config">
+        <tr>
+            <td class="name">Breaking point stress (%%)</td>
+            <td id="trendbreak_scalability">%s</td></tr>
+        <tr>
+            <td class="name">Breaking point stress (#virtual users)</td>
+            <td id="trendbreak_scalability_vusers">%s</td>
+        </tr>
+    </table>
+</html>
+"""
+
+
 class PerformanceTestRunnerScalabilityTest(PerformanceTestRunnerTestCase):
     """Unit tests for the Performancetest-runner performance test scalability collector."""
 
@@ -10,21 +25,17 @@ class PerformanceTestRunnerScalabilityTest(PerformanceTestRunnerTestCase):
     METRIC_ADDITION = "min"
 
     async def test_scalability(self):
-        """Test that the percentage of the max users at which the ramp-up of throughput breaks is returned."""
-        html = """<html><table class="config">
-            <tr><td class="name">Trendbreak 'scalability' (%)</td><td id="trendbreak_scalability">74</td></tr>
-            </table></html>"""
+        """Test that the number of virtual users at which the ramp-up of throughput breaks is returned."""
+        html = PERFORMANCETEST_RUNNER_HTML % (63, 354)
         response = await self.collect(get_request_text=html)
-        self.assert_measurement(response, value="74")
+        self.assert_measurement(response, value="354", total="562")
 
     async def test_scalability_without_breaking_point(self):
         """Test the scalability without breaking point.
 
-        Test that if the percentage of the max users at which the ramp-up of throughput breaks is 100%, the metric
+        Test that if the number of virtual users at which the ramp-up of throughput breaks is missing, the metric
         does not report an error (despite there being no breaking point).
         """
-        html = """<html><table class="config">
-            <tr><td class="name">Trendbreak 'scalability' (%)</td><td id="trendbreak_scalability">100</td></tr>
-            </table></html>"""
+        html = PERFORMANCETEST_RUNNER_HTML % (0, 0)
         response = await self.collect(get_request_text=html)
-        self.assert_measurement(response, value="100")
+        self.assert_measurement(response, value="0", total="0")

--- a/components/shared_python/src/shared/data_model/meta/unit.py
+++ b/components/shared_python/src/shared/data_model/meta/unit.py
@@ -32,7 +32,7 @@ class Unit(str, Enum):
     UNCOVERED_LINES = "uncovered lines"
     UNITS_WITH_TOO_MANY_PARAMETERS = "units with too many parameters"
     UPVOTES = "upvotes"
-    USERS = "users"
     USER_STORY_POINTS = "user story points"
     USER_STORY_POINTS_PER_SPRINT = "user story points per sprint"
     VIOLATIONS = "violations"
+    VIRTUAL_USERS = "virtual users"

--- a/components/shared_python/src/shared/data_model/metrics.py
+++ b/components/shared_python/src/shared/data_model/metrics.py
@@ -237,12 +237,13 @@ METRICS = Metrics.parse_obj(
         ),
         scalability=dict(
             name="Scalability",
-            description="The percentage of (max) users at which ramp-up of throughput breaks.",
+            description="The number of virtual users (or percentage of the maximum number of virtual users) at "
+            "which ramp-up of throughput breaks.",
             rationale="When stress testing, the load on the system-under-test has to increase sufficiently to detect "
             "the point at which the system breaks, as indicated by increasing throughput or error counts. If this "
             "breakpoint is not detected, the load has not been increased enough.",
-            scales=["percentage"],
-            unit=Unit.USERS,
+            scales=["count", "percentage"],
+            unit=Unit.VIRTUAL_USERS,
             addition=Addition.MIN,
             direction=Direction.MORE_IS_BETTER,
             target="75",

--- a/components/testdata/reports/performancetest-runner/loadtestreport.html
+++ b/components/testdata/reports/performancetest-runner/loadtestreport.html
@@ -239,24 +239,25 @@
 <table width="100%">
 <tr valign="top">
 <td><h3>Summary</h3>
-<table class="config">
-	<tr><td class="name">Transactions failed (%)</td><td id="transactions_failed">0,00</td></tr>
-	<tr><td class="name">Threshold violations</td><td id="threshold_violations">0</td></tr>
-	<tr><td class="name">Baseline warnings</td><td id="baseline_warnings">0</td></tr>
-	<tr><td class="name">Trendbreak 'scalability' (%)</td><td id="trendbreak_scalability">63</td></tr>
-	<tr><td class="name">Trendbreak 'stability' (%)</td><td id="trendbreak_stability">10</td></tr>
-	<tr><td>&nbsp</td><td></td></tr>
-	<tr><td class="name">Duration</td><td id="duration">01:00:01</td></tr>
-	<tr><td class="name">Virtual users</td><td id="virtual_users">8</td></tr>
-	<tr><td class="name">Transactions executed</td><td id="executed">1250</td></tr>
-	<tr><td class="name">Transactions success</td><td id="success">1250</td></tr>
-	<tr><td class="name">Transactions failed</td><td id="failed">0</td></tr>
-	<tr><td class="name">Min of minima (s)</td><td id="min">0,043</td></tr>
-	<tr><td class="name">Avg of averages (s)</td><td id="avg">1,058</td></tr>
-	<tr><td class="name">Avg of 90 percentiles (s)</td><td id="avg_90_percentile">1,538</td></tr>
-	<tr><td class="name">Max of maxima (s)</td><td id="max">13,877</td></tr>
-	<tr><td class="name">Avg of StdDev (s)</td><td id="avg_stddev">0,512</td></tr>
-</table>
+    <table class="config">
+        <tr><td class="name">Transactions failed (%)</td><td id="transactions_failed">0,03</td></tr>
+        <tr><td class="name">Threshold violations</td><td id="threshold_violations">74</td></tr>
+        <tr><td class="name">Baseline warnings</td><td id="baseline_warnings">103</td></tr>
+        <tr style="display:none"><td class="name">Breaking point stress (%)</td><td id="trendbreak_scalability">63</td></tr>
+        <tr><td class="name">Breaking point stress (#virtual users)</td><td id="trendbreak_scalability_vusers">354</td></tr>
+        <tr><td class="name">Breaking point endurance (%)</td><td id="trendbreak_stability">90</td></tr>
+        <tr><td>&nbsp</td><td></td></tr>
+        <tr><td class="name">Duration</td><td id="duration">01:00:17</td></tr>
+        <tr><td class="name">Virtual users</td><td id="virtual_users">566</td></tr>
+        <tr><td class="name">Transactions executed</td><td id="executed">248980</td></tr>
+        <tr><td class="name">Transactions success</td><td id="success">248816</td></tr>
+        <tr><td class="name">Transactions failed</td><td id="failed">164</td></tr>
+        <tr><td class="name">Min of minima (s)</td><td id="min">0,000</td></tr>
+        <tr><td class="name">Avg of averages (s)</td><td id="avg">3,204</td></tr>
+        <tr><td class="name">Avg of 90 percentiles (s)</td><td id="avg_90_percentile">5,005</td></tr>
+        <tr><td class="name">Max of maxima (s)</td><td id="max">379,804</td></tr>
+        <tr><td class="name">Avg of StdDev (s)</td><td id="avg_stddev">2,080</td></tr>
+    </table>
 </td>
 	<td style="min-width: 600px; min-height: 400px"><canvas id="chart_counters"></canvas></td>
 	<td style="min-width: 600px; min-height: 400px"><canvas id="chart_trend"></canvas></td>

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Deployment notes
+
+If your currently installed *Quality-time* version is not v3.37.0, please read the v3.37.0 deployment notes.
+
+### Added
+
+- The [Performancetest-runner](https://github.com/ICTU/performancetest-runner) HTML report now reports the breaking point as the absolute number of virtual users as well as percentage of the maximum number of virtual users. This allows the 'scalability' metric to support the count scale in addition to the already supported percentage scale. Closes [#3980](https://github.com/ICTU/quality-time/issues/3980).
+
 ## v3.37.0 - 2022-06-07
 
 ### Deployment notes

--- a/tests/feature_tests/features/measurement.feature
+++ b/tests/feature_tests/features/measurement.feature
@@ -32,7 +32,7 @@ Feature: measurement
     Given an existing metric with type "performancetest_stability"
     And an existing source with type "performancetest_runner"
     When the collector measures "50"
-    Then the metric status is "near_target_met"
+    Then the metric status is "target_not_met"
 
   Scenario: the metric has a percentage scale and measures total 0
     Given an existing metric with type "performancetest_stability"

--- a/tests/feature_tests/features/measurement.feature
+++ b/tests/feature_tests/features/measurement.feature
@@ -29,13 +29,13 @@ Feature: measurement
     Then the metric status is "target_not_met"
 
   Scenario: the metric has a percentage scale
-    Given an existing metric with type "scalability"
+    Given an existing metric with type "performancetest_stability"
     And an existing source with type "performancetest_runner"
     When the collector measures "50"
     Then the metric status is "near_target_met"
 
   Scenario: the metric has a percentage scale and measures total 0
-    Given an existing metric with type "scalability"
+    Given an existing metric with type "performancetest_stability"
     And an existing source with type "performancetest_runner"
     When the collector measures "0" with total "0"
     Then the metric status is "target_met"


### PR DESCRIPTION
…runner) HTML report now reports the breaking point as the absolute number of virtual users as well as percentage of the maximum number of virtual users. This allows the 'scalability' metric to support the count scale in addition to the already supported percentage scale. Closes #3980.