### PR TITLE
 When changing the type of a metric with configured sources, don't re…

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 If your currently installed *Quality-time* version is not v4.3.0, please read the v4.3.0 deployment notes.
 
-###  Fixed
+### Fixed
 
 - When changing the type of a metric with configured sources, don't remove the sources that support both the old and the new metric type. Fixes [#4443](https://github.com/ICTU/quality-time/issues/4443).
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 If your currently installed *Quality-time* version is not v4.3.0, please read the v4.3.0 deployment notes.
 
+###  Fixed
+
+- When changing the type of a metric with configured sources, don't remove the sources that support both the old and the new metric type. Fixes [#4443](https://github.com/ICTU/quality-time/issues/4443).
+
 ### Added
 
 - When creating issues, include the rationale for the metric in the created issue so that people encountering the issue in the issue tracker have a better understanding of why the issue needs addressing. Closes [#4232](https://github.com/ICTU/quality-time/issues/4232).

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -205,7 +205,11 @@ After you've added a metric, the metric is visible in the subject's metric table
 :class: only-dark
 ```
 
-The first parameter is the "Metric type". The metric type determines what gets measured. When you change the metric type, the sources you can select in the "Sources" tab change accordingly. By default, the name of the metric is equal to its type, "Accessibility violations" in the example above, but you can change the metric name using the "Metric name" field.
+The first parameter is the "Metric type". The metric type determines what gets measured. By default, the name of the metric is equal to its type, "Accessibility violations" in the example above, but you can change the metric name using the "Metric name" field. When you change the metric type, the sources you can select in the "Sources" tab change accordingly.
+
+```{warning}
+If you change the type of a metric that has sources configured, sources that do not support the new metric type will be removed.
+```
 
 Metrics can have zero or more arbitrary "{index}`Tags <Tag>`". Most metric have a default tag, but you can remove it and/or add more if you like. For each tag, the report dashboard at the top of the page shows a summary of the metrics with that tag:
 


### PR DESCRIPTION
…move the sources that support both the old and the new metric type. Fixes #4443.