### PR TITLE
Link to RTD from subjects, metrics, and sources in the UI

### DIFF
--- a/components/frontend/src/metric/MetricTypeHeader.js
+++ b/components/frontend/src/metric/MetricTypeHeader.js
@@ -1,52 +1,17 @@
 import React from 'react';
 import { Icon } from 'semantic-ui-react';
-import { Header, Popup } from '../semantic_ui_react_wrappers';
-
-function seeAlso(key, urls) {
-    return (
-        <div key={key}>
-            <Header>See also</Header>
-            <ol>
-                {urls.map((url) => <li key={url}><a href={url}>{url}</a></li>)}
-            </ol>
-        </div>
-    )
-}
+import { Header } from '../semantic_ui_react_wrappers';
+import { HyperLink } from '../widgets/HyperLink';
+import { slugify } from '../utils';
 
 export function MetricTypeHeader({ metricType }) {
-    let popup = null;
-    const popupContents = [];
-    if (metricType.rationale) {
-        popupContents.push(<Header key="rationale-header">Why measure {metricType.name.toLowerCase()}?</Header>)
-        popupContents.push(<p key="rationale-text">{metricType.rationale}</p>)
-        if (metricType.rationale_urls?.length > 0) {
-            popupContents.push(seeAlso("rationale-urls", metricType.rationale_urls))
-        }
-    }
-    if (metricType.explanation) {
-        popupContents.push(<Header key="explanation=header">More information</Header>)
-        popupContents.push(<p key="explanation-text">{metricType.explanation}</p>)
-        if (metricType.explanation_urls?.length > 0) {
-            popupContents.push(seeAlso("explanation-urls", metricType.explanation_urls))
-        }
-    }
-    if (popupContents.length > 0) {
-        popup = <Popup
-            content={<>{popupContents}</>}
-            hoverable
-            on={['hover', 'focus']}
-            trigger={
-                <span>&nbsp;<Icon role="tooltip" aria-label="help" tabIndex="0" name="info circle" /></span>
-            }
-            wide="very"
-        />
-    }
+    const url = `https://quality-time.readthedocs.io/en/v${process.env.REACT_APP_VERSION}/reference.html${slugify(metricType.name)}`
     return (
         <Header>
             <Header.Content>
                 {metricType.name}
                 <Header.Subheader>
-                    {metricType.description}{popup}
+                    {metricType.description} <HyperLink url={url}>Read the Docs <Icon name="external" link /></HyperLink>
                 </Header.Subheader>
             </Header.Content>
         </Header>

--- a/components/frontend/src/metric/MetricTypeHeader.test.js
+++ b/components/frontend/src/metric/MetricTypeHeader.test.js
@@ -1,19 +1,14 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { MetricTypeHeader } from "./MetricTypeHeader";
 
-function renderMetricTypeHeader(rationale, rationaleUrls, explanation, explanationUrls) {
+function renderMetricTypeHeader() {
     render(
         <MetricTypeHeader
             metricType={
                 {
                     name: "Metric type",
                     description: "Description",
-                    rationale: rationale,
-                    rationale_urls: rationaleUrls,
-                    explanation: explanation,
-                    explanation_urls: explanationUrls
                 }
             }
         />
@@ -23,28 +18,4 @@ function renderMetricTypeHeader(rationale, rationaleUrls, explanation, explanati
 it('shows the header', async () => {
     renderMetricTypeHeader();
     expect(screen.getAllByText("Metric type").length).toBe(1)
-});
-
-it('shows the rationale', async () => {
-    renderMetricTypeHeader("Rationale");
-    await userEvent.hover(screen.queryByRole("tooltip"))
-    await waitFor(() => { expect(screen.queryAllByText(/Rationale/).length).toBe(1) });
-});
-
-it('shows the rationale URLs', async () => {
-    renderMetricTypeHeader("Rationale", ["https://rationale"]);
-    await userEvent.hover(screen.queryByRole("tooltip"))
-    await waitFor(() => { expect(screen.queryAllByText(/https:\/\/rationale/).length).toBe(1) });
-});
-
-it('shows the explanation', async () => {
-    renderMetricTypeHeader("", [], "Explanation.");
-    await userEvent.hover(screen.queryByRole("tooltip"))
-    await waitFor(() => { expect(screen.queryAllByText(/Explanation/).length).toBe(1) });
-});
-
-it('shows the explanation URLs', async () => {
-    renderMetricTypeHeader("", [], "Explanation.", ["https://explanation"]);
-    await userEvent.hover(screen.queryByRole("tooltip"))
-    await waitFor(() => { expect(screen.queryAllByText(/https:\/\/explanation/).length).toBe(1) });
 });

--- a/components/frontend/src/source/Source.js
+++ b/components/frontend/src/source/Source.js
@@ -13,7 +13,7 @@ import { SourceParameters } from './SourceParameters';
 import { SourceType } from './SourceType';
 import { ErrorMessage } from '../errorMessage';
 import { FocusableTab } from '../widgets/FocusableTab';
-import { get_metric_name, get_source_name } from '../utils';
+import { get_metric_name, get_source_name, slugify } from '../utils';
 
 function select_sources_parameter_keys(changed_fields, source_uuid) {
     return changed_fields ? changed_fields.filter((field) => field.source_uuid === source_uuid).map((field) => field.parameter_key) : []
@@ -22,14 +22,14 @@ function select_sources_parameter_keys(changed_fields, source_uuid) {
 function SourceHeader({ source }) {
     const dataModel = useContext(DataModel)
     const source_type = dataModel.sources[source.type];
+    const url = `https://quality-time.readthedocs.io/en/v${process.env.REACT_APP_VERSION}/reference.html${slugify(source_type.name)}`
     return (
         <Header>
             <Header.Content>
                 <Logo logo={source.type} alt={source_type.name} />
                 {source_type.name}
                 <Header.Subheader>
-                    {source_type.description}
-                    {source_type.url && <HyperLink url={source_type.url}><Icon name="external" link /></HyperLink>}
+                    {source_type.description} <HyperLink url={url}>Read the Docs <Icon name="external" link /></HyperLink>
                 </Header.Subheader>
             </Header.Content>
         </Header>

--- a/components/frontend/src/subject/SubjectTitle.js
+++ b/components/frontend/src/subject/SubjectTitle.js
@@ -1,23 +1,26 @@
 import React, { useContext } from 'react';
 import { Icon, Menu } from 'semantic-ui-react';
 import { Header, Tab } from '../semantic_ui_react_wrappers';
-import { HeaderWithDetails } from '../widgets/HeaderWithDetails';
 import { DeleteButton, ReorderButtonGroup } from '../widgets/Button';
+import { FocusableTab } from '../widgets/FocusableTab';
+import { HeaderWithDetails } from '../widgets/HeaderWithDetails';
+import { HyperLink } from '../widgets/HyperLink';
 import { ChangeLog } from '../changelog/ChangeLog';
 import { Share } from '../share/Share';
 import { delete_subject, set_subject_attribute } from '../api/subject';
 import { DataModel } from '../context/DataModel';
 import { EDIT_REPORT_PERMISSION, ReadOnlyOrEditable } from '../context/Permissions';
-import { FocusableTab } from '../widgets/FocusableTab';
+import { slugify } from '../utils';
 import { SubjectParameters } from './SubjectParameters';
 
 function SubjectHeader({ subject_type }) {
+    const url = `https://quality-time.readthedocs.io/en/v${process.env.REACT_APP_VERSION}/reference.html${slugify(subject_type.name)}`
     return (
         <Header>
             <Header.Content>
                 {subject_type.name}
                 <Header.Subheader>
-                    {subject_type.description}
+                    {subject_type.description} <HyperLink url={url}>Read the Docs <Icon name="external" link /></HyperLink>
                 </Header.Subheader>
             </Header.Content>
         </Header>

--- a/components/frontend/src/utils.js
+++ b/components/frontend/src/utils.js
@@ -276,3 +276,7 @@ export function userPrefersDarkMode(uiMode) {
 export function dropdownOptions(options) {
     return options.map(option => ({ key: option, text: option, value: option }))
 }
+
+export function slugify(name) {
+    return `#${name?.toLowerCase().replaceAll(" ", "-").replaceAll("(", "").replaceAll(")", "")}`
+}

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -25,6 +25,7 @@ If your currently installed *Quality-time* version is v4.0.0 or older, please re
 - Support GitLab CI pipelines as source for the source-up-to-dateness metric. Closes [#3927](https://github.com/ICTU/quality-time/issues/3927).
 - Allow for changing the log level of the backend containers via environment variables. See the [deployment manual](deployment.md#configuring-logging-optional). Closes [#4943](https://github.com/ICTU/quality-time/issues/4943).
 - When using cloc as source for the LOC (Size) metric with the `--by-file` option, *Quality-time* can filter the cloc data by filename. When also setting the scale of the LOC metric to percentage, this enables tracking the percentage of test code. Closes [#4958](https://github.com/ICTU/quality-time/issues/4958).
+- Make the description of subjects, metrics, and sources in the UI of *Quality-time* link to the relevant documentation on Read-The-Docs. Closes [#5121](https://github.com/ICTU/quality-time/issues/5121).
 - Make the web page title reflect the report title. Closes [#5129](https://github.com/ICTU/quality-time/issues/5129).
 
 ### Changed


### PR DESCRIPTION
Make the description of subjects, metrics, and sources in the UI of Quality-time link to the relevant documentation on Read-The-Docs. Closes #5121.