### PR TITLE
Support GitLab CI pipelines as source for the source-up-to-dateness metric

### DIFF
--- a/components/collector/src/source_collectors/gitlab/base.py
+++ b/components/collector/src/source_collectors/gitlab/base.py
@@ -73,7 +73,7 @@ class GitLabJobsBase(GitLabProjectBase):
         lookback_date = date.today() - timedelta(days=int(cast(str, self._parameter("lookback_days"))))
         for response in responses:
             for job in await response.json():
-                if self.__build_date(job) > lookback_date:
+                if self._build_date(job) > lookback_date:
                     return await super()._next_urls(responses)
         return []
 
@@ -88,7 +88,7 @@ class GitLabJobsBase(GitLabProjectBase):
                     build_status=job["status"],
                     branch=job["ref"],
                     stage=job["stage"],
-                    build_date=str(self.__build_date(job)),
+                    build_date=str(self._build_date(job)),
                 )
                 for job in await self._jobs(responses)
             ]
@@ -115,6 +115,6 @@ class GitLabJobsBase(GitLabProjectBase):
         ) and not match_string_or_regular_expression(job["ref"], self._parameter("refs_to_ignore"))
 
     @staticmethod
-    def __build_date(job: Job) -> date:
+    def _build_date(job: Job) -> date:
         """Return the build date of the job."""
         return parse(job.get("finished_at") or job["created_at"]).date()

--- a/components/collector/src/source_collectors/gitlab/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/gitlab/source_up_to_dateness.py
@@ -84,14 +84,14 @@ class GitLabPipelineUpToDateness(TimePassedCollector, GitLabJobsBase):
         return await super()._landing_url(responses)
 
     async def _parse_source_response_date_time(self, response: Response) -> datetime:
-        """Override to get the date and time of the commit or the pipeline."""
+        """Override to get the date and time of the pipeline."""
         jobs = await self._jobs(SourceResponses(responses=[response]))
         build_dates = [self._build_date(job) for job in jobs]
         return datetime.combine(max(build_dates, default=datetime.min.date()), datetime.min.time())
 
 
 class GitLabSourceUpToDateness(SourceCollector, ABC):
-    """Factory class to create a collector to get the up-to-dateness of either jobs or files."""
+    """Factory class to create a collector to get the up-to-dateness of either pipelines or files."""
 
     def __new__(cls, session: aiohttp.ClientSession, source):
         """Create an instance of either the file up-to-dateness collector or the jobs up-to-dateness collector."""

--- a/components/collector/tests/source_collectors/gitlab/base.py
+++ b/components/collector/tests/source_collectors/gitlab/base.py
@@ -21,6 +21,7 @@ class GitLabTestCase(SourceCollectorTestCase):  # skipcq: PTC-W0046
                 name="job1",
                 stage="stage",
                 created_at="2019-03-31T19:40:39.927Z",
+                pipeline=dict(web_url="https://gitlab/project/-/pipelines/1"),
                 web_url="https://gitlab/job1",
                 ref="master",
             ),

--- a/components/collector/tests/source_collectors/gitlab/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/gitlab/test_source_up_to_dateness.py
@@ -18,10 +18,10 @@ class GitLabSourceUpToDatenessTest(GitLabTestCase):
         self.commit_json = dict(committed_date="2019-01-01T09:06:12+00:00")
         self.expected_age = (datetime.now(timezone.utc) - datetime(2019, 1, 1, 9, 6, 9, tzinfo=timezone.utc)).days
 
-    def patched_client_session_head(self):
+    @staticmethod
+    def patched_client_session_head():
         """Return a patched version of the client session head method."""
-        head_response = Mock()
-        head_response.headers = {"X-Gitlab-Last-Commit-Id": "commit-sha"}
+        head_response = Mock(headers={"X-Gitlab-Last-Commit-Id": "commit-sha"})
         return patch("aiohttp.ClientSession.head", AsyncMock(side_effect=[head_response, head_response]))
 
     async def test_source_up_to_dateness_file(self):

--- a/components/collector/tests/source_collectors/gitlab/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/gitlab/test_source_up_to_dateness.py
@@ -17,12 +17,16 @@ class GitLabSourceUpToDatenessTest(GitLabTestCase):
         super().setUp()
         self.commit_json = dict(committed_date="2019-01-01T09:06:12+00:00")
         self.expected_age = (datetime.now(timezone.utc) - datetime(2019, 1, 1, 9, 6, 9, tzinfo=timezone.utc)).days
-        self.head_response = Mock()
-        self.head_response.headers = {"X-Gitlab-Last-Commit-Id": "commit-sha"}
+
+    def patched_client_session_head(self):
+        """Return a patched version of the client session head method."""
+        head_response = Mock()
+        head_response.headers = {"X-Gitlab-Last-Commit-Id": "commit-sha"}
+        return patch("aiohttp.ClientSession.head", AsyncMock(side_effect=[head_response, head_response]))
 
     async def test_source_up_to_dateness_file(self):
         """Test that the age of a file in a repo can be measured."""
-        with patch("aiohttp.ClientSession.head", AsyncMock(return_value=self.head_response)):
+        with self.patched_client_session_head():
             response = await self.collect(
                 get_request_json_side_effect=[[], self.commit_json, dict(web_url="https://gitlab.com/project")]
             )
