### PR TITLE
The documentation about exporting and importing reports via the API d…

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,7 @@ If your currently installed *Quality-time* version is not v4.2.0, please read th
 
 - In the [development documentation](https://quality-time.readthedocs.io/en/latest/development.html#adding-metrics-and-sources), mention that the parameters of the 'Quality-time' source need to be changed when adding new metrics or sources to the data model. Fixes [#4278](https://github.com/ICTU/quality-time/issues/4278).
 - When time traveling, metrics would be incorrectly flagged as not having been measured recently. Fixes [#4279](https://github.com/ICTU/quality-time/issues/4279).
+- The documentation about exporting and importing reports via the API did not mention that the public key of the destination *Quality-time* instance has to be encoded before being passed as parameter to the export endpoint of the source *Quality-time* instance. Fixes [#4313](https://github.com/ICTU/quality-time/issues/4313).
 
 ## v4.2.0 - 2022-07-22
 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -639,7 +639,7 @@ The public key endpoint returns a JSON like this:
 To be able to pass the public key as query parameter to the export endpoint, it needs to be encoded. Download the public key as file:
 
 ```console
-$ curl --output public_key.json https://quality-time.destination.org/api/v3/public_key
+curl --output public_key.json https://quality-time.destination.org/api/v3/public_key
 ```
 
 And then encode the public key as follows:

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -614,7 +614,7 @@ To use the import and export endpoints you need to be authenticated. For example
 curl --cookie-jar cookie.txt --request POST --header "Content-Type: application/json" --data '{"username": "jadoe", "password": "secret"}' https://quality-time.example.org/api/v3/login
 ```
 
-### Export API
+### Exporting reports
 
 The exporting endpoint is available via `https://quality-time.source.org/api/v3/report/<report-uuid>/json?public_key=<public-key>`. The exporting endpoint returns JSON content only.
 
@@ -649,7 +649,7 @@ $ python3 -c 'import json; import urllib.parse; key = json.load(open("public_key
 -----BEGIN+PUBLIC+KEY----- ... encoded public key ... -----END+PUBLIC+KEY-----%0A
 ```
 
-### Import API
+### Importing reports
 
 The importing endpoint is available via `https://quality-time.destination.org/api/v3/report/import`. The import endpoint accepts JSON content only. See the [example reports](https://github.com/ICTU/quality-time/tree/master/components/shared_server_code/src/shared/example-reports) for the format.
 
@@ -666,9 +666,9 @@ If the report contains encrypted credentials, the importing *Quality-time* insta
 
 To allow for seeding a *Quality-time* instance with default reports, imported reports may contain unencrypted credentials. These unencrypted credentials will be imported unchanged.
 
-### Tying it all together
+### Copying reports from one *Quality-time* instance to another
 
-To summarize, use these steps to export a report from a source *Quality-time* instance and import it into a destination instance:
+Tying the previous two sections together, these steps export a report from a source *Quality-time* instance and import it into a destination instance:
 
 ```console
 # Get the public key of the destination Quality-time

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -611,31 +611,52 @@ A *Quality-time* report in JSON format contains the latest configuration of the 
 To use the import and export endpoints you need to be authenticated. For example, using curl:
 
 ```console
-curl --cookie-jar cookie.txt --request POST --header "Content-Type: application/json" --data '{"username": "jadoe", "password": "secret"}' https://www.quality-time.example.org/api/v3/login
+curl --cookie-jar cookie.txt --request POST --header "Content-Type: application/json" --data '{"username": "jadoe", "password": "secret"}' https://quality-time.example.org/api/v3/login
 ```
 
 ### Export API
 
-The exporting endpoint is available via `https://www.quality-time.example.org/api/v3/report/<report-uuid>/json?public_key=<public-key>`. The exporting endpoint returns JSON content only.
+The exporting endpoint is available via `https://quality-time.source.org/api/v3/report/<report-uuid>/json?public_key=<public-key>`. The exporting endpoint returns JSON content only.
 
 For example, using curl, and assuming you have logged in as shown above:
 
 ```console
-curl --cookie cookie.txt --output export.json https://quality-time.example.org/api/v3/report/97b2f341-45ce-4f2b-9a71-3675f2f54cf7/json
+curl --cookie cookie.txt --output report.json https://quality-time.source.org/api/v3/report/97b2f341-45ce-4f2b-9a71-3675f2f54cf7/json
 ```
 
-The `report_uuid` is the unique identifier that *Quality-time* assigns to a report. It can be found by navigating to a report in the browser and looking for the `report_uuid` in the address bar. For example, when the URL in the browser's address bar is `https://www.quality-time.example.org/f1d0e056-2440-43bd-b640-f6753ccf4496?hidden_columns=comment`, the part between the last slash and the question mark is the `report_uuid`.
+The `report_uuid` is the unique identifier that *Quality-time* assigns to a report. It can be found by navigating to a report in the browser and looking for the `report_uuid` in the address bar. For example, when the URL in the browser's address bar is `https://quality-time.source.org/f1d0e056-2440-43bd-b640-f6753ccf4496?hidden_columns=comment`, the part between the last slash and the question mark is the `report_uuid`.
 
-The {index}`public key <Public key>` argument is optional. If no public key is provided, the public key of the exporting *Quality-time* instance is used for encrypting the source credentials. If the report needs to be imported in a different *Quality-time* instance, the public key of that instance should be provided. It can be obtained at `www.quality-time.example.org/api/v3/public_key`. The exported JSON report can only be imported into the *Quality-time* whose public key has been used for the encryption of credentials during the export.
+The {index}`public key <Public key>` argument is optional. If no public key is provided, the public key of the exporting *Quality-time* instance is used for encrypting the source credentials. If the report needs to be imported in a different *Quality-time* instance, the public key of that instance should be provided. It can be obtained at `https://quality-time.destination.org/api/v3/public_key`. The exported JSON report can only be imported into the *Quality-time* whose public key has been used for the encryption of credentials during the export.
+
+The public key endpoint returns a JSON like this:
+
+```json
+{
+  "public_key": "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAtXvAeTqsgXIb98rGfZDk\n4ZUssjjrMOCOL7xuZh6lYwN41UP0Day78tbzMxCx8mLfT76DckK1xkeGkKpS/UYD\n2ooDXluplRDGxfebZg+qy54toW878rnYe4HJu6YoDaBnthr1Muy9ttHOVB+6ucXY\nX23uzOF6FD4rZZTn4uGpEF9qfpzaVZrSpqWy9YAfZEsNNjqmbPYR+H0WjdihIpgY\n3AabLHdw02VN8cIzgh1ILLPFcBo2CqNWpETNIGdlPORfDiUx6HVxSXt80xwxFpop\n9hXQDuKSDVGlpVl5YKTwRyqEcFvhbTEJ1gJ+FksCRfrZ/hdVlI5mlCyN/gi+k3gO\nErtN0kFlIwCPyLHw5hsi/f8rLGpG1MaXmtI4fBoTbnozwaTcmoO9GO/Ell3ITTBW\nJbS3fSqKDtTU3NhalnJk5h99yQc+tgHIc+y/odKcicTDw5ZvlNIsY/ig6Z1BqYOl\n3FEI9a+I/mhcynSM/30elGsi+j/ZrWyhD6uB3E9+UtL5l7FtDWyIIoE7DaMQJZxg\nDNLCHWKACjjE+Tjr4ExUEgtzcMMmRXL2QZkylxxT9WU0Qe0U3nwJWBj6h+3xJird\npJ3weRfCPwrZ/6SxWE19tmZiynNnvnywxTJKgT15/Qkv1T0QyVCH/UeyxAhAXqYc\nBulld6J57dZwlpfWtf/ua3cCAwEAAQ==\n-----END PUBLIC KEY-----\n"
+}
+```
+
+To be able to pass the public key as query parameter to the export endpoint, it needs to be encoded. Download the public key as file:
+
+```console
+$ curl --output public_key.json https://quality-time.destination.org/api/v3/public_key
+```
+
+And then encode the public key as follows:
+
+```console
+$ python3 -c 'import json; import urllib.parse; key = json.load(open("public_key.json"))["public_key"]; print(urllib.parse.quote_plus(key))'
+-----BEGIN+PUBLIC+KEY----- ... encoded public key ... -----END+PUBLIC+KEY-----%0A
+```
 
 ### Import API
 
-The importing endpoint is available via `https://www.quality-time.example.org/api/v3/report/import`. The import endpoint accepts JSON content only. See the [example reports](https://github.com/ICTU/quality-time/tree/master/components/shared_server_code/src/shared/example-reports) for the format.
+The importing endpoint is available via `https://quality-time.destination.org/api/v3/report/import`. The import endpoint accepts JSON content only. See the [example reports](https://github.com/ICTU/quality-time/tree/master/components/shared_server_code/src/shared/example-reports) for the format.
 
 For example, using curl, and assuming you have logged in as shown above:
 
 ```console
-$ curl --cookie cookie.txt --request POST --header "Content-Type: application/json" --data @report-to-import.json https://www.quality-time.example.org/api/v3/report/import
+$ curl --cookie cookie.txt --request POST --header "Content-Type: application/json" --data @report.json https://quality-time.destination.org/api/v3/report/import
 {"ok": true, "new_report_uuid": "97a3e341-44ce-4f2b-4471-36e5f2f34cf6"}
 ```
 
@@ -644,6 +665,26 @@ On import, all UUID's contained in the report (UUID's of the report, subjects, m
 If the report contains encrypted credentials, the importing *Quality-time* instance will decrypt the credentials using its public key. Note that if the credentials were encrypted using the public key of a different *Quality-time* instance, an error will occur, and the import will fail.
 
 To allow for seeding a *Quality-time* instance with default reports, imported reports may contain unencrypted credentials. These unencrypted credentials will be imported unchanged.
+
+### Tying it all together
+
+To summarize, use these steps to export a report from a source *Quality-time* instance and import it into a destination instance:
+
+```console
+# Get the public key of the destination Quality-time
+$ curl --output public_key.json https://quality-time.destination.org/api/v3/public_key
+# Encode the public key
+$ python3 -c 'import json; import urllib.parse; key = json.load(open("public_key.json"))["public_key"]; print(urllib.parse.quote_plus(key))'
+-----BEGIN+PUBLIC+KEY-----encoded-public-key-----END+PUBLIC+KEY-----%0A
+# Log in to the source Quality-time
+$ curl --cookie-jar cookie.txt --request POST --header "Content-Type: application/json" --data '{"username": "jadoe", "password": "secret"}' https://quality-time.source.org/api/v3/login
+# Copy the public key and use it in the next line to export the report
+$ curl --cookie cookie.txt --output report.json https://quality-time.source.org/api/v3/report/1352450b-30fa-4a82-aec5-7b5d0017ee13/json?public_key=-----BEGIN+PUBLIC+KEY-----encoded-public-key-----END+PUBLIC+KEY-----%0A
+# Log in to the destination Quality-time
+$ curl --cookie-jar cookie.txt --request POST --header "Content-Type: application/json" --data '{"username": "jadoe", "password": "secret"}' https://quality-time.destination.org/api/v3/login
+# Import the report in the destination Quality-time
+$ curl --cookie cookie.txt --request POST --header "Content-Type: application/json" --data @report.json https://quality-time.destination.org/api/v3/report/import
+```
 
 ```{index} Issue tracker
 ```


### PR DESCRIPTION
…id not mention that the public key of the destination *Quality-time* instance has to be encoded before being passed as parameter to the export endpoint of the source *Quality-time* instance. Fixes #4313.