### PR TITLE
When measuring violations with SonarQube as source, add the selected …

### DIFF
--- a/components/collector/src/source_collectors/sonarqube/security_warnings.py
+++ b/components/collector/src/source_collectors/sonarqube/security_warnings.py
@@ -26,7 +26,7 @@ class SonarQubeSecurityWarnings(SonarQubeViolations):
             landing_path = "project/issues"
             extra_url_parameters = f"{self._query_parameter('severities')}&resolved=false&types=VULNERABILITY"
         else:
-            landing_path = "security_hotspots"
+            landing_path = "project/security_hotspots"
         return URL(f"{base_landing_url}/{landing_path}{common_url_parameters}{extra_url_parameters}")
 
     async def _get_source_responses(self, *urls: URL, **kwargs) -> SourceResponses:

--- a/components/collector/src/source_collectors/sonarqube/security_warnings.py
+++ b/components/collector/src/source_collectors/sonarqube/security_warnings.py
@@ -24,6 +24,7 @@ class SonarQubeSecurityWarnings(SonarQubeViolations):
             landing_path = "dashboard"
         elif "vulnerability" in security_types:
             landing_path = "project/issues"
+            # We don't use self._query_parameter() because when we get here, the value of the types parameter is fixed
             extra_url_parameters = f"{self._query_parameter('severities')}&resolved=false&types=VULNERABILITY"
         else:
             landing_path = "project/security_hotspots"

--- a/components/collector/src/source_collectors/sonarqube/security_warnings.py
+++ b/components/collector/src/source_collectors/sonarqube/security_warnings.py
@@ -29,7 +29,7 @@ class SonarQubeSecurityWarnings(SonarQubeViolations):
             landing_path = "project/security_hotspots"
         return URL(f"{base_landing_url}/{landing_path}{common_url_parameters}{extra_url_parameters}")
 
-    async def _get_source_responses(self, *urls: URL, **kwargs) -> SourceResponses:
+    async def _get_source_responses(self, *urls: URL, **kwargs) -> SourceResponses:  # skipcq: PYL-W0613
         """Extend to add urls for the selected security types."""
         api_urls = []
         security_types = self._parameter(self.types_parameter)

--- a/components/collector/src/source_collectors/sonarqube/suppressed_violations.py
+++ b/components/collector/src/source_collectors/sonarqube/suppressed_violations.py
@@ -34,8 +34,8 @@ class SonarQubeSuppressedViolations(SonarQubeViolations):
         branch = self._parameter("branch")
         all_issues_api_url = URL(f"{url}/api/issues/search?componentKeys={component}&branch={branch}")
         resolved_issues_api_url = URL(
-            f"{all_issues_api_url}&status=RESOLVED&resolutions=WONTFIX,FALSE-POSITIVE&ps=500&"
-            f"severities={self._violation_severities()}&types={self._violation_types()}"
+            f"{all_issues_api_url}&status=RESOLVED&resolutions=WONTFIX,FALSE-POSITIVE&ps=500"
+            f"{self._query_parameter('severities')}{self._query_parameter(self.types_parameter)}"
         )
         return await super()._get_source_responses(*(urls + (resolved_issues_api_url, all_issues_api_url)), **kwargs)
 

--- a/components/collector/src/source_collectors/sonarqube/suppressed_violations.py
+++ b/components/collector/src/source_collectors/sonarqube/suppressed_violations.py
@@ -12,7 +12,7 @@ class SonarQubeSuppressedViolations(SonarQubeViolations):
 
     rules_configuration = "suppression_rules"
 
