### PR TITLE
Refactor notifier

### DIFF
--- a/components/internal_server/.vulture_ignore_list.py
+++ b/components/internal_server/.vulture_ignore_list.py
@@ -1,1 +1,1 @@
-args  # unused variable (tests/quality_time_server_under_coverage.py:20)
+GetMeasurements  # unused class (tests/routes/test_measurement.py:398)

--- a/components/internal_server/src/database/measurements.py
+++ b/components/internal_server/src/database/measurements.py
@@ -21,3 +21,26 @@ def latest_successful_measurement(database: Database, metric: Metric) -> Measure
 def update_measurement_end(database: Database, measurement_id: MeasurementId):
     """Set the end date and time of the measurement to the current date and time."""
     return database.measurements.update_one(filter={"_id": measurement_id}, update={"$set": {"end": iso_timestamp()}})
+
+
+def recent_measurements(database: Database, *metrics: Metric, limit_per_metric: int = 2):
+    """Return recent measurements for the specified metrics, without entities and issue status."""
+    projection = {
+        "_id": False,
+        "sources.entities": False,
+        "sources.entity_user_data": False,
+        "issue_status": False,
+    }
+    measurements: list = []
+    for metric in metrics:
+        measurements.extend(
+            list(
+                database.measurements.find(
+                    {"metric_uuid": metric.uuid},
+                    limit=limit_per_metric,
+                    sort=[("start", pymongo.DESCENDING)],
+                    projection=projection,
+                )
+            )
+        )
+    return measurements

--- a/components/internal_server/src/routes/__init__.py
+++ b/components/internal_server/src/routes/__init__.py
@@ -1,6 +1,6 @@
 """Internal routes."""
 
 from .health import get_health
-from .measurement import post_measurement
+from .measurement import get_measurements, post_measurement
 from .metric import get_metrics
-from .report import get_report
+from .report import get_reports

--- a/components/internal_server/src/routes/measurement.py
+++ b/components/internal_server/src/routes/measurement.py
@@ -5,9 +5,10 @@ from pymongo.database import Database
 
 from shared.database.measurements import insert_new_measurement, latest_measurement
 from shared.model.measurement import Measurement
+from shared.model.metric import Metric
 
-from database.measurements import latest_successful_measurement, update_measurement_end
-from database.reports import latest_metric
+from database.measurements import latest_successful_measurement, recent_measurements, update_measurement_end
+from database.reports import latest_metric, latest_reports
 
 
 @bottle.post("/api/measurements")
@@ -31,3 +32,12 @@ def post_measurement(database: Database) -> None:
             update_measurement_end(database, latest["_id"])
             return
     insert_new_measurement(database, measurement)
+
+
+@bottle.get("/api/measurements")
+def get_measurements(database: Database):
+    """Return the two most recent measurements (without details) for all metrics in all reports."""
+    metrics: list[Metric] = []
+    for report in latest_reports(database):
+        metrics.extend(report.metrics)
+    return dict(measurements=recent_measurements(database, *metrics))

--- a/components/internal_server/src/routes/report.py
+++ b/components/internal_server/src/routes/report.py
@@ -3,20 +3,12 @@
 import bottle
 from pymongo.database import Database
 
-from shared.database.measurements import recent_measurements
-
 from database.reports import latest_reports
 
 
 @bottle.get("/api/report")
-def get_report(database: Database) -> dict[str, list]:
-    """Return the quality reports, including summaries of recent measurements."""
+def get_reports(database: Database) -> dict[str, list]:
+    """Return the quality reports."""
     # DeepSource somehow confuses latest_reports() with another latest_reports() that needs two arguments, suppress.
     reports = latest_reports(database)  # skipcq: PYL-E1120
-    summarized_reports = []
-
-    for report in reports:
-        measurements = recent_measurements(database, report.metrics_dict)
-        summarized_reports.append(report.summarize(measurements))
-
-    return dict(reports=summarized_reports)
+    return dict(reports=reports)

--- a/components/internal_server/tests/routes/test_measurement.py
+++ b/components/internal_server/tests/routes/test_measurement.py
@@ -3,9 +3,9 @@
 from datetime import date, datetime, timedelta
 from unittest.mock import Mock, patch
 
-from routes import post_measurement
+from routes import get_measurements, post_measurement
 
-from ..base import DataModelTestCase
+from ..base import DatabaseTestCase, DataModelTestCase
 from ..fixtures import METRIC_ID, METRIC_ID2, REPORT_ID, SOURCE_ID, SOURCE_ID2, SUBJECT_ID, SUBJECT_ID2
 
 
@@ -393,3 +393,23 @@ class PostMeasurementTests(DataModelTestCase):
                 ),
             )
         )
+
+
+class GetMeasurements(DatabaseTestCase):
+    """Unit tests for the get measurements endpoint."""
+
+    def test_no_reports(self):
+        """Test that there are no measurements if there are no reports."""
+        self.database.reports.find.return_value = []
+        self.assertEqual(dict(measurements=[]), get_measurements(self.database))
+
+    def test_no_metrics(self):
+        """Test that there are no measurements if none of the reports has metrics."""
+        self.database.reports.find.return_value = [{}]
+        self.assertEqual(dict(measurements=[]), get_measurements(self.database))
+
+    def test_one_metric(self):
+        """Test that the measurement is returned."""
+        self.database.reports.find.return_value = [{"subjects": {SUBJECT_ID: {"metrics": {METRIC_ID: {}}}}}]
+        self.database.measurements.find.return_value = [{}]
+        self.assertEqual(dict(measurements=[{}]), get_measurements(self.database))

