### PR TITLE
Fix source up-to-dateness of GitLab pipelines: look at newwest page i…

### DIFF
--- a/components/collector/src/base_collectors/source_collector.py
+++ b/components/collector/src/base_collectors/source_collector.py
@@ -245,7 +245,7 @@ class TimeCollector(SourceCollector):
     async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
         """Override to get the datetime from the parse data time method that subclasses should implement."""
         date_times = await self._parse_source_response_date_times(responses)
-        return SourceMeasurement(value=str(self.days(min(date_times))))
+        return SourceMeasurement(value=str(self.days(self.mininum(date_times))))
 
     async def _parse_source_response_date_times(self, responses: SourceResponses) -> Sequence[datetime]:
         """Parse the source update datetimes from the responses and return the datetimes."""
@@ -259,6 +259,11 @@ class TimeCollector(SourceCollector):
     def days(date_time) -> int:
         """Return the time between the current date time and the specified date time."""
         raise NotImplementedError  # pragma: no cover
+
+    @staticmethod
+    def mininum(date_times: Sequence[datetime]) -> datetime:
+        """Allow for overriding what the minimum of the datetimes is: the newest or the oldest?"""
+        return min(date_times)
 
 
 class TimePassedCollector(TimeCollector):

--- a/components/collector/src/source_collectors/gitlab/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/gitlab/source_up_to_dateness.py
@@ -4,6 +4,7 @@ import asyncio
 import itertools
 from abc import ABC
 from datetime import datetime
+from typing import Sequence
 from urllib.parse import quote
 
 import aiohttp
@@ -88,6 +89,11 @@ class GitLabPipelineUpToDateness(TimePassedCollector, GitLabJobsBase):
         jobs = await self._jobs(SourceResponses(responses=[response]))
         build_dates = [self._build_date(job) for job in jobs]
         return datetime.combine(max(build_dates, default=datetime.min.date()), datetime.min.time())
+
+    @staticmethod
+    def mininum(date_times: Sequence[datetime]) -> datetime:
+        """Override to return the newest datetime."""
+        return max(date_times)
 
 
 class GitLabSourceUpToDateness(SourceCollector, ABC):


### PR DESCRIPTION
…nstead of oldest when retrieving multiple pages of data.