### PR TITLE
Make subject measurements endpoint more flexible

### DIFF
--- a/components/external_server/src/routes/subject.py
+++ b/components/external_server/src/routes/subject.py
@@ -1,6 +1,5 @@
 """Subject routes."""
 
-from datetime import datetime, timedelta, timezone
 from typing import cast
 
 import bottle
@@ -119,18 +118,14 @@ def post_subject_attribute(subject_uuid: SubjectId, subject_attribute: str, data
 
 @bottle.get("/api/v3/subject/<subject_uuid>/measurements", authentication_required=False)
 def get_subject_measurements(subject_uuid: SubjectId, database: Database):
-    """Return all measurements for the subject within the last 28 weeks."""
+    """Return all measurements for the subject between the date of the report and the minimum date."""
     date_time = report_date_time()
+    min_date_time = report_date_time("min_report_date")
     metric_uuids: list[MetricId] = metrics_of_subject(database, subject_uuid, date_time)
-
-    report_timestamp = datetime.fromisoformat(date_time) if date_time else datetime.now(timezone.utc)
-    min_datetime = report_timestamp - timedelta(weeks=28)
-    min_iso_timestamp = min_datetime.isoformat()
-
     return dict(
         measurements=list(
             measurements_by_metric(
-                database, *metric_uuids, min_iso_timestamp=min_iso_timestamp, max_iso_timestamp=date_time
+                database, *metric_uuids, min_iso_timestamp=min_date_time, max_iso_timestamp=date_time
             )
         )
     )

--- a/components/external_server/src/utils/functions.py
+++ b/components/external_server/src/utils/functions.py
@@ -178,9 +178,9 @@ def md5_hash(string: str) -> str:
     return md5.hexdigest()
 
 
-def report_date_time() -> str:
+def report_date_time(attribute_name: str = "report_date") -> str:
     """Return the report date requested as query parameter if it's in the past, else return an empty string."""
-    if report_date_string := dict(bottle.request.query).get("report_date"):
+    if report_date_string := dict(bottle.request.query).get(attribute_name):
         iso_report_date_string = str(report_date_string).replace("Z", "+00:00")
         if iso_report_date_string < iso_timestamp():
             return iso_report_date_string

--- a/components/frontend/src/api/subject.js
+++ b/components/frontend/src/api/subject.js
@@ -1,25 +1,28 @@
 import { api_with_report_date, fetch_server_api } from "./fetch_server_api";
 
 export function add_subject(report_uuid, subjectType, reload) {
-  return fetch_server_api('post', `subject/new/${report_uuid}`, { type: subjectType }).then(reload)
+    return fetch_server_api('post', `subject/new/${report_uuid}`, { type: subjectType }).then(reload)
 }
 
 export function copy_subject(subject_uuid, report_uuid, reload) {
-  return fetch_server_api('post', `subject/${subject_uuid}/copy/${report_uuid}`, {}).then(reload)
+    return fetch_server_api('post', `subject/${subject_uuid}/copy/${report_uuid}`, {}).then(reload)
 }
 
 export function move_subject(subject_uuid, report_uuid, reload) {
-  return fetch_server_api('post', `subject/${subject_uuid}/move/${report_uuid}`, {}).then(reload)
+    return fetch_server_api('post', `subject/${subject_uuid}/move/${report_uuid}`, {}).then(reload)
 }
 
 export function delete_subject(subject_uuid, reload) {
-  return fetch_server_api('delete', `subject/${subject_uuid}`, {}).then(reload)
+    return fetch_server_api('delete', `subject/${subject_uuid}`, {}).then(reload)
 }
 
 export function set_subject_attribute(subject_uuid, attribute, value, reload) {
-  return fetch_server_api('post', `subject/${subject_uuid}/attribute/${attribute}`, { [attribute]: value }).then(reload)
+    return fetch_server_api('post', `subject/${subject_uuid}/attribute/${attribute}`, { [attribute]: value }).then(reload)
 }
 
-export function get_subject_measurements(subject_uuid, date) {
-  return fetch_server_api('get', api_with_report_date(`subject/${subject_uuid}/measurements`, date))
+export function get_subject_measurements(subject_uuid, date, minDate) {
+    const minReportDate = minDate.toISOString().split("T")[0] + "T00:00:00.000Z" // Ignore the time so we get all measurements for the min date
+    let api = api_with_report_date(`subject/${subject_uuid}/measurements`, date)
+    const sep = api.indexOf("?") < 0 ? "?" : "&"
+    return fetch_server_api('get', api + `${sep}min_report_date=${minReportDate}`)
 }

--- a/components/frontend/src/subject/Subject.js
+++ b/components/frontend/src/subject/Subject.js
@@ -107,7 +107,8 @@ export function Subject({
 
     useEffect(() => {
         if (dates.length > 1) {
-            get_subject_measurements(subject_uuid, report_date).then(json => {
+            const minReportDate = dates.slice().sort((d1, d2) => {return (d1.toISOString() > d2.toISOString())}).at(0);
+            get_subject_measurements(subject_uuid, report_date, minReportDate).then(json => {
                 if (json.ok !== false) {
                     setMeasurements(json.measurements)
                 }

--- a/components/frontend/src/subject/Subject.test.js
+++ b/components/frontend/src/subject/Subject.test.js
@@ -26,15 +26,15 @@ function renderSubject(dates, hideMetricsNotRequiringAction, sortColumn, sortDir
 it('fetches measurements if nr dates > 1', async () => {
     jest.mock("../api/fetch_server_api.js")
     fetch_server_api.fetch_server_api = jest.fn().mockResolvedValue({ ok: true, measurements: [] });
-    await act(async () => { renderSubject([new Date(2022, 3, 25), new Date(2022, 3, 26)]) });
-    expect(fetch_server_api.fetch_server_api).toHaveBeenCalledWith("get", "subject/subject_uuid/measurements");
+    await act(async () => { renderSubject([new Date(Date.UTC(2022, 3, 25)), new Date(Date.UTC(2022, 3, 28))]) });
+    expect(fetch_server_api.fetch_server_api).toHaveBeenCalledWith("get", "subject/subject_uuid/measurements?min_report_date=2022-04-25T00:00:00.000Z");
 })
 
 it('fetches measurements if nr dates > 1 and time traveling', async () => {
     jest.mock("../api/fetch_server_api.js")
     fetch_server_api.fetch_server_api = jest.fn().mockResolvedValue({ ok: true, measurements: [] });
-    await act(async () => { renderSubject([new Date(2022, 3, 25), new Date(2022, 3, 26)], false, null, null, new Date(Date.UTC(2022, 3, 26))) });
-    expect(fetch_server_api.fetch_server_api).toHaveBeenCalledWith("get", "subject/subject_uuid/measurements?report_date=2022-04-26T00:00:00.000Z");
+    await act(async () => { renderSubject([new Date(Date.UTC(2022, 3, 25)), new Date(Date.UTC(2022, 3, 26))], false, null, null, new Date(Date.UTC(2022, 3, 26))) });
+    expect(fetch_server_api.fetch_server_api).toHaveBeenCalledWith("get", "subject/subject_uuid/measurements?report_date=2022-04-26T00:00:00.000Z&min_report_date=2022-04-25T00:00:00.000Z");
 })
 
 it('does not fetch measurements if nr dates == 1', async () => {

--- a/tests/feature_tests/environment.py
+++ b/tests/feature_tests/environment.py
@@ -19,7 +19,8 @@ def before_all(context):
         """Get the resource."""
         url = api_url(api, internal)
         if context.report_date:
-            url += f"?report_date={context.report_date}"
+            sep = "&" if "?" in url else "?"
+            url += f"{sep}report_date={context.report_date}"
         context.response = response = requests.get(url, headers=headers, cookies=cookies())
         return response.json() if response.headers.get("Content-Type") == "application/json" else response
 

--- a/tests/feature_tests/steps/subject.py
+++ b/tests/feature_tests/steps/subject.py
@@ -7,6 +7,9 @@ def get_measurements(context, has_or_had, expected_number):
     """Get the recent measurements of a subject."""
     if has_or_had == "had":
         context.report_date = "2020-11-17T10:00:00Z"
+        min_report_date_parameter = "?min_report_date=2020-11-16T00:00:00Z"
+    else:
+        min_report_date_parameter = ""
 
-    response = context.get(f"subject/{context.uuid['subject']}/measurements?min_report_date=2020-11-16T00:00:00Z")
+    response = context.get(f"subject/{context.uuid['subject']}/measurements{min_report_date_parameter}")
     assert_equal(int(expected_number), len(response["measurements"]))

--- a/tests/feature_tests/steps/subject.py
+++ b/tests/feature_tests/steps/subject.py
@@ -8,5 +8,5 @@ def get_measurements(context, has_or_had, expected_number):
     if has_or_had == "had":
         context.report_date = "2020-11-17T10:00:00Z"
 
-    response = context.get(f"subject/{context.uuid['subject']}/measurements?min_report_date=2020-11-17")
+    response = context.get(f"subject/{context.uuid['subject']}/measurements?min_report_date=2020-11-16T00:00:00Z")
     assert_equal(int(expected_number), len(response["measurements"]))

--- a/tests/feature_tests/steps/subject.py
+++ b/tests/feature_tests/steps/subject.py
@@ -8,5 +8,5 @@ def get_measurements(context, has_or_had, expected_number):
     if has_or_had == "had":
         context.report_date = "2020-11-17T10:00:00Z"
 
-    response = context.get(f"subject/{context.uuid['subject']}/measurements")
+    response = context.get(f"subject/{context.uuid['subject']}/measurements?min_report_date=2020-11-17")
     assert_equal(int(expected_number), len(response["measurements"]))


### PR DESCRIPTION
Make the subject measurements endpoint in the external server more flexible: instead of always returning measurements for the previous 28 weeks (max 7 dates with max 4 week intervals), make the endpoint return the measurements between two dates.

This not only saves time/bandwidth, but will also make it easier to implement #4538 because we receive exactly the right measurements to determine for how long metrics have missed their deadlines between the two dates.