--- a/components/internal_server/tests/routes/test_report.py
+++ b/components/internal_server/tests/routes/test_report.py
@@ -2,7 +2,7 @@
 
 from shared.model.report import Report
 
-from routes import get_report
+from routes import get_reports
 
 from ..base import DataModelTestCase
 from ..fixtures import REPORT_ID, create_report
@@ -19,6 +19,6 @@ class ReportTest(DataModelTestCase):  # skipcq: PTC-W0046
 
     def test_get_report(self):
         """Test that the reports can be retrieved."""
-        reports = get_report(self.database)["reports"]
+        reports = get_reports(self.database)["reports"]
         self.assertEqual(1, len(reports))
         self.assertEqual(REPORT_ID, reports[0][REPORT_ID])

--- a/components/notifier/src/models/metric_notification_data.py
+++ b/components/notifier/src/models/metric_notification_data.py
@@ -6,12 +6,11 @@ from shared_data_model import DATA_MODEL
 class MetricNotificationData:  # pylint: disable=too-few-public-methods
     """Handle metric data needed for notifications."""
 
-    def __init__(self, metric, subject) -> None:
+    def __init__(self, metric, measurements, subject) -> None:
         """Initialise the Notification with metric data."""
         self.metric_name = metric["name"] or f'{DATA_MODEL.metrics[metric["type"]].name}'
         self.metric_unit = metric["unit"] or f'{DATA_MODEL.metrics[metric["type"]].unit}'
         self.subject_name = subject.get("name") or DATA_MODEL.subjects[subject["type"]].name
-        recent_measurements = metric["recent_measurements"]
         scale = metric["scale"]
 
         self.new_metric_value = None
@@ -19,13 +18,13 @@ class MetricNotificationData:  # pylint: disable=too-few-public-methods
         self.new_metric_status = self.__user_friendly_status(None)
         self.old_metric_status = self.__user_friendly_status(None)
 
-        if len(recent_measurements) >= 1:
-            self.new_metric_value = recent_measurements[-1][scale]["value"]
-            self.new_metric_status = self.__user_friendly_status(recent_measurements[-1][scale]["status"])
+        if len(measurements) >= 1:
+            self.new_metric_value = measurements[-1][scale]["value"]
+            self.new_metric_status = self.__user_friendly_status(measurements[-1][scale]["status"])
 
-        if len(recent_measurements) >= 2:
-            self.old_metric_value = recent_measurements[-2][scale]["value"]
-            self.old_metric_status = self.__user_friendly_status(recent_measurements[-2][scale]["status"])
+        if len(measurements) >= 2:
+            self.old_metric_value = measurements[-2][scale]["value"]
+            self.old_metric_status = self.__user_friendly_status(measurements[-2][scale]["status"])
 
     @staticmethod
     def __user_friendly_status(metric_status) -> str:

--- a/components/notifier/src/notifier/notifier.py
+++ b/components/notifier/src/notifier/notifier.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import os
 from datetime import datetime, timezone
 from typing import NoReturn
 
@@ -12,13 +11,10 @@ from destinations.ms_teams import notification_text, send_notification
 from strategies.notification_strategy import NotificationFinder
 
 
-async def notify() -> NoReturn:
+async def notify(
+    internal_server_host: str = "localhost", internal_server_port: str = "5002", sleep_duration: int = 60
+) -> NoReturn:
     """Notify our users periodically of the number of red metrics."""
-    log_level = str(os.getenv("NOTIFIER_LOG_LEVEL", "WARNING"))
-    logging.getLogger().setLevel(log_level)
-    sleep_duration = int(os.getenv("NOTIFIER_SLEEP_DURATION", "60"))
-    internal_server_host = os.getenv("INTERNAL_SERVER_HOST", "localhost")
-    internal_server_port = os.getenv("INTERNAL_SERVER_PORT", "5002")
     internal_server_api = f"http://{internal_server_host}:{internal_server_port}/api"
     reports_url = f"{internal_server_api}/report"
     measurements_url = f"{internal_server_api}/measurements"

--- a/components/notifier/src/notifier/notifier.py
+++ b/components/notifier/src/notifier/notifier.py
@@ -1,0 +1,70 @@
+"""Notifier."""
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timezone
+from typing import NoReturn
+
+import aiohttp
+
+from destinations.ms_teams import notification_text, send_notification
+from strategies.notification_strategy import NotificationFinder
+
+
+async def notify() -> NoReturn:
+    """Notify our users periodically of the number of red metrics."""
+    log_level = str(os.getenv("NOTIFIER_LOG_LEVEL", "WARNING"))
+    logging.getLogger().setLevel(log_level)
+    sleep_duration = int(os.getenv("NOTIFIER_SLEEP_DURATION", "60"))
+    internal_server_host = os.getenv("INTERNAL_SERVER_HOST", "localhost")
+    internal_server_port = os.getenv("INTERNAL_SERVER_PORT", "5002")
+    internal_server_api = f"http://{internal_server_host}:{internal_server_port}/api"
+    reports_url = f"{internal_server_api}/report"
+    measurements_url = f"{internal_server_api}/measurements"
+    most_recent_measurement_seen = datetime.max.replace(tzinfo=timezone.utc)
+    notification_finder = NotificationFinder()
+    while True:
+        record_health()
+        logging.info("Determining notifications...")
+        reports, measurements = await get_reports_and_measurements(reports_url, measurements_url)
+        for notification in notification_finder.get_notifications(reports, measurements, most_recent_measurement_seen):
+            send_notification(str(notification.destination["webhook"]), notification_text(notification))
+        most_recent_measurement_seen = most_recent_measurement_timestamp(measurements)
+        logging.info("Sleeping %.1f seconds...", sleep_duration)
+        await asyncio.sleep(sleep_duration)
+
+
+async def get_reports_and_measurements(reports_url: str, measurements_url: str):
+    """Get the reports and measurements from the internal server."""
+    async with aiohttp.ClientSession(raise_for_status=True, trust_env=True) as session:
+        try:
+            url = reports_url
+            response = await session.get(url)
+            reports = (await response.json())["reports"]
+            url = measurements_url
+            response = await session.get(url)
+            measurements = (await response.json())["measurements"]
+        except Exception as reason:  # pylint: disable=broad-except
+            logging.error("Could not get data from %s: %s", url, reason)
+            reports = []
+            measurements = []
+    return reports, measurements
+
+
+def record_health() -> None:
+    """Record the current date and time in a file to allow for health checks."""
+    filename = "/home/notifier/health_check.txt"
+    try:
+        with open(filename, "w", encoding="utf-8") as health_check:
+            health_check.write(datetime.now().isoformat())
+    except OSError as reason:
+        logging.error("Could not write health check time stamp to %s: %s", filename, reason)
+
+
+def most_recent_measurement_timestamp(measurements) -> datetime:
+    """Return the most recent measurement timestamp."""
+    most_recent = datetime.min.replace(tzinfo=timezone.utc)
+    for measurement in measurements:
+        most_recent = max(most_recent, datetime.fromisoformat(measurement["end"]))
+    return most_recent

