### PR TITLE
Reduce amount of logging

### DIFF
--- a/components/collector/src/quality_time_collector.py
+++ b/components/collector/src/quality_time_collector.py
@@ -16,4 +16,4 @@ async def collect(log_level: int = None) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(collect(logging.INFO), debug=True)  # pragma: no cover
+    asyncio.run(collect(logging.WARNING))  # pragma: no cover

--- a/components/database/Dockerfile
+++ b/components/database/Dockerfile
@@ -2,5 +2,3 @@ FROM mongo:5.0.13
 
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time database"
-
-CMD ["mongod", "--quiet"]

--- a/components/database/Dockerfile
+++ b/components/database/Dockerfile
@@ -2,3 +2,5 @@ FROM mongo:5.0.13
 
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time database"
+
+CMD ["mongod", "--quiet"]

--- a/components/proxy/default.conf.template
+++ b/components/proxy/default.conf.template
@@ -5,6 +5,7 @@ server {
     add_header      X-Frame-Options "DENY";
     gzip            on;
     server_tokens   off;
+    access_log      off;
 
     location /api/v3/nr_measurements {
         gzip                off;

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -70,6 +70,7 @@ services:
       - ALL
   database:
     image: ictu/quality-time_database:${QUALITY_TIME_VERSION}
+    command: --quiet
     restart: always
     environment:
       - MONGO_INITDB_ROOT_USERNAME=root

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
-## v4.6.0-rc.3 - 2022-10-20
+## [Unreleased]
 
 ### Deployment notes
 
@@ -22,6 +22,10 @@ If your currently installed *Quality-time* version is not v4.5.0, please read th
 
 - Date pickers have a "today" button now. Closes [#378](https://github.com/ICTU/quality-time/issues/378).
 - When displaying multiple dates, also show the metric deadline overrun. The deadline overrun is the number of days a metric was not addressed within the desired response time. Closes [#4538](https://github.com/ICTU/quality-time/issues/4538).
+
+### Changed
+
+- Reduce the considerable amount of logging that *Quality-time* generates by turning off the proxy access log, turning off the asyncio debug logging in the collector, increasing the log level to warning in the collector, and by passing `--quiet` to MongoDB. Closes [#4736](https://github.com/ICTU/quality-time/issues/4736).
 
 ## v4.5.0 - 2022-10-04
 

--- a/docs/src/deployment.md
+++ b/docs/src/deployment.md
@@ -127,6 +127,22 @@ The date/time format and timezone of the reports that user sees are determined b
       - TZ=Europe/Amsterdam  # To get Central European Time
 ```
 
+## Configuring logging (optional)
+
+The options for configuring logging are limited at the moment. The MongoDB daemon can be told to produce less logging by passing the `--quiet` flag:
+
+```yaml
+  database:
+    command: --quiet
+```
+
+Other logging settings are currently fixed. These include:
+- The proxy access log is turned off.
+- The log level of the collector component is set to `WARNING`.
+- The log level of the notifier, the external server, and the internal server is set to `INFO`.
+
+Please submit an issue if you need these and other logging settings to be configurable.
+
 ## Moving *Quality-time*
 
 The easiest way to move a *Quality-time* instance is to deploy a new *Quality-time* instance at the new location and then copy the database contents from the old instance to the new instance. All *Quality-time* data is contained in the Mongo database, so that is the only data that needs to be copied.

--- a/docs/src/deployment.md
+++ b/docs/src/deployment.md
@@ -137,6 +137,7 @@ The options for configuring logging are limited at the moment. The MongoDB daemo
 ```
 
 Other logging settings are currently fixed. These include:
+
 - The proxy access log is turned off.
 - The log level of the collector component is set to `WARNING`.
 - The log level of the notifier, the external server, and the internal server is set to `INFO`.

--- a/docs/styles/Vocab/Base/accept.txt
+++ b/docs/styles/Vocab/Base/accept.txt
@@ -22,6 +22,7 @@ UUIDs
 Wekan
 [Hh]ostname
 [Uu]nmerged
+asyncio
 autoformatting
 breakpoint
 clearable


### PR DESCRIPTION
Reduced logging:
- Add --quiet flag to mongod
- Remove asyncio debug logging in the collector
- Increase logging level to WARNING in the collector
- No access log in proxy.

Closes #4736. 