### PR TITLE
When creating issues, include the rationale for the metric in the cre…

### DIFF
--- a/components/external_server/src/routes/metric.py
+++ b/components/external_server/src/routes/metric.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 import bottle
 from pymongo.database import Database
 
+from shared_data_model import DATA_MODEL
 from shared.database.datamodels import latest_datamodel
 from shared.database.measurements import insert_new_measurement, latest_measurement
 from shared.database.reports import insert_new_report
@@ -172,5 +173,6 @@ def create_issue_description(metric, subject, report) -> str:
     metric_url = dict(bottle.request.json)["metric_url"]
     return (
         f"Metric '[{metric.name}|{metric_url}]' of subject '{subject.name}' "
-        f"in Quality-time report '{report.name}' needs attention."
+        f"in Quality-time report '{report.name}' needs attention.\n\n"
+        f"Why address '{metric.name}'? {DATA_MODEL.metrics[metric.type()].rationale}"
     )

--- a/components/external_server/tests/routes/test_metric.py
+++ b/components/external_server/tests/routes/test_metric.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 import requests
 
+from shared_data_model import DATA_MODEL
 from shared.model.report import Report
 
 from routes import (
@@ -522,7 +523,7 @@ class MetricIssueTest(unittest.TestCase):
             dict(
                 report_uuid=REPORT_ID,
                 issue_tracker=dict(parameters=dict(url="https://tracker", project_key="KEY", issue_type="BUG")),
-                subjects={SUBJECT_ID: dict(name="Subject", metrics={METRIC_ID: dict(name="name")})},
+                subjects={SUBJECT_ID: dict(name="Subject", metrics={METRIC_ID: dict(type="violations", name="name")})},
             ),
         )
         self.database.reports.find.return_value = [report]
@@ -548,7 +549,8 @@ class MetricIssueTest(unittest.TestCase):
                     "issuetype": {"name": "BUG"},
                     "summary": "Quality-time metric 'name'",
                     "description": "Metric '[name|https://quality_time/metric42]' of subject "
-                    "'Subject' in Quality-time report '' needs attention.",
+                    "'Subject' in Quality-time report '' needs attention.\n\n"
+                    f"Why address 'name'? {DATA_MODEL.metrics['violations'].rationale}",
                 }
             },
         )

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Deployment notes
+
+If your currently installed *Quality-time* version is not v4.3.0, please read the v4.3.0 deployment notes.
+
+### Added
+
+- When creating issues, include the rationale for the metric in the created issue so that people encountering the issue in the issue tracker have a better understanding of why the issue needs addressing. Closes [#4232](https://github.com/ICTU/quality-time/issues/4232).
+
 ## v4.3.0 - 2022-08-24
 
 ### Deployment notes


### PR DESCRIPTION
…ated issue so that people encountering the issue in the issue tracker have a better understanding of why the issue needs addressing. Closes #4232.