--- a/components/notifier/src/quality_time_notifier.py
+++ b/components/notifier/src/quality_time_notifier.py
@@ -1,9 +1,15 @@
 """Notifier."""
 
 import asyncio
+import logging
+import os
 
 from notifier.notifier import notify
 
 
-if __name__ == "__main__":
-    asyncio.run(notify())  # pragma: no cover
+if __name__ == "__main__":  # pragma: no cover
+    logging.getLogger().setLevel(str(os.getenv("NOTIFIER_LOG_LEVEL", "WARNING")))
+    internal_server_host = os.getenv("INTERNAL_SERVER_HOST", "localhost")
+    internal_server_port = os.getenv("INTERNAL_SERVER_PORT", "5002")
+    sleep_duration = int(os.getenv("NOTIFIER_SLEEP_DURATION", "60"))
+    asyncio.run(notify(internal_server_host, internal_server_port, sleep_duration))

--- a/components/notifier/src/quality_time_notifier.py
+++ b/components/notifier/src/quality_time_notifier.py
@@ -17,10 +17,9 @@ async def notify() -> NoReturn:
     log_level = str(os.getenv("NOTIFIER_LOG_LEVEL", "WARNING"))
     logging.getLogger().setLevel(log_level)
     sleep_duration = int(os.getenv("NOTIFIER_SLEEP_DURATION", "60"))
-    reports_url = (
-        f"http://{os.getenv('INTERNAL_SERVER_HOST', 'localhost')}:"
-        f"{os.getenv('INTERNAL_SERVER_PORT', '5002')}/api/report"
-    )
+    internal_server_host = os.getenv("INTERNAL_SERVER_HOST", "localhost")
+    internal_server_port = os.getenv("INTERNAL_SERVER_PORT", "5002")
+    reports_url = f"http://{internal_server_host}:{internal_server_port}/api/report"
     most_recent_measurement_seen = datetime.max.replace(tzinfo=timezone.utc)
     notification_finder = NotificationFinder()
     while True:

--- a/components/notifier/src/quality_time_notifier.py
+++ b/components/notifier/src/quality_time_notifier.py
@@ -1,73 +1,8 @@
 """Notifier."""
 
 import asyncio
-import logging
-import os
-from datetime import datetime, timezone
-from typing import NoReturn
 
-import aiohttp
-
-from destinations.ms_teams import notification_text, send_notification
-from strategies.notification_strategy import NotificationFinder
-
-
-async def notify() -> NoReturn:
-    """Notify our users periodically of the number of red metrics."""
-    log_level = str(os.getenv("NOTIFIER_LOG_LEVEL", "WARNING"))
-    logging.getLogger().setLevel(log_level)
-    sleep_duration = int(os.getenv("NOTIFIER_SLEEP_DURATION", "60"))
-    internal_server_host = os.getenv("INTERNAL_SERVER_HOST", "localhost")
-    internal_server_port = os.getenv("INTERNAL_SERVER_PORT", "5002")
-    internal_server_api = f"http://{internal_server_host}:{internal_server_port}/api"
-    reports_url = f"{internal_server_api}/report"
-    measurements_url = f"{internal_server_api}/measurements"
-    most_recent_measurement_seen = datetime.max.replace(tzinfo=timezone.utc)
-    notification_finder = NotificationFinder()
-    while True:
-        record_health()
-        logging.info("Determining notifications...")
-        reports, measurements = await get_reports_and_measurements(reports_url, measurements_url)
-        for notification in notification_finder.get_notifications(reports, measurements, most_recent_measurement_seen):
-            send_notification(str(notification.destination["webhook"]), notification_text(notification))
-        most_recent_measurement_seen = most_recent_measurement_timestamp(measurements)
-        logging.info("Sleeping %.1f seconds...", sleep_duration)
-        await asyncio.sleep(sleep_duration)
-
-
-async def get_reports_and_measurements(reports_url: str, measurements_url: str):
-    """Get the reports and measurements from the internal server."""
-    async with aiohttp.ClientSession(raise_for_status=True, trust_env=True) as session:
-        try:
-            url = reports_url
-            response = await session.get(url)
-            reports = (await response.json())["reports"]
-            url = measurements_url
-            response = await session.get(url)
-            measurements = (await response.json())["measurements"]
-        except Exception as reason:  # pylint: disable=broad-except
-            logging.error("Could not get data from %s: %s", url, reason)
-            reports = []
-            measurements = []
-    return reports, measurements
-
-
-def record_health() -> None:
-    """Record the current date and time in a file to allow for health checks."""
-    filename = "/home/notifier/health_check.txt"
-    try:
-        with open(filename, "w", encoding="utf-8") as health_check:
-            health_check.write(datetime.now().isoformat())
-    except OSError as reason:
-        logging.error("Could not write health check time stamp to %s: %s", filename, reason)
-
-
-def most_recent_measurement_timestamp(measurements) -> datetime:
-    """Return the most recent measurement timestamp."""
-    most_recent = datetime.min.replace(tzinfo=timezone.utc)
-    for measurement in measurements:
-        most_recent = max(most_recent, datetime.fromisoformat(measurement["end"]))
-    return most_recent
+from notifier.notifier import notify
 
 
 if __name__ == "__main__":

