### PR TITLE
Fixed typo's in description of metrics and sources

### DIFF
--- a/components/collector/src/source_collectors/gitlab/job_runs_within_time_period.py
+++ b/components/collector/src/source_collectors/gitlab/job_runs_within_time_period.py
@@ -13,7 +13,7 @@ from .base import GitLabJobsBase
 
 
 class GitLabJobRunsWithinTimePeriod(GitLabJobsBase):
-    """Collector class to measure the amount of GitLab CI builds run within a specified time period."""
+    """Collector class to measure the number of GitLab CI builds run within a specified time period."""
 
     async def _jobs(self, responses: SourceResponses) -> Sequence[Job]:
         """Return the jobs to count, not deduplicated to latest branch or tag run."""

--- a/components/collector/src/source_collectors/jenkins/job_runs_within_time_period.py
+++ b/components/collector/src/source_collectors/jenkins/job_runs_within_time_period.py
@@ -11,7 +11,7 @@ from .base import JenkinsJobs
 
 
 class JenkinsJobRunsWithinTimePeriod(JenkinsJobs):
-    """Collector class to measure the amount of Jenkins jobs run within a specified time period."""
+    """Collector class to measure the number of Jenkins jobs run within a specified time period."""
 
     def _include_build(self, build) -> bool:
         """Return whether to include this build or not."""
@@ -19,7 +19,7 @@ class JenkinsJobRunsWithinTimePeriod(JenkinsJobs):
         return days_ago(build_datetime) <= int(cast(str, self._parameter("lookback_days")))
 
     def _builds_within_timeperiod(self, job: Job) -> int:
-        """Return the amount of job builds within timeperiod."""
+        """Return the number of job builds within time period."""
         return len([build for build in job.get("builds", []) if self._include_build(build)])
 
     async def _parse_entities(self, responses: SourceResponses) -> Entities:

--- a/components/collector/src/source_collectors/jenkins_test_report/tests.py
+++ b/components/collector/src/source_collectors/jenkins_test_report/tests.py
@@ -12,7 +12,7 @@ Suite = dict[str, list[TestCase]]
 
 
 class JenkinsTestReportTests(SourceCollector):
