### PR TITLE
The target column would show the technical debt target value instead …

### DIFF
--- a/components/frontend/src/measurement/MeasurementTarget.js
+++ b/components/frontend/src/measurement/MeasurementTarget.js
@@ -1,17 +1,31 @@
 import { useContext } from "react";
+import { Icon, Label, Popup } from '../semantic_ui_react_wrappers';
 import { DataModel } from "../context/DataModel";
-import { formatMetricDirection, get_metric_target } from '../utils';
+import { formatMetricDirection, formatMetricScale, formatMetricScaleAndUnit, get_metric_target } from '../utils';
 
 export function MeasurementTarget({ metric }) {
     const dataModel = useContext(DataModel)
     if (metric?.evaluate_targets === false) { return null }
     const metricDirection = formatMetricDirection(metric, dataModel)
-    let debtEnd = "";
-    if (metric.debt_end_date) {
-        const endDate = new Date(metric.debt_end_date);
-        debtEnd = ` until ${endDate.toLocaleDateString()}`;
+    const target = `${metricDirection} ${get_metric_target(metric)}${formatMetricScale(metric)}`
+    if (metric.accept_debt) {
+        const trigger = <Label color="grey">{target}</Label>
+        const unit = formatMetricScaleAndUnit(dataModel.metrics[metric.type], metric)
+        let debtEnd = "";
+        if (metric.debt_end_date) {
+            const endDate = new Date(metric.debt_end_date);
+            debtEnd = ` until ${endDate.toLocaleDateString()}`;
+        }
+        return (
+            <Popup
+                flowing
+                hoverable
+                on={['hover', 'focus']}
+                trigger={trigger}
+            >
+                {`Measurements ${metricDirection} ${metric.debt_target ?? 0}${unit} are accepted as technical debt${debtEnd}.`}
+            </Popup>
+        )
     }
-    const debt = metric.accept_debt ? ` (debt accepted${debtEnd})` : "";
-    const target = get_metric_target(metric);
-    return `${metricDirection} ${target}${metric.scale === "percentage" ? "%" : ""}${debt}`
+    return target
 }

--- a/components/frontend/src/measurement/MeasurementTarget.js
+++ b/components/frontend/src/measurement/MeasurementTarget.js
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { Icon, Label, Popup } from '../semantic_ui_react_wrappers';
+import { Label, Popup } from '../semantic_ui_react_wrappers';
 import { DataModel } from "../context/DataModel";
 import { formatMetricDirection, formatMetricScale, formatMetricScaleAndUnit, get_metric_target } from '../utils';
 

--- a/components/frontend/src/measurement/MeasurementTarget.test.js
+++ b/components/frontend/src/measurement/MeasurementTarget.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { DataModel } from '../context/DataModel';
 import { MeasurementTarget } from './MeasurementTarget';
 
@@ -39,20 +40,26 @@ it('renders the target with minutes percentage', () => {
     expect(screen.getAllByText(/≦ 0%/).length).toBe(1)
 })
 
-it('does not render the technical debt end date if technical debt is not accepted', () => {
+it('does not render the technical debt popup if technical debt is not accepted', async () => {
     render(
         <DataModel.Provider value={{ metrics: { violations: { direction: "<", unit: "violations" } } }}>
-            <MeasurementTarget metric={{ type: "violations", debt_end_date: "2022-12-31" }} />
+            <MeasurementTarget metric={{ type: "violations", target: "100", debt_end_date: "2022-12-31" }} />
         </DataModel.Provider>
     )
-    expect(screen.queryAllByText(/until /).length).toBe(0)
+    await userEvent.hover(screen.queryByText(/100/))
+    await waitFor(() => {
+        expect(screen.queryAllByText(/accepted as technical debt/).length).toBe(0)
+    })
 })
 
-it('renders the technical debt end date if technical debt is accepted', () => {
+it('renders the technical debt popup if technical debt is accepted',  async () => {
     render(
         <DataModel.Provider value={{ metrics: { violations: { direction: "<", unit: "violations" } } }}>
-            <MeasurementTarget metric={{ type: "violations", accept_debt: true, debt_end_date: "2022-12-31" }} />
+            <MeasurementTarget metric={{ type: "violations", target: "100", accept_debt: true, debt_end_date: "2022-12-31" }} />
         </DataModel.Provider>
     )
-    expect(screen.queryAllByText(/until /).length).toBe(1)
+    await userEvent.hover(screen.queryByText(/100/))
+    await waitFor(() => {
+        expect(screen.queryAllByText(/accepted as technical debt/).length).toBe(1)
+    })
 })

--- a/components/frontend/src/metric/MetricDebtParameters.js
+++ b/components/frontend/src/metric/MetricDebtParameters.js
@@ -32,11 +32,12 @@ function AcceptTechnicalDebt({ metric, metric_uuid, reload }) {
 
 function TechnicalDebtEndDate({ metric, metric_uuid, reload }) {
     const labelId = `technical-debt-end-date-label-${metric_uuid}`
+    const help = "Accept technical debt until this date."
     return (
         <DateInput
             ariaLabelledBy={labelId}
             requiredPermissions={[EDIT_REPORT_PERMISSION]}
-            label={<label id={labelId}>Technical debt end date</label>}
+            label={<label id={labelId}>Technical debt end date <Popup on={['hover', 'focus']} content={help} trigger={<Icon tabIndex="0" name="help circle" />} /></label>}
             placeholder="YYYY-MM-DD"
             set_value={(value) => set_metric_attribute(metric_uuid, "debt_end_date", value, reload)}
             value={metric.debt_end_date ?? ""}
@@ -45,7 +46,7 @@ function TechnicalDebtEndDate({ metric, metric_uuid, reload }) {
 }
 
 function IssueIdentifiers({ issue_tracker_instruction, metric, metric_uuid, report_uuid, reload }) {
-    const issueStatusHelp = `Identifiers of issues in the configured issue tracker that track the progress of fixing this metric. ${issue_tracker_instruction}`;
+    const issueStatusHelp = <><p>Identifiers of issues in the configured issue tracker that track the progress of fixing this metric.</p>{issue_tracker_instruction}</>
     const [suggestions, setSuggestions] = useState([]);
     const labelId = `issue-identifiers-label-${metric_uuid}`
     const issue_ids = get_metric_issue_ids(metric);
@@ -77,7 +78,7 @@ function IssueIdentifiers({ issue_tracker_instruction, metric, metric_uuid, repo
 export function MetricDebtParameters({ report, metric, metric_uuid, reload }) {
     const parameters = report?.issue_tracker?.parameters;
     const issueTrackerConfigured = report?.issue_tracker?.type && parameters?.url && parameters?.project_key && parameters?.issue_type;
-    const issueTrackerInstruction = issueTrackerConfigured ? "" : " Please configure an issue tracker by expanding the report title, selecting the 'Issue tracker' tab, and configuring an issue tracker.";
+    const issueTrackerInstruction = issueTrackerConfigured ? null : <p>Please configure an issue tracker by expanding the report title, selecting the 'Issue tracker' tab, and configuring an issue tracker.</p>;
     return (
         <Grid stackable columns={3}>
             <Grid.Row>

--- a/components/frontend/src/semantic_ui_react_wrappers/Label.css
+++ b/components/frontend/src/semantic_ui_react_wrappers/Label.css
@@ -2,6 +2,10 @@
     color: rgba(255, 255, 255, 0.87) !important;
 }
 
+.ui.inverted.grey.label {
+    background-color: rgba(118, 118, 118, 0.87) !important;
+}
+
 .ui.label > a {
     opacity: 1.0;
 }

--- a/components/frontend/src/utils.js
+++ b/components/frontend/src/utils.js
@@ -23,7 +23,7 @@ export function get_subject_name(subject, datamodel) {
 }
 
 export function get_metric_target(metric) {
-    return (metric.accept_debt ? metric.debt_target : metric.target) || "0";
+    return metric.target || "0";
 }
 
 export function getMetricUnit(metric, dataModel) {

--- a/components/frontend/src/utils.test.js
+++ b/components/frontend/src/utils.test.js
@@ -77,16 +77,12 @@ it('gets the metric tags even if there are none', () => {
     expect(get_metric_tags({})).toStrictEqual([]);
 });
 
+it('gets the metric target', () => {
+    expect(get_metric_target({ target: "2" })).toStrictEqual("2");
+});
+
 it('gets the metric target, even if the target is missing', () => {
     expect(get_metric_target({})).toStrictEqual("0");
-});
-
-it('gets the metric debt target, if technical debt has been accepted', () => {
-    expect(get_metric_target({ accept_debt: true, debt_target: "1" })).toStrictEqual("1");
-});
-
-it('gets the metric target, if technical debt has not been accepted', () => {
-    expect(get_metric_target({ accept_debt: false, target: "2" })).toStrictEqual("2");
 });
 
 it('gets the source name', () => {

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
-## v4.2.0-rc.1 - 2022-07-09
+## [Unreleased]
 
 ### Deployment notes
 
@@ -18,6 +18,7 @@ If your currently installed *Quality-time* version is not v4.1.0, please read th
 
 - Don't add items when hitting enter while an add-item button with collapsed dropdown menu has focus. Fixes [#4144](https://github.com/ICTU/quality-time/issues/4144).
 - Don't close the dropdown menu of an add-item button when entering a space into the filter input field. Fixes [#4147](https://github.com/ICTU/quality-time/issues/4147).
+- The target column would show the technical debt target value instead of the target value when technical debt was accepted. Fixed by always displaying the target value. In addition, if technical debt is accepted, the target value has a grey label. On hovering, a popup shows the technical debt target value and the technical debt end date, if any. Fixes [#4171](https://github.com/ICTU/quality-time/issues/4171).
 
 ### Added
 


### PR DESCRIPTION
…of the target value when technical debt was accepted. Fixed by always displaying the target value. In addition, if technical debt is accepted, the target value has a grey label. On hovering, a popup shows the technical debt target value and the technical debt end date, if any. Fixes #4171.