### PR TITLE
When using SonarQube security hotspots as source for the security war…

### DIFF
--- a/components/collector/tests/source_collectors/sonarqube/base.py
+++ b/components/collector/tests/source_collectors/sonarqube/base.py
@@ -29,6 +29,7 @@ class SonarQubeTestCase(SourceCollectorTestCase):  # skipcq: PTC-W0046
         review_priority: str = None,
         creation_date: str = None,
         update_date: str = None,
+        hotspot_status: str = None,
     ) -> Entity:
         """Create an entity."""
         url = (
@@ -53,4 +54,6 @@ class SonarQubeTestCase(SourceCollectorTestCase):  # skipcq: PTC-W0046
             entity["rationale"] = rationale
         if review_priority is not None:
             entity["review_priority"] = review_priority
+        if hotspot_status is not None:
+            entity["hotspot_status"] = hotspot_status
         return entity

--- a/components/collector/tests/source_collectors/sonarqube/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_security_warnings.py
@@ -44,6 +44,7 @@ class SonarQubeSecurityWarningsTest(SonarQubeTestCase):
                     vulnerabilityProbability="MEDIUM",
                     creationDate="2010-12-13T10:37:07+0000",
                     updateDate="2019-08-26T09:02:49+0000",
+                    status="TO_REVIEW",
                 ),
                 dict(
                     key="hotspot2",
@@ -52,6 +53,8 @@ class SonarQubeSecurityWarningsTest(SonarQubeTestCase):
                     vulnerabilityProbability="LOW",
                     creationDate="2011-10-26T13:34:12+0000",
                     updateDate="2020-08-31T08:19:00+0000",
+                    status="REVIEWED",
+                    resolution="FIXED",
                 ),
             ],
         )
@@ -64,6 +67,7 @@ class SonarQubeSecurityWarningsTest(SonarQubeTestCase):
                 review_priority="medium",
                 creation_date="2010-12-13T10:37:07+0000",
                 update_date="2019-08-26T09:02:49+0000",
+                hotspot_status="to review",
             ),
             self.entity(
                 key="hotspot2",
@@ -73,6 +77,7 @@ class SonarQubeSecurityWarningsTest(SonarQubeTestCase):
                 review_priority="low",
                 creation_date="2011-10-26T13:34:12+0000",
                 update_date="2020-08-31T08:19:00+0000",
+                hotspot_status="fixed",
             ),
         ]
         self.vulnerability_entities = [
@@ -132,4 +137,17 @@ class SonarQubeSecurityWarningsTest(SonarQubeTestCase):
             total="100",
             entities=self.vulnerability_entities,
             landing_url="https://sonarqube/project/issues?id=id&branch=master&resolved=false&types=VULNERABILITY",
+        )
+
+    async def test_filter_security_warnings_hotspots_by_status(self):
+        """Test that the security hotspots can be filtered by status."""
+        self.set_source_parameter("security_types", ["security_hotspot"])
+        self.set_source_parameter("hotspot_statuses", ["fixed"])
+        response = await self.collect(get_request_json_return_value=self.hotspots_json)
+        self.assert_measurement(
+            response,
+            value="1",
+            total="100",
+            entities=self.hotspot_entities[1:],
+            landing_url="https://sonarqube/project/security_hotspots?id=id&branch=master",
         )

--- a/components/shared_data_model/src/shared_data_model/sources/sonarqube.py
+++ b/components/shared_data_model/src/shared_data_model/sources/sonarqube.py
@@ -23,7 +23,9 @@ class Lines(str, Enum):
     CODE = "lines with code"
 
 
-def violation_entity_attributes(include_review_priority=False, include_resolution=False, include_rationale=False):
+def violation_entity_attributes(
+    include_review_priority=False, include_resolution=False, include_rationale=False, include_status=False
+):
     """Return the violation entity attributes."""
     attributes = [
         dict(name="Message"),
@@ -31,7 +33,9 @@ def violation_entity_attributes(include_review_priority=False, include_resolutio
     ]
     if include_review_priority:
         attributes.append(dict(name="Review priority", color=dict(high=Color.NEGATIVE, medium=Color.WARNING)))
-    attributes.append(dict(name="Type"))
+    attributes.append(dict(name="Warning type", key="type"))
+    if include_status:
+        attributes.append(dict(name="Hotspot status"))
     if include_resolution:
         attributes.append(dict(name="Resolution"))
     if include_rationale:
@@ -245,6 +249,14 @@ SONARQUBE = Source.parse_obj(
                 values=["info", "minor", "major", "critical", "blocker"],
                 metrics=["security_warnings", "suppressed_violations", "violations"],
             ),
+            hotspot_statuses=MultipleChoiceParameter(
+                name="Security hotspot statuses",
+                short_name="hotspot statuses",
+                help_url="https://docs.sonarqube.org/latest/user-guide/security-hotspots/",
+                placeholder="all hotspot statuses",
+                values=["to review", "acknowledged", "safe", "fixed"],
+                metrics=["security_warnings"],
+            ),
             review_priorities=MultipleChoiceParameter(
                 name="Security hotspot review priorities",
                 short_name="review priorities",
@@ -280,10 +292,10 @@ SONARQUBE = Source.parse_obj(
             security_types=MultipleChoiceParameter(
                 name="Security issue types (measuring security hotspots requires SonarQube 8.2 or newer)",
                 short_name="types",
-                placeholder="all security issue types",
+                placeholder="vulnerability",
                 help_url="https://docs.sonarqube.org/latest/user-guide/rules/",
                 default_value=["vulnerability"],
-                values=["vulnerability", "security_hotspot"],
+                values=["security_hotspot", "vulnerability"],
                 metrics=["security_warnings"],
             ),
         ),
@@ -309,7 +321,8 @@ SONARQUBE = Source.parse_obj(
                 ],
             ),
             security_warnings=dict(
-                name="security warning", attributes=violation_entity_attributes(include_review_priority=True)
+                name="security warning",
+                attributes=violation_entity_attributes(include_review_priority=True, include_status=True),
             ),
             suppressed_violations=dict(
                 name="violation",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Deployment notes
+
+If your currently installed *Quality-time* version is v4.0.0 or older, please read the v4.0.0 deployment notes.
+
+### Added
+
+- When using SonarQube security hotspots as source for the security warnings metric, allow for filtering hotspots by hotspot status ('to review', 'acknowledged', 'fixed', 'safe'). Closes [#5956](https://github.com/ICTU/quality-time/issues/5956).
+
 ## v4.10.0 - 2023-04-26
 
 ### Deployment notes

--- a/docs/styles/Vocab/Base/accept.txt
+++ b/docs/styles/Vocab/Base/accept.txt
@@ -34,7 +34,7 @@ donut
 errored
 favicon
 hostnames?
-hotspots
+hotspots?
 misconfigured
 mypy
 namespace


### PR DESCRIPTION
…nings metric, allow for filtering hotspots by hotspot status ('to review', 'acknowledged', 'fixed', 'safe'). Closes #5956.