### PR TITLE
Temporarily turn off pip-audit because we're getting 'too many redire…

### DIFF
--- a/components/collector/ci/quality.sh
+++ b/components/collector/ci/quality.sh
@@ -18,7 +18,7 @@ run () {
 run mypy src
 run pylint --rcfile=../../.pylintrc src tests
 run python -m flake8 --select=DUO src  # Dlint
-run pip-audit --strict --progress-spinner=off -r requirements/requirements-base.txt -r requirements/requirements.txt -r requirements/requirements-dev.txt
+# run pip-audit --strict --progress-spinner=off -r requirements/requirements-base.txt -r requirements/requirements.txt -r requirements/requirements-dev.txt
 run safety check --bare --ignore 41002 -r requirements/requirements-base.txt -r requirements/requirements.txt -r requirements/requirements-dev.txt  # See https://github.com/nedbat/coveragepy/issues/1200
 run bandit --quiet --recursive src/
 NAMES_TO_IGNORE='Anchore*,Axe*,AzureDevops*,Bandit*,Calendar*,Cloc*,Cobertura*,Composer*,CxSAST*,Gatling*,Generic*,GitLab*,Jacoco*,Jenkins*,Jira*,JMeter*,JUnit*,ManualNumber*,NCover*,Npm*,OJAudit*,OpenVAS*,OWASPDependencyCheck*,OWASPZAP*,PerformanceTestRunner*,Pip*,PyupioSafety*,QualityTime*,RobotFramework*,SARIF*,Snyk*,SonarQube*,Trello*'

--- a/components/external_server/ci/quality.sh
+++ b/components/external_server/ci/quality.sh
@@ -18,7 +18,7 @@ run () {
 run mypy src
 run pylint --rcfile=../../.pylintrc src tests
 run python -m flake8 --select=DUO src
-run pip-audit --strict --progress-spinner=off -r requirements/requirements-base.txt -r requirements/requirements.txt -r requirements/requirements-dev.txt
+# run pip-audit --strict --progress-spinner=off -r requirements/requirements-base.txt -r requirements/requirements.txt -r requirements/requirements-dev.txt
 run safety check --bare --ignore 41002 -r requirements/requirements-base.txt -r requirements/requirements.txt -r requirements/requirements-dev.txt  # See https://github.com/nedbat/coveragepy/issues/1200
 run bandit --quiet --recursive src/
 run vulture --min-confidence 0 src/ tests/ .vulture_ignore_list.py

--- a/components/notifier/ci/quality.sh
+++ b/components/notifier/ci/quality.sh
@@ -18,7 +18,7 @@ run () {
 run mypy src
 run pylint --rcfile=../../.pylintrc src tests
 run python -m flake8 --select=DUO src
-run pip-audit --strict --progress-spinner=off -r requirements/requirements-base.txt -r requirements/requirements.txt -r requirements/requirements-dev.txt
+# run pip-audit --strict --progress-spinner=off -r requirements/requirements-base.txt -r requirements/requirements.txt -r requirements/requirements-dev.txt
 run safety check --bare --ignore 41002 -r requirements/requirements-base.txt -r requirements/requirements.txt -r requirements/requirements-dev.txt  # See https://github.com/nedbat/coveragepy/issues/1200
 run bandit --quiet --recursive src/
 run vulture --min-confidence 0 src/ tests/ .vulture_ignore_list.py

--- a/components/shared_python/ci/quality.sh
+++ b/components/shared_python/ci/quality.sh
@@ -18,7 +18,7 @@ run () {
 run mypy src
 run pylint --rcfile=../../.pylintrc src tests
 run python -m flake8 --select=DUO src
-run pip-audit --strict --progress-spinner=off -r requirements/requirements-base.txt -r requirements/requirements.txt -r requirements/requirements-dev.txt
+# run pip-audit --strict --progress-spinner=off -r requirements/requirements-base.txt -r requirements/requirements.txt -r requirements/requirements-dev.txt
 run safety check --bare --ignore 41002 -r requirements/requirements-base.txt -r requirements/requirements.txt -r requirements/requirements-dev.txt  # See https://github.com/nedbat/coveragepy/issues/1200
 run bandit --quiet --recursive src/
 run vulture --min-confidence 0 src/ tests/ .vulture_ignore_list.py

--- a/docs/ci/quality.sh
+++ b/docs/ci/quality.sh
@@ -20,7 +20,7 @@ run mypy src
 run pylint --rcfile=../.pylintrc src tests
 run python -m flake8 --select=DUO src
 run isort **/*.py --check-only
-run pip-audit --strict --progress-spinner=off -r requirements/requirements-base.txt -r requirements/requirements-dev.txt
+# run pip-audit --strict --progress-spinner=off -r requirements/requirements-base.txt -r requirements/requirements-dev.txt
 run safety check --bare --ignore 41002 -r requirements/requirements-base.txt -r requirements/requirements-dev.txt  # See https://github.com/nedbat/coveragepy/issues/1200
 NAMES_TO_IGNORE=''
 run vulture --min-confidence 0 --ignore-names $NAMES_TO_IGNORE src/ tests/ .vulture_ignore_list.py


### PR DESCRIPTION
…cts' errors.