### PR TITLE
Due to a small change to the loading spinner, *Quality-time* would no…

### DIFF
--- a/components/renderer/src/index.js
+++ b/components/renderer/src/index.js
@@ -24,7 +24,7 @@ app.get("/api/render", async (req, res) => {
             timeout: 60000
         });
         console.log(`URL ${url}: opened`);
-        await webPage.waitForSelector(".loading", { hidden: true });
+        await webPage.waitForSelector(".loader", { hidden: true });
         console.log(`URL ${url}: spinner hidden`);
         const pdf = await webPage.pdf({
             printBackground: true,

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is not v4.3.0, please read th
 ### Fixed
 
 - When changing the type of a metric with configured sources, don't remove the sources that support both the old and the new metric type. Fixes [#4443](https://github.com/ICTU/quality-time/issues/4443).
+- Due to a small change to the loading spinner, *Quality-time* would no longer wait for the spinner to disappear before converting a report to PDF, causing the PDF to be empty for big reports. Fixes [#4542](https://github.com/ICTU/quality-time/issues/4542).
 
 ### Added
 


### PR DESCRIPTION
… longer wait for the spinner to disappear before converting a report to PDF, causing the PDF to be empty for big reports. Fixes #4542.