### PR TITLE
Bump2version is reported by deadpendency. Suppress warning.

### DIFF
--- a/.github/deadpendency.yaml
+++ b/.github/deadpendency.yaml
@@ -85,6 +85,7 @@ additional-deps:
 ignore-failures:
   python:
     - behave
+    - bump2version  # Issue to find alternative: https://github.com/ICTU/quality-time/issues/4619
     - sseclient  # Used in one feature test. Issue to find alternative: https://github.com/ICTU/quality-time/issues/4560
   javascript:
     - react-hash-link  # No alternative available AFAICT


### PR DESCRIPTION
Issue #4619 scheduled for March 2023 to look for an alternative.