### PR TITLE
When showing multiple dates in a quality report, the *Quality-time* f…

### DIFF
--- a/components/frontend/src/api/fetch_server_api.js
+++ b/components/frontend/src/api/fetch_server_api.js
@@ -1,7 +1,7 @@
 export const api_version = 'v3'
 
 export function api_with_report_date(api, date) {
-    return date === null ? api : api + `?report_date=${date.toISOString()}`
+    return date ? api + `?report_date=${date.toISOString()}` : api
 }
 
 export function fetch_server_api(method, api, body, content_type) {

--- a/components/frontend/src/api/subject.js
+++ b/components/frontend/src/api/subject.js
@@ -1,4 +1,4 @@
-import { fetch_server_api } from "./fetch_server_api";
+import { api_with_report_date, fetch_server_api } from "./fetch_server_api";
 
 export function add_subject(report_uuid, subjectType, reload) {
   return fetch_server_api('post', `subject/new/${report_uuid}`, { type: subjectType }).then(reload)
@@ -21,5 +21,5 @@ export function set_subject_attribute(subject_uuid, attribute, value, reload) {
 }
 
 export function get_subject_measurements(subject_uuid, date) {
-  return fetch_server_api('get', `subject/${subject_uuid}/measurements`, date)
+  return fetch_server_api('get', api_with_report_date(`subject/${subject_uuid}/measurements`, date))
 }

--- a/components/frontend/src/subject/Subject.test.js
+++ b/components/frontend/src/subject/Subject.test.js
@@ -4,13 +4,14 @@ import * as fetch_server_api from '../api/fetch_server_api';
 import { DataModel } from "../context/DataModel";
 import { datamodel, report } from "../__fixtures__/fixtures";
 
-function renderSubject(dates, hideMetricsNotRequiringAction, sortColumn, sortDirection) {
+function renderSubject(dates, hideMetricsNotRequiringAction, sortColumn, sortDirection, reportDate) {
     render(
         <DataModel.Provider value={datamodel}>
             <Subject
                 dates={dates}
                 handleSort={() => { /* Dummy implementation */ }}
                 report={report}
+                report_date={reportDate}
                 sortColumn={sortColumn}
                 sortDirection={sortDirection}
                 subject_uuid="subject_uuid"
@@ -26,7 +27,14 @@ it('fetches measurements if nr dates > 1', async () => {
     jest.mock("../api/fetch_server_api.js")
     fetch_server_api.fetch_server_api = jest.fn().mockResolvedValue({ ok: true, measurements: [] });
     await act(async () => { renderSubject([new Date(2022, 3, 25), new Date(2022, 3, 26)]) });
-    expect(fetch_server_api.fetch_server_api).toHaveBeenCalledWith("get", "subject/subject_uuid/measurements", undefined);
+    expect(fetch_server_api.fetch_server_api).toHaveBeenCalledWith("get", "subject/subject_uuid/measurements");
+})
+
+it('fetches measurements if nr dates > 1 and time traveling', async () => {
+    jest.mock("../api/fetch_server_api.js")
+    fetch_server_api.fetch_server_api = jest.fn().mockResolvedValue({ ok: true, measurements: [] });
+    await act(async () => { renderSubject([new Date(2022, 3, 25), new Date(2022, 3, 26)], false, null, null, new Date(Date.UTC(2022, 3, 26))) });
+    expect(fetch_server_api.fetch_server_api).toHaveBeenCalledWith("get", "subject/subject_uuid/measurements?report_date=2022-04-26T00:00:00.000Z");
 })
 
 it('does not fetch measurements if nr dates == 1', async () => {

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Deployment notes
+
+If your currently installed *Quality-time* version is not v4.5.0, please read the v4.5.0 deployment notes.
+
+### Fixed
+
+- When showing multiple dates in a quality report, the *Quality-time* frontend retrieves 28 weeks of measurements so that the maximum period (seven weeks times a four-week interval) can be displayed. However, the frontend would always get the most recent 28 weeks, even if the user was time traveling. Fixes [#4705](https://github.com/ICTU/quality-time/issues/4705).
+
 ## v4.5.0 - 2022-10-04
 
 ### Deployment notes


### PR DESCRIPTION
…rontend retrieves 28 weeks of measurements so that the maximum period (seven weeks times a four-week interval) can be displayed. However, the frontend would always get the most recent 28 weeks, even if the user was time traveling. Fixes #4705.