### PR TITLE
Make Jira issue ids uppercase when querying Jira for the status of is…

### DIFF
--- a/components/collector/src/source_collectors/jira/issue_status.py
+++ b/components/collector/src/source_collectors/jira/issue_status.py
@@ -26,7 +26,7 @@ class JiraIssueStatus(JiraBase):
         # Capitalize the issue id because for some reason the URL is case sensitive and Jira ids are always full caps
         return URL(f"{url}/rest/agile/1.0/issue/{self._issue_id.upper()}?fields={fields}")
 
-    async def _landing_url(self, responses: SourceResponses) -> URL:
+    async def _landing_url(self, responses: SourceResponses) -> URL:  # skipcq: PYL-W0613
         """Override to add the issue to the landing URL."""
         url = await super()._api_url()
         return URL(f"{url}/browse/{self._issue_id}")  # Don't need upper() here; the browse URL is not case sensitive

--- a/components/collector/src/source_collectors/jira/issue_status.py
+++ b/components/collector/src/source_collectors/jira/issue_status.py
@@ -23,12 +23,13 @@ class JiraIssueStatus(JiraBase):
         """Override to get the issue, including the status field, from Jira."""
         url = await super()._api_url()
         fields = "created,status,summary,updated,duedate,fixVersions,sprint"
-        return URL(f"{url}/rest/agile/1.0/issue/{self._issue_id}?fields={fields}")
+        # Capitalize the issue id because for some reason the URL is case sensitive and Jira ids are always full caps
+        return URL(f"{url}/rest/agile/1.0/issue/{self._issue_id.upper()}?fields={fields}")
 
     async def _landing_url(self, responses: SourceResponses) -> URL:
         """Override to add the issue to the landing URL."""
         url = await super()._api_url()
-        return URL(f"{url}/browse/{self._issue_id}")
+        return URL(f"{url}/browse/{self._issue_id}")  # Don't need upper() here; the browse URL is not case sensitive
 
     async def _parse_issue_status(self, responses: SourceResponses) -> IssueStatus:
         """Override to get the issue status from the responses."""

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -21,7 +21,7 @@ If your currently installed *Quality-time* version is not v4.3.0, please read th
 ### Added
 
 - When creating issues, include the rationale for the metric in the created issue so that people encountering the issue in the issue tracker have a better understanding of why the issue needs addressing. Closes [#4232](https://github.com/ICTU/quality-time/issues/4232).
-- Make Jira issue ids uppercase when querying Jira for the status of issues, so that users don't have to enter uppercase Jira ids in *Quality-time*. Closes [#4450](https://github.com/ICTU/quality-time/issues/4450).
+- Make Jira issue identifiers uppercase when querying Jira for the status of issues, so that users don't have to enter uppercase Jira identifiers in *Quality-time*. Closes [#4450](https://github.com/ICTU/quality-time/issues/4450).
 
 ## v4.3.0 - 2022-08-24
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -21,6 +21,7 @@ If your currently installed *Quality-time* version is not v4.3.0, please read th
 ### Added
 
 - When creating issues, include the rationale for the metric in the created issue so that people encountering the issue in the issue tracker have a better understanding of why the issue needs addressing. Closes [#4232](https://github.com/ICTU/quality-time/issues/4232).
+- Make Jira issue ids uppercase when querying Jira for the status of issues, so that users don't have to enter uppercase Jira ids in *Quality-time*. Closes [#4450](https://github.com/ICTU/quality-time/issues/4450).
 
 ## v4.3.0 - 2022-08-24
 


### PR DESCRIPTION
…sues, so that users don't have to enter uppercase Jira ids in Quality-time. Closes #4450.