@@ -32,7 +36,7 @@ class GitLabSourceUpToDatenessTest(GitLabTestCase):
 
     async def test_source_up_to_dateness_folder(self):
         """Test that the age of a folder in a repo can be measured."""
-        with patch("aiohttp.ClientSession.head", AsyncMock(side_effect=[self.head_response, self.head_response])):
+        with self.patched_client_session_head():
             response = await self.collect(
                 get_request_json_side_effect=[
                     [dict(type="blob", path="file.txt"), dict(type="tree", path="folder")],
@@ -51,7 +55,7 @@ class GitLabSourceUpToDatenessTest(GitLabTestCase):
         self.set_source_parameter("file_path", "")
         build_date = datetime.fromisoformat(self.gitlab_jobs_json[0]["created_at"].strip("Z")).date()
         expected_age = (date.today() - build_date).days
-        with patch("aiohttp.ClientSession.head", AsyncMock(return_value=self.head_response)):
+        with self.patched_client_session_head():
             response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
         self.assert_measurement(response, value=str(expected_age), landing_url="https://gitlab/project/-/pipelines/1")
 

--- a/components/shared_data_model/src/shared_data_model/sources/azure_devops.py
+++ b/components/shared_data_model/src/shared_data_model/sources/azure_devops.py
@@ -76,7 +76,7 @@ AZURE_DEVOPS = Source(
             mandatory=False,
             help="This should only contain the WHERE clause of a WIQL query, as the selected fields are static. "
             "For example, use the following clause to hide issues marked as done: \"[System.State] <> 'Done'\". "
-            "See: https://docs.microsoft.com/en-us/azure/devops/boards/queries/wiql-syntax?view=azure-devops",
+            "See https://docs.microsoft.com/en-us/azure/devops/boards/queries/wiql-syntax?view=azure-devops",
             metrics=["issues", "lead_time_for_changes", "user_story_points"],
         ),
         file_path=StringParameter(

--- a/components/shared_data_model/src/shared_data_model/sources/gitlab.py
+++ b/components/shared_data_model/src/shared_data_model/sources/gitlab.py
@@ -116,7 +116,6 @@ profile/personal_access_tokens.html) with the scope `read_repository` in the pri
             short_name="path",
             help="Use the date and time the path was last changed to determine the up-to-dateness. If no path "
             "is specified, the pipeline is used to determine the up-to-dateness.",
-            # help_url="https://docs.gitlab.com/ee/api/repository_files.html",
             metrics=["source_up_to_dateness"],
         ),
         branch=Branch(help_url=GITLAB_BRANCH_HELP_URL),

--- a/components/shared_data_model/src/shared_data_model/sources/gitlab.py
+++ b/components/shared_data_model/src/shared_data_model/sources/gitlab.py
@@ -114,8 +114,9 @@ profile/personal_access_tokens.html) with the scope `read_repository` in the pri
         file_path=StringParameter(
             name="File or folder path",
             short_name="path",
-            mandatory=True,
-            help_url="https://docs.gitlab.com/ee/api/repository_files.html",
+            help="Use the date and time the path was last changed to determine the up-to-dateness. If no path "
+            "is specified, the pipeline is used to determine the up-to-dateness.",
+            # help_url="https://docs.gitlab.com/ee/api/repository_files.html",
             metrics=["source_up_to_dateness"],
         ),
         branch=Branch(help_url=GITLAB_BRANCH_HELP_URL),
@@ -124,7 +125,7 @@ profile/personal_access_tokens.html) with the scope `read_repository` in the pri
             name="Branches and tags to ignore (regular expressions, branch names or tag names)",
             short_name="branches and tags to ignore",
             help_url=GITLAB_BRANCH_HELP_URL,
-            metrics=["failed_jobs", "job_runs_within_time_period", "unused_jobs"],
+            metrics=["failed_jobs", "job_runs_within_time_period", "source_up_to_dateness", "unused_jobs"],
         ),
         inactive_days=Days(
             name="Number of days since last commit after which to consider branches inactive",
@@ -143,13 +144,13 @@ profile/personal_access_tokens.html) with the scope `read_repository` in the pri
             name="Jobs to ignore (regular expressions or job names)",
             short_name="jobs to ignore",
             help="Jobs to ignore can be specified by job name or by regular expression.",
-            metrics=["failed_jobs", "job_runs_within_time_period", "unused_jobs"],
+            metrics=["failed_jobs", "job_runs_within_time_period", "source_up_to_dateness", "unused_jobs"],
         ),
         lookback_days=Days(
             name="Number of days to look back in selecting pipeline jobs to consider",
             short_name="number of days to look back",
             default_value="90",
-            metrics=["failed_jobs", "job_runs_within_time_period", "unused_jobs"],
+            metrics=["failed_jobs", "job_runs_within_time_period", "source_up_to_dateness", "unused_jobs"],
         ),
         merge_request_state=MergeRequestState(values=["opened", "locked", "merged", "closed"]),
         approval_state=MultipleChoiceParameter(

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Deployment notes
+
+If your currently installed *Quality-time* version is v4.0.0 or older, please read the v4.0.0 deployment notes.
+
+### Added
+
+- Support GitLab CI pipelines as source for the source-up-to-dateness metric. Closes [#3927](https://github.com/ICTU/quality-time/issues/3927).
+
 ## v4.6.1 - 2022-11-07
 
 ### Deployment notes


### PR DESCRIPTION
Closes #3927.