### PR TITLE
ReactDOM.render is no longer supported in React 18. Use createRoot in…

### DIFF
--- a/components/frontend/src/index.js
+++ b/components/frontend/src/index.js
@@ -1,8 +1,10 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import 'fomantic-ui-css/semantic.min.css'
 import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
 import App from './App';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);


### PR DESCRIPTION
…stead. Forgot to change this in the React 18 PR. Closes #4167.