### PR TITLE
When configuring Azure DevOps as source for the source up-to-dateness…

### DIFF
--- a/components/shared_data_model/src/shared_data_model/sources/azure_devops.py
+++ b/components/shared_data_model/src/shared_data_model/sources/azure_devops.py
@@ -82,7 +82,7 @@ AZURE_DEVOPS = Source(
         file_path=StringParameter(
             name="File or folder path",
             short_name="path",
-            help="Use the date and time the path was last changed to determine the up-to-dateness. If no file path "
+            help="Use the date and time the path was last changed to determine the up-to-dateness. If no path "
             "is specified, the pipeline is used to determine the up-to-dateness.",
             placeholder="none",
             metrics=["source_up_to_dateness"],

--- a/components/shared_data_model/src/shared_data_model/sources/azure_devops.py
+++ b/components/shared_data_model/src/shared_data_model/sources/azure_devops.py
@@ -82,9 +82,8 @@ AZURE_DEVOPS = Source(
         file_path=StringParameter(
             name="File or folder path",
             short_name="path",
-            help="Use the date and time the path was last changed to determine the up-to-dateness. Note that if a "
-            "pipeline is specified, the pipeline is used to determine the up-to-dateness, and the path is "
-            "ignored.",
+            help="Use the date and time the path was last changed to determine the up-to-dateness. If no file path "
+            "is specified, the pipeline is used to determine the up-to-dateness.",
             placeholder="none",
             metrics=["source_up_to_dateness"],
         ),
@@ -179,9 +178,8 @@ AZURE_DEVOPS = Source(
         job_runs_within_time_period=dict(name="pipeline", attributes=PIPELINE_ATTRIBUTES),
         lead_time_for_changes=dict(
             name="lead time",
-            attributes=ISSUE_ATTRIBUTES + [dict(
-                name="Work item lead time in days", key="lead_time", type=EntityAttributeType.INTEGER
-            )]
+            attributes=ISSUE_ATTRIBUTES
+            + [dict(name="Work item lead time in days", key="lead_time", type=EntityAttributeType.INTEGER)],
         ),
         merge_requests=dict(
             name="merge request",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is not v4.5.0, please read th
 
 ### Fixed
 
+- When configuring Azure DevOps as source for the source up-to-dateness metric, the tooltip says files get preference, but in reality code pipelines get preference. Updated the tooltip. Fixes [#4685](https://github.com/ICTU/quality-time/issues/4685).
 - When showing multiple dates in a quality report, the *Quality-time* frontend retrieves 28 weeks of measurements so that the maximum period (seven weeks times a four-week interval) can be displayed. However, the frontend would always get the most recent 28 weeks, even if the user was time traveling. Fixes [#4705](https://github.com/ICTU/quality-time/issues/4705).
 
 ### Added

--- a/docs/styles/Vocab/Base/accept.txt
+++ b/docs/styles/Vocab/Base/accept.txt
@@ -44,7 +44,7 @@ sparkline
 subfolders
 submenus
 suppressions
-tooltips
+tooltips?
 tracebacks?
 unencrypted
 unicode


### PR DESCRIPTION
… metric, the tooltip says files get preference, but in reality code pipelines get preference. Updated the tooltip. Fixes #4685.