### PR TITLE
GitLab pipeline source up-to-dateness should take filters into account

### DIFF
--- a/components/collector/src/source_collectors/gitlab/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/gitlab/source_up_to_dateness.py
@@ -89,7 +89,10 @@ class GitLabPipelineUpToDateness(TimePassedCollector, GitLabProjectBase):
         try:
             for response in responses:
                 pipelines = await response.json()
-                urls.extend([(self._datetime(pipeline), pipeline["web_url"]) for pipeline in pipelines])
+                urls.extend([
+                    (self._datetime(pipeline), pipeline["web_url"])
+                    for pipeline in pipelines if self._include_pipeline(pipeline)
+                ])
         except StopAsyncIteration:
             pass
         return max(urls, default=(None, await super()._landing_url(responses)))[1]

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is v4.0.0 or older, please re
 ### Fixed
 
 - The unit name of metrics in MS Teams notifications would not be rendered correctly. Fixes [#5347](https://github.com/ICTU/quality-time/issues/5347).
+- GitLab pipeline source up-to-dateness should take filters into account. Fixes [#5181](https://github.com/ICTU/quality-time/issues/5181).
 
 ### Changed
 


### PR DESCRIPTION
Fixes #5181