--- a/components/notifier/src/strategies/notification_strategy.py
+++ b/components/notifier/src/strategies/notification_strategy.py
@@ -9,27 +9,28 @@ from models.metric_notification_data import MetricNotificationData
 class NotificationFinder:
     """Handle notification contents and status."""
 
-    def get_notifications(self, json, most_recent_measurement_seen: datetime) -> list[Notification]:
+    def get_notifications(self, reports, measurements, most_recent_measurement_seen: datetime) -> list[Notification]:
         """Return the reports that have a webhook and metrics that require notifying."""
+        measurements.sort(key=lambda measurement: measurement["end"])
         notifications = []
-        for report in json["reports"]:
+        for report in reports:
             notable_metrics = []
             for subject in report["subjects"].values():
-                for metric in subject["metrics"].values():
-                    if self.status_changed(metric, most_recent_measurement_seen):
-                        notable_metrics.append(MetricNotificationData(metric, subject))
+                for metric_uuid, metric in subject["metrics"].items():
+                    metric_measurements = [m for m in measurements if m["metric_uuid"] == metric_uuid]
+                    if self.status_changed(metric, metric_measurements, most_recent_measurement_seen):
+                        notable_metrics.append(MetricNotificationData(metric, metric_measurements, subject))
             if notable_metrics:
                 for destination_uuid, destination in report.get("notification_destinations", {}).items():
                     notifications.append(Notification(report, notable_metrics, destination_uuid, destination))
         return notifications
 
     @staticmethod
-    def status_changed(metric, most_recent_measurement_seen: datetime) -> bool:
+    def status_changed(metric, measurements, most_recent_measurement_seen: datetime) -> bool:
         """Determine if a metric got a new status after the given timestamp."""
-        recent_measurements = metric.get("recent_measurements") or []
-        if len(recent_measurements) < 2:
+        if len(measurements) < 2:
             return False  # If there are fewer than two measurements, the metric couldn't have recently changed status
         scale = metric["scale"]
-        metric_had_other_status = recent_measurements[-2][scale]["status"] != recent_measurements[-1][scale]["status"]
-        change_was_recent = datetime.fromisoformat(recent_measurements[-1]["start"]) > most_recent_measurement_seen
+        metric_had_other_status = measurements[-2][scale]["status"] != measurements[-1][scale]["status"]
+        change_was_recent = datetime.fromisoformat(measurements[-1]["start"]) > most_recent_measurement_seen
         return bool(metric_had_other_status and change_was_recent)

--- a/components/notifier/tests/destinations/test_teams.py
+++ b/components/notifier/tests/destinations/test_teams.py
@@ -46,23 +46,23 @@ class BuildNotificationTextTests(TestCase):
             name="Metric",
             unit="units",
             scale=scale,
-            recent_measurements=[
-                dict(count=dict(value=0, status="near_target_met")),
-                dict(count=dict(value=42, status="target_not_met")),
-            ],
         )
+        measurements1 = [
+            dict(count=dict(value=0, status="near_target_met")),
+            dict(count=dict(value=42, status="target_not_met")),
+        ]
         metric2 = dict(
             type="metric_type",
             name="Metric",
             unit="units",
             scale=scale,
-            recent_measurements=[
-                dict(count=dict(value=5, status="target_met")),
-                dict(count=dict(value=10, status="target_not_met")),
-            ],
         )
-        metric_notification_data1 = MetricNotificationData(metric1, self.subject)
-        metric_notification_data2 = MetricNotificationData(metric2, self.subject)
+        measurements2 = [
+            dict(count=dict(value=5, status="target_met")),
+            dict(count=dict(value=10, status="target_not_met")),
+        ]
+        metric_notification_data1 = MetricNotificationData(metric1, measurements1, self.subject)
+        metric_notification_data2 = MetricNotificationData(metric2, measurements2, self.subject)
         notification = Notification(
             self.report, [metric_notification_data1, metric_notification_data2], "destination_uuid", {}
         )
@@ -83,12 +83,12 @@ class BuildNotificationTextTests(TestCase):
             name="Metric",
             unit="units",
             scale="count",
-            recent_measurements=[
-                dict(count=dict(value=0, status="near_target_met")),
-                dict(count=dict(value=None, status="unknown")),
-            ],
         )
