### PR TITLE
Don't query SonarQube for the rule `plsql:PlSql.FunctionAndProcedureE…

### DIFF
--- a/components/collector/tests/source_collectors/sonarqube/test_many_parameters.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_many_parameters.py
@@ -28,7 +28,5 @@ class SonarQubeManyParametersTest(SonarQubeTestCase):
             value="2",
             total="4",
             landing_url=f"{self.issues_landing_url}&rules=c:S107,csharpsquid:S107,csharpsquid:S2436,cpp:S107,flex:S107,"
-            "javascript:S107,objc:S107,php:S107,"
-            "plsql:PlSql.FunctionAndProcedureExcessiveParameters,python:S107,java:S107,"
-            "tsql:S107,typescript:S107",
+            "javascript:S107,objc:S107,php:S107,python:S107,java:S107,tsql:S107,typescript:S107",
         )

--- a/components/shared_data_model/src/shared_data_model/sources/sonarqube.py
+++ b/components/shared_data_model/src/shared_data_model/sources/sonarqube.py
@@ -147,7 +147,6 @@ SONARQUBE = Source.parse_obj(
                     "javascript:S107",
                     "objc:S107",
                     "php:S107",
-                    "plsql:PlSql.FunctionAndProcedureExcessiveParameters",
                     "python:S107",
                     "java:S107",
                     "tsql:S107",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -35,6 +35,7 @@ See the [deployment instructions](https://quality-time.readthedocs.io/en/latest/
 - Reports for tags with spaces in them could not be exported to PDF. Fixes [#4765](https://github.com/ICTU/quality-time/issues/4765).
 - Remove useless popup that appears when hovering tags in the dashboard. Fixes [#5525](https://github.com/ICTU/quality-time/issues/5525).
 - Don't attempt to collect all projects and repositories from Harbor when the user has configured filters on projects and/or repositories. Partially fixes [#6220](https://github.com/ICTU/quality-time/issues/6220).
+- Don't query SonarQube for the rule `plsql:PlSql.FunctionAndProcedureExcessiveParameters` when collecting data for the 'many parameters' metric. Sonarcloud.io gives a permission denied error when querying for that rule. Fixes [#6277](https://github.com/ICTU/quality-time/issues/6277).
 
 ### Added
 


### PR DESCRIPTION
…xcessiveParameters` when collecting data for the 'many parameters' metric. Sonarcloud.io gives a permission denied error when querying for that rule. Fixes #6277.