### PR TITLE
When measuring failed or unused CI-jobs, Jenkins multibranch pipeline…

### DIFF
--- a/components/collector/src/model/entity.py
+++ b/components/collector/src/model/entity.py
@@ -1,6 +1,10 @@
 """Measurement entity model class."""
 
 from collections.abc import Iterable
+import re
+
+
+QUOTED_SLASH = re.compile("%2f", re.IGNORECASE)
 
 
 class Entity(dict):
@@ -13,8 +17,8 @@ class Entity(dict):
 
     @staticmethod
     def safe_entity_key(key: str) -> str:
-        """Return a escaped version of the key that is safe in URLs and as Mongo document key."""
-        return str(key).replace("/", "-").replace(".", "_")
+        """Return an escaped version of the key that is safe in URLs and as Mongo document key."""
+        return re.sub(QUOTED_SLASH, "-", str(key).replace("/", "-").replace(".", "_"))
 
 
 class Entities(list[Entity]):

--- a/components/collector/tests/model/test_entity.py
+++ b/components/collector/tests/model/test_entity.py
@@ -12,3 +12,10 @@ class EntityTest(unittest.TestCase):
         """Test that duplicate entities are removed on initialization."""
         entities = Entities([Entity(key="1"), Entity(key="2"), Entity(key="2")])
         self.assertEqual(2, len(entities))
+
+    def test_entity_key(self):
+        """Test that unsafe characters are replaced."""
+        self.assertEqual("_", Entity(".")["key"])
+        self.assertEqual("-", Entity("/")["key"])
+        self.assertEqual("-", Entity(r"%2f")["key"])
+        self.assertEqual("-", Entity(r"%2F")["key"])

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -20,7 +20,7 @@ If your currently installed *Quality-time* version is not v4.2.0, please read th
 - When time traveling, metrics would be incorrectly flagged as not having been measured recently. Fixes [#4279](https://github.com/ICTU/quality-time/issues/4279).
 - The documentation about exporting and importing reports via the API did not mention that the public key of the destination *Quality-time* instance has to be encoded before being passed as parameter to the export endpoint of the source *Quality-time* instance. Fixes [#4313](https://github.com/ICTU/quality-time/issues/4313).
 - The status start date of metrics would only be set on their first status *change*, not on their first status. Fixes [#4327](https://github.com/ICTU/quality-time/issues/4327).
-- When measuring failed or unused CI-jobs, Jenkins multibranch pipeline jobs based on branch names containing forward slashes (for example 'feature/432-new-customer') could not be marked as false positive. Fixes [#4434](https://github.com/ICTU/quality-time/issues/4434).
+- When measuring failed or unused CI-jobs, Jenkins multi-branch pipeline jobs based on branch names containing forward slashes (for example 'feature/432-new-customer') could not be marked as false positive. Fixes [#4434](https://github.com/ICTU/quality-time/issues/4434).
 
 ### Added
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
-## v4.3.0-rc.1 - 2022-08-15
+## [Unreleased]
 
 ### Deployment notes
 
@@ -20,6 +20,7 @@ If your currently installed *Quality-time* version is not v4.2.0, please read th
 - When time traveling, metrics would be incorrectly flagged as not having been measured recently. Fixes [#4279](https://github.com/ICTU/quality-time/issues/4279).
 - The documentation about exporting and importing reports via the API did not mention that the public key of the destination *Quality-time* instance has to be encoded before being passed as parameter to the export endpoint of the source *Quality-time* instance. Fixes [#4313](https://github.com/ICTU/quality-time/issues/4313).
 - The status start date of metrics would only be set on their first status *change*, not on their first status. Fixes [#4327](https://github.com/ICTU/quality-time/issues/4327).
+- When measuring failed or unused CI-jobs, Jenkins multibranch pipeline jobs based on branch names containing forward slashes (for example 'feature/432-new-customer') could not be marked as false positive. Fixes [#4434](https://github.com/ICTU/quality-time/issues/4434).
 
 ### Added
 


### PR DESCRIPTION
… jobs based on branch names containing forward slashes (for example 'feature/432-new-customer') could not be marked as false positive. Fixes #4434.