### PR TITLE
Fix a regression introduced in Quality-time v4.9.0 that causes all …

### DIFF
--- a/components/collector/src/source_collectors/sonarqube/security_warnings.py
+++ b/components/collector/src/source_collectors/sonarqube/security_warnings.py
@@ -45,8 +45,10 @@ class SonarQubeSecurityWarnings(SonarQubeViolations):
                 )
             )
         if "security_hotspot" in security_types:
+            # Note: SonarQube is a bit inconsistent. For issue search, the SonarQube status parameter is called
+            # "statuses", but for hotspots it's called "status".
             api_urls.append(
-                URL(f"{base_url}/api/hotspots/search?projectKey={component}&branch={branch}&statuses=TO_REVIEW&ps=500")
+                URL(f"{base_url}/api/hotspots/search?projectKey={component}&branch={branch}&status=TO_REVIEW&ps=500")
             )
         return await super()._get_source_responses(*api_urls, **kwargs)
 

--- a/components/renderer/Dockerfile
+++ b/components/renderer/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
     ttf-droid=20200215-r2 \
     ttf-freefont=20120503-r3 \
     ttf-liberation=2.1.5-r2 \
-    chromium=112.0.5615.49-r0 && \
+    chromium=112.0.5615.121-r0 && \
     rm -rf /var/cache/apk/* /tmp/*
 
 RUN update-ms-fonts \

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Deployment notes
+
+If your currently installed *Quality-time* version is v4.0.0 or older, please read the v4.0.0 deployment notes.
+
+### Fixed
+
+- Fix a regression introduced in *Quality-time* v4.9.0 that causes all SonarQube security hotspots to be shown as part of the security warnings metric, instead of only the hotspots with status "to review". Fixes [#5953](https://github.com/ICTU/quality-time/issues/5953).
+
 ## v4.9.0 - 2023-04-14
 
 ### Deployment notes


### PR DESCRIPTION
…SonarQube security hotspots to be shown as part of the security warnings metric, instead of only the hotspots with status TO_REVIEW.