-        metric_notification_data1 = MetricNotificationData(metric1, self.subject)
+        measurements = [
+            dict(count=dict(value=0, status="near_target_met")),
+            dict(count=dict(value=None, status="unknown")),
+        ]
+        metric_notification_data1 = MetricNotificationData(metric1, measurements, self.subject)
         notification = Notification(self.report, [metric_notification_data1], "destination_uuid", {})
         self.assertEqual(
             "[Report 1](https://report1) has 1 metric that changed status:\n\n"

--- a/components/notifier/tests/models/test_metric_notification_data.py
+++ b/components/notifier/tests/models/test_metric_notification_data.py
@@ -15,26 +15,25 @@ class MetricNotificationDataModelTestCase(unittest.TestCase):
             name="default metric 1",
             unit="units",
             scale="count",
-            recent_measurements=[
-                dict(count=dict(value=10, status="target_met")),
-                dict(count=dict(value=20, status="target_not_met")),
-            ],
         )
+        self.measurements = [
+            dict(count=dict(value=10, status="target_met")),
+            dict(count=dict(value=20, status="target_not_met")),
+        ]
         self.subject = dict(type="software", name="Subject")
 
     def test_new_status(self):
         """Test that the new status is set correctly."""
-        new_status = MetricNotificationData(self.metric, self.subject).new_metric_status
+        new_status = MetricNotificationData(self.metric, self.measurements, self.subject).new_metric_status
         self.assertEqual("red (target not met)", new_status)
 
     def test_unknown_status(self):
         """Test that a recent measurement without status works."""
-        self.metric["recent_measurements"][-1]["count"]["status"] = None
-        new_status = MetricNotificationData(self.metric, self.subject).new_metric_status
+        self.measurements[-1]["count"]["status"] = None
+        new_status = MetricNotificationData(self.metric, self.measurements, self.subject).new_metric_status
         self.assertEqual("white (unknown)", new_status)
 
     def test_unknown_status_without_recent_measurements(self):
         """Test that a metric without recent measurements works."""
-        self.metric["recent_measurements"] = []
-        new_status = MetricNotificationData(self.metric, self.subject).new_metric_status
+        new_status = MetricNotificationData(self.metric, [], self.subject).new_metric_status
         self.assertEqual("white (unknown)", new_status)

--- a/components/notifier/tests/notifier/test_notifier.py
+++ b/components/notifier/tests/notifier/test_notifier.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from unittest.mock import mock_open, patch
 
-from quality_time_notifier import most_recent_measurement_timestamp, notify, record_health
+from notifier.notifier import most_recent_measurement_timestamp, notify, record_health
 
 
 class MostRecentMeasurementTimestampTests(unittest.TestCase):
@@ -30,7 +30,7 @@ class HealthCheckTest(unittest.TestCase):
         self.filename = "/home/notifier/health_check.txt"
 
     @patch("builtins.open", new_callable=mock_open)
-    @patch("quality_time_notifier.datetime")
+    @patch("notifier.notifier.datetime")
     def test_writing_health_check(self, mocked_datetime, mocked_open):
         """Test that the current time is written to the health check file."""
         mocked_datetime.now.return_value = now = datetime.now()
@@ -129,7 +129,7 @@ class NotifyTests(unittest.IsolatedAsyncioTestCase):
             pass
         mocked_send.assert_not_called()
 
-    @patch("quality_time_notifier.send_notification")
+    @patch("notifier.notifier.send_notification")
     @patch("asyncio.sleep")
     @patch("aiohttp.ClientSession.get")
     async def test_one_new_red_metric(self, mocked_get, mocked_sleep, mocked_send):

--- a/components/notifier/tests/strategies/test_notification_strategy.py
+++ b/components/notifier/tests/strategies/test_notification_strategy.py
@@ -9,31 +9,37 @@ from strategies.notification_strategy import NotificationFinder
 class StrategiesTests(unittest.TestCase):
     """Unit tests for the 'number of new red metrics per report' notification strategy."""
 
+    OLD_TIMESTAMP = "2019-01-01T00:00:00+00:00"
+    NEW_TIMESTAMP = "2020-01-01T00:00:00+00:00"
+
     def setUp(self):
         """Override to create a reports JSON fixture."""
-        self.old_timestamp = "2019-01-01T00:00:00+00:00"
-        self.new_timestamp = "2020-01-01T00:00:00+00:00"
         self.notification_finder = NotificationFinder()
         self.most_recent_measurement_seen = datetime.min.replace(tzinfo=timezone.utc)
         self.white_metric_status = "unknown"
-        self.red_metric = self.metric(
-            name="metric1",
-            status="target_not_met",
-            recent_measurements=[
-                dict(start=self.old_timestamp, end=self.new_timestamp, count=dict(status="target_met", value="5")),
-                dict(start=self.new_timestamp, end=self.new_timestamp, count=dict(status="target_not_met", value="10")),
-            ],
-        )
-        self.reports = dict(
-            reports=[
-                dict(
-                    report_uuid="report1",
-                    title="Title",
-                    subjects=dict(subject1=dict(metrics=dict(red_metric=self.red_metric), type="software")),
-                    notification_destinations=dict(destination_uuid=dict(name="destination")),
-                )
-            ]
-        )
+        self.red_metric = self.metric(name="metric1", status="target_not_met")
+        self.red_metric_measurements = [
+            dict(
+                metric_uuid="red_metric",
+                start=self.OLD_TIMESTAMP,
+                end=self.NEW_TIMESTAMP,
+                count=dict(status="target_met", value="5"),
+            ),
+            dict(
+                metric_uuid="red_metric",
+                start=self.NEW_TIMESTAMP,
+                end=self.NEW_TIMESTAMP,
+                count=dict(status="target_not_met", value="10"),
+            ),
+        ]
+        self.reports = [
+            dict(
+                report_uuid="report1",
+                title="Title",
+                subjects=dict(subject1=dict(metrics=dict(red_metric=self.red_metric), type="software")),
+                notification_destinations=dict(destination_uuid=dict(name="destination")),
+            )
+        ]
 
     @staticmethod
     def metric(name="metric1", status="target_met", scale="count", recent_measurements=None, status_start=None):
