### PR TITLE
The user interface would sometimes crash when navigating to the repor…

### DIFF
--- a/components/frontend/src/App.js
+++ b/components/frontend/src/App.js
@@ -63,8 +63,12 @@ class App extends Component {
     }
 
     loadAndSetState(report_date, show_error) {
+        const report_uuid = this.state.report_uuid;
         Promise.all([get_datamodel(report_date), get_reports_overview(report_date), get_reports(this.state.report_uuid, report_date)]).then(
             ([data_model, reports_overview, reports]) => {
+                if (this.state.report_uuid !== report_uuid) {
+                    return  // User navigated to a different report or to the overview page, cancel update
+                }
                 if (data_model.ok === false || reports.ok === false) {
                     show_error();
                 } else {

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -49,6 +49,7 @@ See the [deployment instructions](https://quality-time.readthedocs.io/en/latest/
 ### Fixed
 
 - *Quality-time* would use the Jira issue picker endpoint to suggest issue ids to the user when typing text in the issue id field. However, the Jira endpoint uses the Jira interaction history of the user contacting the endpoint to make suggestions. In the case of *Quality-time*, this would be the user configured in the issue tracker. If this is a system user without any Jira interaction history, no suggestions would be made. Fixed by using the Jira search endpoint instead of the Jira issue picker endpoint. Fixes [#4017](https://github.com/ICTU/quality-time/issues/4017).
+- The user interface would sometimes crash when navigating to the report overview right after editing an input field on a report page. Fixes [#4034](https://github.com/ICTU/quality-time/issues/4034).
 
 ## v3.37.0 - 2022-06-07
 


### PR DESCRIPTION
…t overview right after editing an input field on a report page. Fixes #4034.