### PR TITLE
When showing multiple dates in a quality report and also time traveli…

### DIFF
--- a/components/external_server/src/database/reports.py
+++ b/components/external_server/src/database/reports.py
@@ -64,7 +64,7 @@ def metrics_of_subject(database: Database, subject_uuid: SubjectId, max_iso_time
     else:
         report_filter["last"] = True  # Otherwise select only reports that are the most recent ones
     projection: dict = {"_id": False, f"subjects.{subject_uuid}.metrics": True}
-    report = database.reports.find_one(report_filter, projection=projection)
+    report = database.reports.find_one(report_filter, projection=projection, sort=TIMESTAMP_DESCENDING)
     return list(report["subjects"][subject_uuid]["metrics"].keys()) if report else []
 
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+If your currently installed *Quality-time* version is not v4.6.0, please read the v4.6.0 deployment notes.
+
+### Fixed
+
+- When showing multiple dates in a quality report and also time traveling, *Quality-time* would not retrieve the most recent measurements for the selected dates. Fixes [#4793](https://github.com/ICTU/quality-time/issues/4793).
+
 ## v4.6.0 - 2022-11-03
 
 ### Deployment notes


### PR DESCRIPTION
…ng, Quality-time would not retrieve the most recent measurements for the selected dates. Fixes #4793.