### PR TITLE
Fix: Victory Bar charts animation were defered and not showing, this fixes it

### DIFF
--- a/components/frontend/src/dashboard/MetricSummaryCard.js
+++ b/components/frontend/src/dashboard/MetricSummaryCard.js
@@ -12,7 +12,7 @@ function nr_metrics_text(nr_metrics) {
 }
 
 export function MetricSummaryCard({ header, onClick, summary, maxY }) {
-    const animate = { duration: 0 }
+    const animate = { duration: 0, onLoad: { duration: 0 } }
     const colors = STATUSES.map((status) => STATUS_COLORS_RGB[status]);
     const labelColor = useContext(DarkMode) ? "darkgrey" : "rgba(120, 120, 120)";
     const flyoutBgColor = useContext(DarkMode) ? "rgba(60, 65, 70)" : "white";

--- a/components/frontend/src/dashboard/StatusBarChart.js
+++ b/components/frontend/src/dashboard/StatusBarChart.js
@@ -25,6 +25,7 @@ export function StatusBarChart({ animate, colors, label, tooltip, summary, maxY,
                 labels={() => null}
                 labelComponent={tooltip}
                 data={data}
+                animate={animate}
             />
         )
     });
@@ -35,7 +36,6 @@ export function StatusBarChart({ animate, colors, label, tooltip, summary, maxY,
         <svg viewBox="0 0 400 400">
             {nrMetrics === 0 && label}
             <VictoryStack
-                animate={animate}
                 colorScale={colors}
                 containerComponent={<VictoryContainer responsive={false} />}
                 domainPadding={10}


### PR DESCRIPTION
By explicitly adding the prop for animation on VictoryBar component the chart starts the animation immediately.

This seems to be a bug in Victory itself. Related issue: https://github.com/FormidableLabs/victory/issues/2104