### PR TITLE
When using SonarQube as source for the 'suppressed violations' metric…

### DIFF
--- a/components/collector/src/source_collectors/sonarqube/suppressed_violations.py
+++ b/components/collector/src/source_collectors/sonarqube/suppressed_violations.py
@@ -12,6 +12,17 @@ class SonarQubeSuppressedViolations(SonarQubeViolations):
 
     rules_configuration = "suppression_rules"
 
+    async def _landing_url(self, responses: SourceResponses) -> URL:
+        """Override to not include the rules parameter in the landing URL.
+
+        This collector uses two SonarQube endpoints to get the suppressed violations. As we can't include both URLs in
+        the landing URL, we use the overview of all issues as landing page.
+        """
+        url = await SourceCollector._api_url(self)  # pylint: disable=protected-access
+        component = self._parameter("component")
+        branch = self._parameter("branch")
+        return URL(f"{url}/project/issues?id={component}&branch={branch}")
+
     async def _get_source_responses(self, *urls: URL, **kwargs) -> SourceResponses:
         """Get the suppressed violations from SonarQube.
 

--- a/components/collector/tests/source_collectors/sonarqube/test_suppressed_violations.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_suppressed_violations.py
@@ -70,6 +70,5 @@ class SonarQubeSuppressedViolationsTest(SonarQubeTestCase):
             value="2",
             total="4",
             entities=expected_entities,
-            landing_url=f"{self.issues_landing_url}&rules=csharpsquid:S1309,php:NoSonar,Pylint:I0011,Pylint:I0020,"
-            "java:NoSonar,java:S1309,java:S1310,java:S1315",
+            landing_url="https://sonarqube/project/issues?id=id&branch=master",
         )

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,7 @@ If your currently installed *Quality-time* version is not v4.0.0, please read th
 
 - Trendgraphs would show yellow background areas as grey for metrics with the "more is better" direction. Fixes [#1380](https://github.com/ICTU/quality-time/issues/1380).
 - If for some reason measurements are not updated, the only way to detect this in the UI was to check the last measurement attempt in the popup of meaasurement values. Fixed by coloring measurement values red when the the last measurement attempt is more than one hour ago. Fixes [#4075](https://github.com/ICTU/quality-time/issues/4075).
+- When using SonarQube as source for the 'suppressed violations' metric, the source URL SonarQube would direct users to a SonarQube page with only part of the information. Unfortunately, SonarQube does not allow for creating a filter that shows a combination of suppressed issues and suppressions in the source code. Partially fixed by sending users to a page with all issues. Fixes [#4080](https://github.com/ICTU/quality-time/issues/4080).
 - When showing multiple dates, the most recent measurement of one of the metrics would sometimes be shown as unknown despite not being unknown at all.
 
 ### Changed


### PR DESCRIPTION
…, the source URL SonarQube would direct users to a SonarQube page with only part of the information. Unfortunately, SonarQube does not allow for creating a filter that shows a combination of suppressed issues and suppressions in the source code. Partially fixed by sending users to a page with all issues. Fixes #4080.