-    """Collector to get the amount of tests from a Jenkins test report."""
+    """Collector to get the number of tests from a Jenkins test report."""
 
     JENKINS_TEST_REPORT_COUNTS: Final[dict[str, str]] = dict(
         failed="failCount", passed="passCount", skipped="skipCount"

--- a/components/notifier/tests/strategies/test_notification_strategy.py
+++ b/components/notifier/tests/strategies/test_notification_strategy.py
@@ -7,7 +7,7 @@ from strategies.notification_strategy import NotificationFinder
 
 
 class StrategiesTests(unittest.TestCase):
-    """Unit tests for the 'amount of new red metrics per report' notification strategy."""
+    """Unit tests for the 'number of new red metrics per report' notification strategy."""
 
     def setUp(self):
         """Override to create a reports JSON fixture."""

--- a/components/shared_data_model/src/shared_data_model/metrics.py
+++ b/components/shared_data_model/src/shared_data_model/metrics.py
@@ -51,7 +51,7 @@ METRICS = Metrics.parse_obj(
         ),
         complex_units=dict(
             name="Complex units",
-            description="The amount of units (classes, functions, methods, files) that are too complex.",
+            description="The number of units (classes, functions, methods, files) that are too complex.",
             rationale="Complex code makes software harder to test and harder to maintain. Complex code is harder to "
             "test because there are more execution paths that need to be tested. Complex code is harder to "
             "maintain because it is harder to understand and analyze.",
@@ -80,7 +80,7 @@ METRICS = Metrics.parse_obj(
         ),
         duplicated_lines=dict(
             name="Duplicated lines",
-            description="The amount of lines that are duplicated.",
+            description="The number of lines that are duplicated.",
             rationale="Duplicate code makes software larger and thus potentially harder to maintain. Also, if the "
             "duplicated code contains bugs, they need to be fixed in multiple locations.",
             rationale_urls=[
@@ -153,7 +153,7 @@ METRICS = Metrics.parse_obj(
         ),
         long_units=dict(
             name="Long units",
-            description="The amount of units (functions, methods, files) that are too long.",
+            description="The number of units (functions, methods, files) that are too long.",
             rationale="Long units are deemed harder to maintain.",
             rationale_urls=[
                 SIG_TUVIT_EVALUATION_CRITERIA,
@@ -185,7 +185,7 @@ METRICS = Metrics.parse_obj(
         ),
         many_parameters=dict(
             name="Many parameters",
-            description="The amount of units (functions, methods, procedures) that have too many parameters.",
+            description="The number of units (functions, methods, procedures) that have too many parameters.",
             rationale="Units with many parameters are deemed harder to maintain.",
             rationale_urls=[
                 SIG_TUVIT_EVALUATION_CRITERIA,
@@ -197,7 +197,7 @@ METRICS = Metrics.parse_obj(
         ),
         merge_requests=dict(
             name="Merge requests",
-            description="The amount of merge requests.",
+            description="The number of merge requests.",
             rationale="Merge requests need to be reviewed and approved. This metric allows for measuring the number of "
             "merge requests without the required approvals.",
             documentation="""In itself, the number of merge requests is not indicative of software quality. However, by
@@ -212,7 +212,7 @@ requests that target specific branches, for example the "develop" branch.""",
         ),
         metrics=dict(
             name="Metrics",
-            description="The amount of metrics from one or more quality reports, with specific states and/or tags.",
+            description="The number of metrics from one or more quality reports, with specific states and/or tags.",
             rationale="Use this metric to monitor other quality reports. For example, count the number of metrics that "
             "don't meet their target value, or count the number of metrics that have been marked as technical debt for "
             "more than two months.",
@@ -247,7 +247,7 @@ report(s).
         ),
         missing_metrics=dict(
             name="Missing metrics",
-            description="The amount of metrics that can be added to each report, but have not been added yet.",
+            description="The number of metrics that can be added to each report, but have not been added yet.",
             rationale="Provide an overview of metrics still to be added to the quality report. If metrics will not be "
             "added, a reason can be documented.",
             scales=["count", "percentage"],
@@ -457,7 +457,7 @@ report(s).
         ),
         suppressed_violations=dict(
             name="Suppressed violations",
-            description="The amount of violations suppressed in the source.",
+            description="The number of violations suppressed in the source.",
             rationale="Some tools allow for suppression of violations. Having the number of suppressed violations "
             "violations visible in Quality-time allows for a double check of the suppressions.",
             scales=["count", "percentage"],
@@ -467,7 +467,7 @@ report(s).
         ),
         test_cases=dict(
             name="Test cases",
-            description="The amount of test cases.",
+            description="The number of test cases.",
             rationale="Track the test results of test cases so there is traceability from the test cases, "
             "defined in Jira, to the test results in test reports produced by tools such as Robot Framework or Junit.",
             documentation="""The test cases metric reports on the number of test cases, and their test results. The
@@ -531,7 +531,7 @@ skipped, and passed. Test cases not found in the test results are listed as unte
         ),
         tests=dict(
             name="Tests",
-            description="The amount of tests.",
+            description="The number of tests.",
             rationale="Keep track of the total number of tests or the number of tests with different states, "
             "for example failed or errored.",
             scales=["count", "percentage"],
@@ -568,7 +568,7 @@ skipped, and passed. Test cases not found in the test results are listed as unte
         ),
         uncovered_branches=dict(
             name="Test branch coverage",
-            description="The amount of code branches not covered by tests.",
+            description="The number of code branches not covered by tests.",
             rationale="Code branches not covered by tests may contain bugs and signal incomplete tests.",
             rationale_urls=[FOWLER_TEST_COVERAGE],
             scales=["count", "percentage"],
@@ -587,7 +587,7 @@ skipped, and passed. Test cases not found in the test results are listed as unte
         ),
         uncovered_lines=dict(
             name="Test line coverage",
-            description="The amount of lines of code not covered by tests.",
+            description="The number of lines of code not covered by tests.",
             rationale="Code lines not covered by tests may contain bugs and signal incomplete tests.",
             rationale_urls=[FOWLER_TEST_COVERAGE],
             scales=["count", "percentage"],

--- a/components/shared_data_model/src/shared_data_model/sources/jira.py
+++ b/components/shared_data_model/src/shared_data_model/sources/jira.py
@@ -130,7 +130,7 @@ JIRA = Source(
         velocity_type=SingleChoiceParameter(
             name="Type of velocity",
             short_name="velocity type",
-            help="Whether to report the amount of story points committed to, the amount of story points actually "
+            help="Whether to report the number of story points committed to, the number of story points actually "
             "completed, or the difference between the two.",
             mandatory=True,
             default_value=VelocityType.COMPLETED,

--- a/components/shared_server_code/src/shared/model/source.py
+++ b/components/shared_server_code/src/shared/model/source.py
@@ -77,8 +77,8 @@ class Source(dict):  # lgtm [py/missing-equals]
         """Return the value of ignored entities, i.e. entities marked as fixed, false positive or won't fix.
 
         If the entities have a measured attribute, return the sum of the measured attributes of the ignored
-        entities, otherwise return the number of ignored attributes. For example, if the metric is the amount of ready
-        user story points, the source entities are user stories and the measured attribute is the amount of story
+        entities, otherwise return the number of ignored attributes. For example, if the metric is the number of ready
+        user story points, the source entities are user stories and the measured attribute is the number of story
         points of each user story.
         """
         entities_to_ignore = self._entities_to_ignore()

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
-## v4.7.0-rc.6 - 2022-12-23
+## [Unreleased]
 
 ### Deployment notes
 
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is v4.0.0 or older, please re
 ### Fixed
 
 - Chrome would not show all historic data when displaying multiple dates. Fixes [#4832](https://github.com/ICTU/quality-time/issues/4832).
+- Fixed typo's in description of metrics and sources: changed all instances of 'amount' where it should have been 'number'.
 
 ### Added
 


### PR DESCRIPTION
changed all instances of 'amount' where it should have been 'number'.