@@ -48,38 +54,40 @@ class StrategiesTests(unittest.TestCase):
             status_start=status_start or "",
         )
 
-    def get_notifications(self):
+    def get_notifications(self, measurements=None):
         """Return the notifications."""
-        return self.notification_finder.get_notifications(self.reports, self.most_recent_measurement_seen)
+        return self.notification_finder.get_notifications(
+            self.reports, measurements or [], self.most_recent_measurement_seen
+        )
 
     def test_no_reports(self):
         """Test that there is nothing to notify when there are no reports."""
-        self.reports["reports"] = []
+        self.reports = []
         self.assertEqual([], self.get_notifications())
 
     def test_no_red_metrics(self):
         """Test that there is nothing to notify when there are no red metrics."""
         green_metric = self.metric(
             recent_measurements=[
-                dict(start=self.old_timestamp, end=self.new_timestamp, count=dict(status="target_met", value="0"))
+                dict(start=self.OLD_TIMESTAMP, end=self.NEW_TIMESTAMP, count=dict(status="target_met", value="0"))
             ]
         )
-        self.reports["reports"][0]["subjects"]["subject1"]["metrics"] = dict(metric=green_metric)
+        self.reports[0]["subjects"]["subject1"]["metrics"] = dict(metric=green_metric)
         self.assertEqual([], self.get_notifications())
 
     def test_old_red_metric(self):
         """Test that there is nothing to notify if the red metric was already red."""
-        self.red_metric["recent_measurements"][0]["count"]["status"] = "target_not_met"
+        self.red_metric_measurements[0]["count"]["status"] = "target_not_met"
         self.assertEqual([], self.get_notifications())
 
     def test_red_metric_without_recent_measurements(self):
         """Test that there is nothing to notify if the red metric has no recent measurements."""
-        self.red_metric["recent_measurements"] = []
+        self.red_metric_measurements = []
         self.assertEqual([], self.get_notifications())
 
     def test_new_red_metric(self):
         """Test that a metric that has become red is included."""
