### PR TITLE
Don't replace empty issue tracker passwords and private tokens with p…

### DIFF
--- a/components/external_server/src/model/transformations.py
+++ b/components/external_server/src/model/transformations.py
@@ -14,16 +14,19 @@ from .iterators import sources as iter_sources
 from .queries import is_password_parameter
 
 
+CREDENTIALS_REPLACEMENT_TEXT = "this string replaces credentials"
+
+
 def hide_credentials(data_model, *reports) -> None:
     """Hide the credentials in the reports."""
-    hidden = "this string replaces credentials"
     for source in iter_sources(*reports):
         for parameter_key in __password_parameter_keys(data_model, source):
-            source["parameters"][parameter_key] = hidden
+            source["parameters"][parameter_key] = CREDENTIALS_REPLACEMENT_TEXT
     for report in reports:
+        issue_tracker_parameters = report.get("issue_tracker", {}).get("parameters", {})
         for secret_attribute in ("password", "private_token"):
-            if secret_attribute in report.get("issue_tracker", {}).get("parameters", {}):
-                report["issue_tracker"]["parameters"][secret_attribute] = hidden
+            if issue_tracker_parameters.get(secret_attribute):
+                issue_tracker_parameters[secret_attribute] = CREDENTIALS_REPLACEMENT_TEXT
 
 
 def encrypt_credentials(data_model, public_key: str, *reports: dict):

--- a/components/external_server/tests/model/test_transformations.py
+++ b/components/external_server/tests/model/test_transformations.py
@@ -1,0 +1,38 @@
+"""Model transformation unit tests."""
+
+from model.transformations import hide_credentials, CREDENTIALS_REPLACEMENT_TEXT
+
+from ..base import DataModelTestCase
+from ..fixtures import create_report, SUBJECT_ID, METRIC_ID, SOURCE_ID
+
+
+class HideCredentialsTest(DataModelTestCase):
+    """Unit tests for the hide credentials transformation."""
+
+    def setUp(self) -> None:
+        """Override to set up the report fixture."""
+        self.report = create_report()
+
+    def test_hide_issue_tracker_credentials(self):
+        """Test that the issue tracker credentials are hidden."""
+        hide_credentials(self.DATA_MODEL, self.report)
+        self.assertEqual(CREDENTIALS_REPLACEMENT_TEXT, self.report["issue_tracker"]["parameters"]["password"])
+
+    def test_hide_source_credentials(self):
+        """Test that the source credentials are hidden."""
+        hide_credentials(self.DATA_MODEL, self.report)
+        self.assertEqual(
+            CREDENTIALS_REPLACEMENT_TEXT,
+            self.report["subjects"][SUBJECT_ID]["metrics"][METRIC_ID]["sources"][SOURCE_ID]["parameters"]["password"],
+        )
+
+    def test_do_not_hide_empty_issue_tracker_credentials(self):
+        """Test that empty issue tracker credentials are not replaced with a placeholder.
+
+        This is needed because users cannot see the difference between a masked credential and a masked empty
+        credential, so otherwise they won't know whether they have cleared a credentials.
+        """
+        issue_tracker_parameters = self.report["issue_tracker"]["parameters"]
+        issue_tracker_parameters["private_token"] = ""
+        hide_credentials(self.DATA_MODEL, self.report)
+        self.assertEqual("", issue_tracker_parameters["private_token"])

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Deployment notes
+
+If your currently installed *Quality-time* version is not v4.4.0, please read the v4.4.0 deployment notes.
+
+### Fixed
+
+- It looked like removing an issue tracker password or private token did not work: the user interface would still show a series of black dots in the password or private token field when later revisiting the issue tracker tab, even though passwords and private tokens were in fact being removed from the report. Fixes [#4564](https://github.com/ICTU/quality-time/issues/4564).
+
 ## v4.4.0 - 2022-09-16
 
 ### Deployment notes


### PR DESCRIPTION
…laceholder text in the API because then it looks like they haven't been removed in the UI. Fixes #4564.