### PR TITLE
Clicking the Quality-time logo should navigate to the home page, but …

### DIFF
--- a/components/frontend/src/AppUI.js
+++ b/components/frontend/src/AppUI.js
@@ -98,8 +98,8 @@ export function AppUI({
             <DarkMode.Provider value={darkMode}>
                 <HashLinkObserver />
                 <Menubar
+                    atHome={report_uuid === ""}
                     clearVisibleDetailsTabs={clearVisibleDetailsTabs}
-                    current_report={current_report}
                     email={email}
                     go_home={go_home}
                     onDate={handleDateChange}

--- a/components/frontend/src/header_footer/Menubar.js
+++ b/components/frontend/src/header_footer/Menubar.js
@@ -53,8 +53,8 @@ function Logout({ user, email, set_user }) {
 }
 
 export function Menubar({
+    atHome,
     clearVisibleDetailsTabs,
-    current_report,
     email,
     go_home,
     onDate,
@@ -77,10 +77,10 @@ export function Menubar({
                 <Menu.Menu position="left">
                     <Popup
                         content="Go to reports overview"
-                        disabled={!current_report}
+                        disabled={atHome}
                         trigger={
-                            <div onKeyPress={(event) => { event.preventDefault(); setPanelVisible(false); go_home() }} tabIndex={current_report ? 0 : -1}>
-                                <Menu.Item header onClick={current_report ? () => { setPanelVisible(false); go_home() } : null}>
+                            <div onKeyPress={(event) => { event.preventDefault(); setPanelVisible(false); go_home() }} tabIndex={atHome ? -1 : 0}>
+                                <Menu.Item header onClick={atHome ? null : () => { setPanelVisible(false); go_home() } }>
                                     <Image size='mini' src='/favicon.ico' alt="Go home" />
                                     <span style={{ paddingLeft: "6mm", fontSize: "2em" }}>Quality-time</span>
                                 </Menu.Item>

--- a/components/frontend/src/header_footer/Menubar.test.js
+++ b/components/frontend/src/header_footer/Menubar.test.js
@@ -37,7 +37,7 @@ it('logs out', async () => {
 it('does not go to home page if on reports overview', async () => {
     const go_home = jest.fn();
     await act(async () => {
-        render(<Menubar go_home={go_home} />);
+        render(<Menubar atHome={true} go_home={go_home} />);
         fireEvent.click(screen.getByAltText(/Go home/));
     });
     expect(go_home).not.toHaveBeenCalled();
@@ -46,7 +46,7 @@ it('does not go to home page if on reports overview', async () => {
 it('goes to home page if on report', async () => {
     const go_home = jest.fn();
     await act(async () => {
-        render(<Menubar current_report={{}} go_home={go_home} />);
+        render(<Menubar atHome={false} go_home={go_home} />);
         fireEvent.click(screen.getByAltText(/Go home/));
     });
     expect(go_home).toHaveBeenCalled();
@@ -72,7 +72,7 @@ it('shows the view panel on menu item click', async () => {
 ["{Enter}", " ", "x"].forEach(key => {
     it('shows the view panel on enter', async () => {
         await act(async () => {
-            render(<Menubar panel={<div>Hello</div>} />);
+            render(<Menubar atHome={true} panel={<div>Hello</div>} />);
         });
         await userEvent.tab()  // Move focus to the settings button
         await userEvent.keyboard(key)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,6 +19,7 @@ If your currently installed *Quality-time* version is not v4.3.0, please read th
 - When changing the type of a metric with configured sources, don't remove the sources that support both the old and the new metric type. Fixes [#4443](https://github.com/ICTU/quality-time/issues/4443).
 - The button in the settings panel to 'Reset all settings' didn't work. Fixes [#4527](https://github.com/ICTU/quality-time/issues/4527).
 - Due to a small change to the loading spinner, *Quality-time* would no longer wait for the spinner to disappear before converting a report to PDF, causing the PDF to be empty for big reports. Fixes [#4542](https://github.com/ICTU/quality-time/issues/4542).
+- Clicking the *Quality-time* logo should navigate to the home page, but this did not work if the user traveled to a point in time where the report did not exist yet. Closes [#4526](https://github.com/ICTU/quality-time/issues/4526).
 
 ### Added
 


### PR DESCRIPTION
…this did not work if the user traveled to a point in time where the report did not exist yet. Closes #4526.