-    async def _landing_url(self, responses: SourceResponses) -> URL:
+    async def _landing_url(self, responses: SourceResponses) -> URL:  # skipcq: PYL-W0613
         """Override to not include the rules parameter in the landing URL.
 
         This collector uses two SonarQube endpoints to get the suppressed violations. As we can't include both URLs in

--- a/components/collector/tests/source_collectors/sonarqube/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_security_warnings.py
@@ -127,5 +127,9 @@ class SonarQubeSecurityWarningsTest(SonarQubeTestCase):
         """Test that by default only the vulnerabilities are returned."""
         response = await self.collect(get_request_json_return_value=self.vulnerabilities_json)
         self.assert_measurement(
-            response, value="2", total="100", entities=self.vulnerability_entities, landing_url=self.issues_landing_url
+            response,
+            value="2",
+            total="100",
+            entities=self.vulnerability_entities,
+            landing_url="https://sonarqube/project/issues?id=id&branch=master&resolved=false&types=VULNERABILITY",
         )

--- a/components/collector/tests/source_collectors/sonarqube/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_security_warnings.py
@@ -120,7 +120,7 @@ class SonarQubeSecurityWarningsTest(SonarQubeTestCase):
             value="2",
             total="100",
             entities=self.hotspot_entities,
-            landing_url="https://sonarqube/security_hotspots?id=id&branch=master",
+            landing_url="https://sonarqube/project/security_hotspots?id=id&branch=master",
         )
 
     async def test_security_warnings_vulnerabilities_only(self):

--- a/components/collector/tests/source_collectors/sonarqube/test_violations.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_violations.py
@@ -8,9 +8,10 @@ class SonarQubeViolationsTest(SonarQubeTestCase):
 
     METRIC_TYPE = "violations"
 
-    async def test_violations(self):
-        """Test that the number of violations is returned."""
-        json = dict(
+    def setUp(self):
+        """Extend to set up the SonarQube violations."""
+        super().setUp()
+        self.json = dict(
             total="2",
             issues=[
                 dict(
@@ -33,7 +34,10 @@ class SonarQubeViolationsTest(SonarQubeTestCase):
                 ),
             ],
         )
-        response = await self.collect(get_request_json_return_value=json)
+
+    async def test_violations(self):
+        """Test that the number of violations is returned."""
+        response = await self.collect(get_request_json_return_value=self.json)
         expected_entities = [
             self.entity(
                 key="violation1",
@@ -55,3 +59,27 @@ class SonarQubeViolationsTest(SonarQubeTestCase):
             ),
         ]
         self.assert_measurement(response, value="2", entities=expected_entities, landing_url=self.issues_landing_url)
+
+    async def test_major_violations(self):
+        """Test that the number of major violations is returned."""
+        self.set_source_parameter("severities", ["major"])
+        self.json["total"] = 1
+        del self.json["issues"][0]
+        response = await self.collect(get_request_json_return_value=self.json)
+        expected_entities = [
+            self.entity(
+                key="violation2",
+                component="component2",
+                entity_type="code_smell",
+                message="message2",
+                severity="major",
+                creation_date="2019-08-30T21:48:52+0200",
+                update_date="2019-09-30T21:48:52+0200",
+            ),
+        ]
+        self.assert_measurement(
+            response,
+            value="1",
+            entities=expected_entities,
+            landing_url=self.issues_landing_url + "&severities=MAJOR",
+        )

--- a/components/collector/tests/source_collectors/sonarqube/test_violations.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_violations.py
@@ -34,11 +34,7 @@ class SonarQubeViolationsTest(SonarQubeTestCase):
                 ),
             ],
         )
-
-    async def test_violations(self):
-        """Test that the number of violations is returned."""
-        response = await self.collect(get_request_json_return_value=self.json)
-        expected_entities = [
+        self.expected_entities = [
             self.entity(
                 key="violation1",
                 component="component1",
@@ -58,7 +54,13 @@ class SonarQubeViolationsTest(SonarQubeTestCase):
                 update_date="2019-09-30T21:48:52+0200",
             ),
         ]
-        self.assert_measurement(response, value="2", entities=expected_entities, landing_url=self.issues_landing_url)
+
+    async def test_violations(self):
+        """Test that the number of violations is returned."""
+        response = await self.collect(get_request_json_return_value=self.json)
+        self.assert_measurement(
+            response, value="2", entities=self.expected_entities, landing_url=self.issues_landing_url
+        )
 
     async def test_major_violations(self):
         """Test that the number of major violations is returned."""
@@ -66,20 +68,10 @@ class SonarQubeViolationsTest(SonarQubeTestCase):
         self.json["total"] = 1
         del self.json["issues"][0]
         response = await self.collect(get_request_json_return_value=self.json)
-        expected_entities = [
-            self.entity(
-                key="violation2",
-                component="component2",
-                entity_type="code_smell",
-                message="message2",
-                severity="major",
-                creation_date="2019-08-30T21:48:52+0200",
-                update_date="2019-09-30T21:48:52+0200",
-            ),
-        ]
+        del self.expected_entities[0]
         self.assert_measurement(
             response,
             value="1",
-            entities=expected_entities,
+            entities=self.expected_entities,
             landing_url=self.issues_landing_url + "&severities=MAJOR",
         )

--- a/components/collector/tests/source_collectors/sonarqube/test_violations.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_violations.py
@@ -75,3 +75,14 @@ class SonarQubeViolationsTest(SonarQubeTestCase):
             entities=self.expected_entities,
             landing_url=self.issues_landing_url + "&severities=MAJOR",
         )
+
+    async def test_multiple_violation_severities(self):
+        """Test that the number of violations is returned and that the landing URL points to the selected severities."""
+        self.set_source_parameter("severities", ["info", "minor", "major"])
+        response = await self.collect(get_request_json_return_value=self.json)
+        self.assert_measurement(
+            response,
+            value="2",
+            entities=self.expected_entities,
+            landing_url=self.issues_landing_url + "&severities=INFO,MAJOR,MINOR",
+        )

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -21,6 +21,7 @@ If your currently installed *Quality-time* version is not v4.3.0, please read th
 ### Added
 
 - When creating issues, include the rationale for the metric in the created issue so that people encountering the issue in the issue tracker have a better understanding of why the issue needs addressing. Closes [#4232](https://github.com/ICTU/quality-time/issues/4232).
+- When measuring violations with SonarQube as source, add the selected issue types (bug, vulnerability, and/or code smell) and severities (info, minor, major, critical, and/or blocker) to the landing URL so that the user sees only the relevant violations when navigating to SonarQube. Closes [#4449](https://github.com/ICTU/quality-time/issues/4449).
 - Make Jira issue identifiers uppercase when querying Jira for the status of issues, so that users don't have to enter uppercase Jira identifiers in *Quality-time*. Closes [#4450](https://github.com/ICTU/quality-time/issues/4450).
 
 ## v4.3.0 - 2022-08-24


### PR DESCRIPTION
…issue types (bug, vulnerability, and/or code smell) and severities (info, minor, major, critical, and/or blocker) to the landing URL so that the user sees only the relevant violations when navigating to SonarQube. Closes #4449.