-        notifications = self.get_notifications()
+        notifications = self.get_notifications(self.red_metric_measurements)
         self.assertEqual(
             ["metric1", "red (target not met)"],
             [notifications[0].metrics[0].metric_name, notifications[0].metrics[0].new_metric_status],
@@ -87,42 +95,49 @@ class StrategiesTests(unittest.TestCase):
 
     def test_new_red_metric_without_count_scale(self):
         """Test that a metric that doesn't have a count scale that became red is included."""
-        self.assertEqual(["metric1"], [self.get_notifications()[0].metrics[0].metric_name])
+        self.assertEqual(["metric1"], [self.get_notifications(self.red_metric_measurements)[0].metrics[0].metric_name])
 
     def test_recently_changed_metric_status(self):
         """Test that a metric that turns white is added."""
-        metric = self.metric(
-            status=self.white_metric_status,
-            recent_measurements=[
-                dict(start=self.new_timestamp, count=dict(status="target_met")),
-                dict(start=self.old_timestamp, count=dict(status=self.white_metric_status)),
-            ],
+        metric = self.metric(status=self.white_metric_status)
+        measurements = [
+            dict(
+                metric_uuid="metric_uuid",
+                start=self.NEW_TIMESTAMP,
+                end=self.NEW_TIMESTAMP,
+                count=dict(status="target_met"),
+            ),
+            dict(
+                metric_uuid="metric_uuid",
+                start=self.OLD_TIMESTAMP,
+                end=self.OLD_TIMESTAMP,
+                count=dict(status=self.white_metric_status),
+            ),
+        ]
+        self.assertTrue(
+            self.notification_finder.status_changed(metric, measurements, self.most_recent_measurement_seen)
         )
-        self.assertTrue(self.notification_finder.status_changed(metric, self.most_recent_measurement_seen))
 
     def test_new_measurement_same_status(self):
         """Test that a metric that was already white isn't added."""
-        metric = self.metric(
-            status=self.white_metric_status,
-            recent_measurements=[
-                dict(start=self.new_timestamp, count=dict(status=self.white_metric_status)),
-                dict(start=self.old_timestamp, count=dict(status=self.white_metric_status)),
-            ],
+        metric = self.metric(status=self.white_metric_status)
+        measurements = [
+            dict(start=self.NEW_TIMESTAMP, count=dict(status=self.white_metric_status)),
+            dict(start=self.OLD_TIMESTAMP, count=dict(status=self.white_metric_status)),
+        ]
+        self.assertFalse(
+            self.notification_finder.status_changed(metric, measurements, self.most_recent_measurement_seen)
         )
-        self.assertFalse(self.notification_finder.status_changed(metric, self.most_recent_measurement_seen))
 
     def test_no_change_due_to_only_one_measurement(self):
         """Test that metrics with only one measurement (and therefore no changes in value) aren't added."""
-        metric = self.metric(
-            status=self.white_metric_status,
-            recent_measurements=[dict(start=self.old_timestamp, count=dict(status=self.white_metric_status))],
-        )
-        self.assertFalse(self.notification_finder.status_changed(metric, self.most_recent_measurement_seen))
+        metric = self.metric(status=self.white_metric_status)
+        self.assertFalse(self.notification_finder.status_changed(metric, [{}], self.most_recent_measurement_seen))
 
     def test_no_change_due_to_no_measurements(self):
         """Test that metrics without measurements (and therefore no changes in value) aren't added."""
         metric = self.metric(status=self.white_metric_status)
-        self.assertFalse(self.notification_finder.status_changed(metric, self.most_recent_measurement_seen))
+        self.assertFalse(self.notification_finder.status_changed(metric, [], self.most_recent_measurement_seen))
 
     def test_multiple_reports_with_same_destination(self):
         """Test that the correct metrics are notified when multiple reports notify the same destination."""
@@ -136,18 +151,32 @@ class StrategiesTests(unittest.TestCase):
             subjects=dict(subject=subject2),
             notification_destinations=dict(uuid1=dict(url="https://report2", name="destination2")),
         )
-        self.reports["reports"].append(report2)
+        self.reports.append(report2)
+        red_metric2_measurements = [
+            dict(
+                metric_uuid="metric1",
+                start=self.OLD_TIMESTAMP,
+                end=self.NEW_TIMESTAMP,
+                count=dict(status="target_met", value="5"),
+            ),
+            dict(
+                metric_uuid="metric1",
+                start=self.NEW_TIMESTAMP,
+                end=self.NEW_TIMESTAMP,
+                count=dict(status="target_not_met", value="10"),
+            ),
+        ]
         metrics = []
-        for notification in self.get_notifications():
+        for notification in self.get_notifications(self.red_metric_measurements + red_metric2_measurements):
             metrics.append(notification.metrics)
         self.assertEqual(["metric1", "metric2"], [metrics[0][0].metric_name, metrics[1][0].metric_name])
 
     def test_no_notification_destinations_configured(self):
         """Test that no notification is to be sent if there are no configurations in notification destinations."""
-        self.reports["reports"][0]["notification_destinations"] = {}
+        self.reports[0]["notification_destinations"] = {}
         self.assertEqual([], self.get_notifications())
 
     def test_no_notification_destinations_in_json(self):
         """Test that no notification is to be sent if notification destinations do not exist in the data."""
-        del self.reports["reports"][0]["notification_destinations"]
+        del self.reports[0]["notification_destinations"]
         self.assertEqual([], self.get_notifications())

--- a/components/notifier/tests/test_quality_time_notifier.py
+++ b/components/notifier/tests/test_quality_time_notifier.py
@@ -2,7 +2,7 @@
 
 import unittest
 from copy import deepcopy
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import mock_open, patch
 
 from quality_time_notifier import most_recent_measurement_timestamp, notify, record_health
@@ -13,18 +13,13 @@ class MostRecentMeasurementTimestampTests(unittest.TestCase):
 
     def test_no_measurements(self):
         """Test without measurements."""
-        report = dict(subjects=dict(subject1=dict(metrics=dict(metric1=dict(recent_measurements=[])))))
-        json_data = dict(reports=[report])
-        self.assertEqual(datetime.min.replace(tzinfo=timezone.utc), most_recent_measurement_timestamp(json_data))
+        self.assertEqual(datetime.min.replace(tzinfo=timezone.utc), most_recent_measurement_timestamp([]))
 
     def test_one_measurement(self):
         """Test that the end timestamp of the measurement is returned."""
         now = datetime.now().replace(microsecond=0, tzinfo=timezone.utc)
-        report = dict(
-            subjects=dict(subject1=dict(metrics=dict(metric1=dict(recent_measurements=[dict(end=now.isoformat())]))))
-        )
-        json_data = dict(reports=[report])
-        self.assertEqual(now, most_recent_measurement_timestamp(json_data))
+        measurement = dict(end=now.isoformat())
+        self.assertEqual(now, most_recent_measurement_timestamp([measurement]))
 
 
 class HealthCheckTest(unittest.TestCase):
@@ -84,9 +79,6 @@ class NotifyTests(unittest.IsolatedAsyncioTestCase):
                         unit="units",
                         status="target_not_met",
                         scale="count",
-                        recent_measurements=[
-                            dict(start=self.history, end=self.history, count=dict(status="target_met", value="5"))
-                        ],
                     )
                 ),
             )
@@ -95,8 +87,12 @@ class NotifyTests(unittest.IsolatedAsyncioTestCase):
     @staticmethod
     async def return_report(report=None):
         """Return the reports response asynchronously."""
-        reports = [report] if report else []
-        return FakeResponse(dict(reports=reports))
+        return FakeResponse(dict(reports=[report] if report else []))
+
+    @staticmethod
+    async def return_measurements(measurements=None):
+        """Return the measurements response asynchronously."""
+        return FakeResponse(dict(measurements=measurements if measurements else []))
 
     @patch("logging.error")
     @patch("asyncio.sleep")
@@ -113,14 +109,19 @@ class NotifyTests(unittest.IsolatedAsyncioTestCase):
         # two different instances of OSError, even without arguments, don't compare equal.
         mocked_log_error.assert_called_once()
         first_two_log_args = mocked_log_error.mock_calls[0][1][0:2]
-        self.assertEqual(("Could not get reports from %s: %s", self.report_api), first_two_log_args)
+        self.assertEqual(("Could not get data from %s: %s", self.report_api), first_two_log_args)
 
     @patch("pymsteams.connectorcard.send")
     @patch("asyncio.sleep")
     @patch("aiohttp.ClientSession.get")
     async def test_no_new_red_metrics(self, mocked_get, mocked_sleep, mocked_send):
         """Test that no notifications are sent if there are no new red metrics."""
