### PR TITLE
Applies URI encoding/decoding to pathname in React history

### DIFF
--- a/components/frontend/src/App.js
+++ b/components/frontend/src/App.js
@@ -31,7 +31,7 @@ class App extends Component {
 
     componentDidMount() {
         const pathname = this.history.location.pathname;
-        const report_uuid = pathname.slice(1, pathname.length);
+        const report_uuid = decodeURI(pathname.slice(1, pathname.length));
         const report_date_iso_string = registeredURLSearchParams(this.history).get("report_date") || "";
         let reportDate = null;
         if (isValidDate_YYYYMMDD(report_date_iso_string)) {
@@ -118,7 +118,7 @@ class App extends Component {
 
     open_report(event, report_uuid) {
         event.preventDefault();
-        this.history_push(report_uuid)
+        this.history_push(encodeURI(report_uuid))
         this.setState({ report_uuid: report_uuid, loading: true }, () => this.reload());
     }
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is v4.0.0 or older, please re
 
 ### Fixed
 
+- Reports for tags with spaces in them could not be exported to PDF. Fixes [#4765](https://github.com/ICTU/quality-time/issues/4765).
 - Remove useless popup that appears when hovering tags in the dashboard. Fixes [#5525](https://github.com/ICTU/quality-time/issues/5525).
 
 ### Added


### PR DESCRIPTION
As the pathname wasn't properly decoded nor encoded any pathname with a space in it would not render when navigated to directly. Closes #4765.