### PR TITLE
The status start date of metrics would only be set on their first sta…

### DIFF
--- a/components/external_server/tests/routes/test_metric.py
+++ b/components/external_server/tests/routes/test_metric.py
@@ -197,13 +197,21 @@ class PostMetricAttributeTest(unittest.TestCase):
         self.database.measurements.find_one.return_value = dict(_id="id", metric_uuid=METRIC_ID, sources=[])
         self.database.measurements.insert_one.side_effect = self.set_measurement_id
         request.json = dict(target="10")
-        self.assertEqual(
+        self.assertDictEqual(
             dict(
                 end="2019-01-01",
                 sources=[],
                 start="2019-01-01",
                 metric_uuid=METRIC_ID,
-                count=dict(status=None, value=None, target="10", near_target="10", debt_target=None, direction="<"),
+                count=dict(
+                    status=None,
+                    status_start="2019-01-01",
+                    value=None,
+                    target="10",
+                    near_target="10",
+                    debt_target=None,
+                    direction="<",
+                ),
             ),
             post_metric_attribute(METRIC_ID, "target", self.database),
         )
@@ -227,6 +235,7 @@ class PostMetricAttributeTest(unittest.TestCase):
                 count=dict(
                     value=None,
                     status=None,
+                    status_start="2019-01-01",
                     target="0",
                     near_target="10",
                     debt_target=None,
@@ -278,7 +287,15 @@ class PostMetricAttributeTest(unittest.TestCase):
         self.database.measurements.find_one.return_value = dict(_id="id", metric_uuid=METRIC_ID, sources=[])
         self.database.measurements.insert_one.side_effect = self.set_measurement_id
         request.json = dict(debt_end_date="2019-06-07")
-        count = dict(value=None, status=None, target="0", near_target="10", debt_target=None, direction="<")
+        count = dict(
+            value=None,
+            status=None,
+            status_start="2019-01-01",
+            target="0",
+            near_target="10",
+            debt_target=None,
+            direction="<",
+        )
         new_measurement = dict(end="2019-01-01", sources=[], start="2019-01-01", metric_uuid=METRIC_ID, count=count)
         self.assertEqual(new_measurement, post_metric_attribute(METRIC_ID, "debt_end_date", self.database))
         updated_report = self.database.reports.insert_one.call_args[0][0]

--- a/components/internal_server/tests/routes/test_measurement.py
+++ b/components/internal_server/tests/routes/test_measurement.py
@@ -117,7 +117,10 @@ class PostMeasurementTests(unittest.TestCase):
         request.json = self.posted_measurement
         post_measurement(self.database)
         self.database.measurements.insert_one.assert_called_once_with(
-            self.measurement(count=self.scale_measurement(value="2", status="near_target_met"), sources=sources)
+            self.measurement(
+                count=self.scale_measurement(value="2", status="near_target_met", status_start="2019-01-01"),
+                sources=sources,
+            )
         )
 
     def test_first_measurement_two_scales(self, request):
@@ -130,8 +133,8 @@ class PostMeasurementTests(unittest.TestCase):
         self.database.measurements.insert_one.assert_called_once_with(
             self.measurement(
                 sources=sources,
-                count=self.scale_measurement(value="2", status="near_target_met"),
-                percentage=dict(direction="<", value="1", status="target_not_met"),
+                count=self.scale_measurement(value="2", status="near_target_met", status_start="2019-01-01"),
+                percentage=dict(direction="<", value="1", status="target_not_met", status_start="2019-01-01"),
             )
         )
 
@@ -146,7 +149,9 @@ class PostMeasurementTests(unittest.TestCase):
             self.measurement(
                 metric_uuid=METRIC_ID2,
                 sources=[self.source(value="1.1.3")],
-                version_number=self.scale_measurement(value="1.1.3", status="near_target_met"),
+                version_number=self.scale_measurement(
+                    value="1.1.3", status="near_target_met", status_start="2019-01-01"
+                ),
             )
         )
 

--- a/components/shared_server_code/src/shared/model/measurement.py
+++ b/components/shared_server_code/src/shared/model/measurement.py
@@ -49,16 +49,10 @@ class ScaleMeasurement(dict):  # lgtm [py/missing-equals]
 
     def __set_status_start(self, status: str | None) -> None:
         """Set the status start date."""
-        if (previous := self.__previous_scale_measurement) is None:
-            return
-
-        if status == previous.status():
-            status_start = previous.status_start()
-        else:
-            status_start = self._measurement["start"]
-
-        if status_start:
-            self["status_start"] = status_start
+        previous = self.__previous_scale_measurement
+        self["status_start"] = (
+            previous.status_start() if previous and previous.status() == status else self._measurement["start"]
+        )
 
     def update_targets(self) -> None:
         """Update the measurement targets."""

--- a/components/shared_server_code/tests/shared/model/test_measurement.py
+++ b/components/shared_server_code/tests/shared/model/test_measurement.py
@@ -77,11 +77,12 @@ class ScaleMeasurementTest(MeasurementTestCase):
         self.assertEqual(status_start, "yesterday")
 
     def test_status_start_empty(self):
-        """The status_start should return None."""
-        measurement = Measurement(self.metric())
+        """The status_start should return the start of the measurement."""
+        measurement = Measurement(self.metric(), start="now")
         s_m = ScaleMeasurement(previous_scale_measurement=None, measurement=measurement)
+        s_m.update_value_and_status()
         status_start = s_m.status_start()
-        self.assertIs(status_start, None)
+        self.assertIs(status_start, "now")
 
     def test_set_status_start(self):
         """Test status_start."""
@@ -112,18 +113,6 @@ class ScaleMeasurementTest(MeasurementTestCase):
         s_m = ScaleMeasurement(previous_scale_measurement=previous_s_m, measurement=measurement)
         s_m._ScaleMeasurement__set_status_start("target_not_met")  # pylint: disable=protected-access
         self.assertEqual(s_m.status_start(), measurement["start"])
-
-    def test_set_status_start_no_status_start(self):
-        """Test status_start."""
-        measurement = Measurement(self.metric())
-        previous_s_m = ScaleMeasurement(
-            previous_scale_measurement=None,
-            measurement=measurement,
-            status="target_met",
-        )
-        s_m = ScaleMeasurement(previous_scale_measurement=previous_s_m, measurement=measurement)
-        s_m._ScaleMeasurement__set_status_start("target_met")  # pylint: disable=protected-access
-        self.assertIs(s_m.status_start(), None)
 
     @patch.object(
         ScaleMeasurement,

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,6 +19,7 @@ If your currently installed *Quality-time* version is not v4.2.0, please read th
 - In the [development documentation](https://quality-time.readthedocs.io/en/latest/development.html#adding-metrics-and-sources), mention that the parameters of the 'Quality-time' source need to be changed when adding new metrics or sources to the data model. Fixes [#4278](https://github.com/ICTU/quality-time/issues/4278).
 - When time traveling, metrics would be incorrectly flagged as not having been measured recently. Fixes [#4279](https://github.com/ICTU/quality-time/issues/4279).
 - The documentation about exporting and importing reports via the API did not mention that the public key of the destination *Quality-time* instance has to be encoded before being passed as parameter to the export endpoint of the source *Quality-time* instance. Fixes [#4313](https://github.com/ICTU/quality-time/issues/4313).
+- The status start date of metrics would only be set on their first status *change*, not on their first status. Fixes [#4327](https://github.com/ICTU/quality-time/issues/4327).
 
 ## v4.2.0 - 2022-07-22
 


### PR DESCRIPTION
…tus *change*, not on their first status. Fixes #4327.