-        mocked_get.side_effect = [self.return_report(), self.return_report()]
+        mocked_get.side_effect = [
+            self.return_report(),
+            self.return_measurements(),
+            self.return_report(),
+            self.return_measurements(),
+        ]
         mocked_sleep.side_effect = [None, RuntimeError]
         try:
             await notify()
@@ -133,7 +134,7 @@ class NotifyTests(unittest.IsolatedAsyncioTestCase):
     @patch("aiohttp.ClientSession.get")
     async def test_one_new_red_metric(self, mocked_get, mocked_sleep, mocked_send):
         """Test that a notification is sent if there is one new red metric."""
-        report = dict(
+        report1 = dict(
             report_uuid="report1",
             title=self.title,
             url=self.url,
@@ -141,11 +142,21 @@ class NotifyTests(unittest.IsolatedAsyncioTestCase):
             subjects=self.subjects,
         )
         now = datetime.now().replace(microsecond=0, tzinfo=timezone.utc).isoformat()
-        report2 = deepcopy(report)
-        report2["subjects"]["subject1"]["metrics"]["metric1"]["recent_measurements"].append(
-            dict(start=now, end=now, count=dict(status="target_not_met", value="10"))
-        )
-        mocked_get.side_effect = [self.return_report(report), self.return_report(report2)]
+        just_now = (datetime.now().replace(microsecond=0, tzinfo=timezone.utc) - timedelta(seconds=10)).isoformat()
+        report2 = deepcopy(report1)
+        mocked_get.side_effect = [
+            self.return_report(report1),
+            self.return_measurements(),
+            self.return_report(report2),
+            self.return_measurements(
+                [
+                    dict(metric_uuid="metric1", end=now, start=now, count=dict(status="target_not_met", value="10")),
+                    dict(
+                        metric_uuid="metric1", end=just_now, start=just_now, count=dict(status="target_met", value="0")
+                    ),
+                ]
+            ),
+        ]
         mocked_sleep.side_effect = [None, RuntimeError]
         try:
             await notify()
@@ -159,6 +170,9 @@ class NotifyTests(unittest.IsolatedAsyncioTestCase):
     async def test_one_old_red_metric_with_one_measurement(self, mocked_get, mocked_sleep, mocked_send):
         """Test that a notification is not sent if there is one old red metric."""
         history = self.history
+        measurement = dict(
+            metric_uuid="metric1", start=history, end=history, count=dict(status="target_met", value="5")
+        )
         report = dict(
             report_uuid="report1",
             title=self.title,
@@ -173,15 +187,17 @@ class NotifyTests(unittest.IsolatedAsyncioTestCase):
                             unit="units",
                             status="target_not_met",
                             scale="count",
-                            recent_measurements=[
-                                dict(start=history, end=history, count=dict(status="target_met", value="5"))
-                            ],
                         )
                     )
                 )
             ),
         )
-        mocked_get.side_effect = [self.return_report(report), self.return_report(report)]
+        mocked_get.side_effect = [
+            self.return_report(report),
+            self.return_measurements([measurement]),
+            self.return_report(report),
+            self.return_measurements([measurement]),
+        ]
         mocked_sleep.side_effect = [None, RuntimeError]
         try:
             await notify()
@@ -201,12 +217,13 @@ class NotifyTests(unittest.IsolatedAsyncioTestCase):
             notification_destinations=dict(destination1=dict(name="destination name", webhook="")),
             subjects=self.subjects,
         )
-        now = datetime.now().replace(microsecond=0, tzinfo=timezone.utc).isoformat()
         report2 = deepcopy(report)
-        report2["subjects"]["subject1"]["metrics"]["metric1"]["recent_measurements"].append(
-            dict(start=now, end=now, count=dict(status="target_met", value="10"))
-        )
-        mocked_get.side_effect = [self.return_report(report), self.return_report(report2)]
+        mocked_get.side_effect = [
+            self.return_report(report),
+            self.return_measurements(),
+            self.return_report(report2),
+            self.return_measurements(),
+        ]
         mocked_sleep.side_effect = [None, RuntimeError]
         try:
             await notify()

--- a/tests/feature_tests/features/notification.feature
+++ b/tests/feature_tests/features/notification.feature
@@ -1,0 +1,19 @@
+Feature: notification destinations
+  Getting the data to send notifications
+
+  Background: a report with a subject and a metric exists
+    Given a logged-in client
+    And an existing report
+    And a notification destination
+    And an existing subject
+    And an existing metric
+    And an existing source
+
+  Scenario: get notification data
+    When the collector measures "0"
+    Then the metric status is "target_met"
+    When the client waits a second
+    And the collector measures "100"
+    Then the metric status is "target_not_met"
+    When the notifier gets the notification data
+    Then the internal server returns two measurements for the metric

--- a/tests/feature_tests/steps/notification.py
+++ b/tests/feature_tests/steps/notification.py
@@ -1,0 +1,17 @@
+"""Step implementations for notifications."""
+
+from asserts import assert_equal
+from behave import then, when  # pylint: disable=no-name-in-module
+
+
+@when("the notifier gets the notification data")
+def get_notification_data(context):
+    """Get the notification data."""
+    context.get("measurements", internal=True)
+
+
+@then("the internal server returns two measurements for the metric")
+def check_internal_server_measurements(context):
+    """Check that the response contains the measurements."""
+    measurements = context.response.json()["measurements"]
+    assert_equal(2, len([m for m in measurements if m["metric_uuid"] == context.uuid["metric"]]))


### PR DESCRIPTION
Refactor the notifier to not use "summarised" report data, but to get the measurements directly from a (new) internal server measurements end point. This is one step towards getting rid of the servers adding measurements to reports.