### PR TITLE
When measuring average issue lead time, users can configure how far b…

### DIFF
--- a/components/collector/src/source_collectors/azure_devops/average_issue_lead_time.py
+++ b/components/collector/src/source_collectors/azure_devops/average_issue_lead_time.py
@@ -26,7 +26,9 @@ class AzureDevopsAverageIssueLeadTime(AzureDevopsIssues):
             return False
         if not entity["lead_time"]:  # no lead time means no changed date
             return False
-        return days_ago(parse_datetime(entity["changed_field"])) <= int(cast(str, self._parameter("lookback_days")))
+        change_age = days_ago(parse_datetime(entity["changed_field"]))
+        max_change_age = int(cast(str, self._parameter("lookback_days_issues")))
+        return change_age <= max_change_age
 
     async def _parse_value(self, responses: SourceResponses) -> Value:
         """Calculate the average lead time of the completed work items."""

--- a/components/collector/src/source_collectors/azure_devops/job_runs_within_time_period.py
+++ b/components/collector/src/source_collectors/azure_devops/job_runs_within_time_period.py
@@ -15,5 +15,6 @@ class AzureDevopsJobRunsWithinTimePeriod(AzureDevopsPipelines):
         """Return whether to include this run or not."""
         if not super()._include_entity(entity):
             return False
-
-        return days_ago(parse_datetime(entity["build_date"])) <= int(cast(str, self._parameter("lookback_days")))
+        build_age = days_ago(parse_datetime(entity["build_date"]))
+        max_build_age = int(cast(str, self._parameter("lookback_days_pipeline_runs")))
+        return build_age <= max_build_age

--- a/components/collector/tests/source_collectors/azure_devops/test_job_runs_within_time_period.py
+++ b/components/collector/tests/source_collectors/azure_devops/test_job_runs_within_time_period.py
@@ -12,7 +12,7 @@ class AzureDevopsJobRunsWithinTimePeriodTest(AzureDevopsPipelinesTestCase):
 
     async def test_pipeline_runs(self):
         """Test that the pipeline runs are counted."""
-        self.set_source_parameter("lookback_days", "424242")
+        self.set_source_parameter("lookback_days_pipeline_runs", "424242")
 
         response = await self.collect(
             get_request_json_return_value=self.pipeline_runs,
@@ -23,7 +23,7 @@ class AzureDevopsJobRunsWithinTimePeriodTest(AzureDevopsPipelinesTestCase):
 
     async def test_pipeline_runs_jobs_exclude(self):
         """Test that the pipeline runs are filtered by name exclude."""
-        self.set_source_parameter("lookback_days", "424242")
+        self.set_source_parameter("lookback_days_pipeline_runs", "424242")
         self.set_source_parameter("jobs_to_ignore", ["azure-pipelines.*"])
 
         response = await self.collect(
@@ -35,7 +35,7 @@ class AzureDevopsJobRunsWithinTimePeriodTest(AzureDevopsPipelinesTestCase):
 
     async def test_pipeline_runs_jobs_empty_include(self):
         """Test that counting pipeline runs filtered by a not-matching name include, works."""
-        self.set_source_parameter("lookback_days", "424242")
+        self.set_source_parameter("lookback_days_pipeline_runs", "424242")
         self.set_source_parameter("jobs_to_include", ["bogus"])
 
         response = await self.collect(
@@ -47,7 +47,7 @@ class AzureDevopsJobRunsWithinTimePeriodTest(AzureDevopsPipelinesTestCase):
 
     async def test_pipeline_runs_lookback_days(self):
         """Test that the pipeline runs are filtered correctly by lookback_days."""
-        self.set_source_parameter("lookback_days", "3")
+        self.set_source_parameter("lookback_days_pipeline_runs", "3")
 
         now_dt = datetime.now(tz=UTC)
         now_timestamp = now_dt.isoformat()

--- a/components/shared_code/src/shared_data_model/sources/azure_devops.py
+++ b/components/shared_code/src/shared_data_model/sources/azure_devops.py
@@ -156,11 +156,19 @@ AZURE_DEVOPS = Source(
             "Use {folder name}/{pipeline name} for the names of pipelines in folders.",
             metrics=["failed_jobs", "job_runs_within_time_period", "source_up_to_dateness", "unused_jobs"],
         ),
-        "lookback_days": Days(
-            name="Number of days to look back in selecting pipeline runs or work items to consider",
+        "lookback_days_pipeline_runs": Days(
+            name="Number of days to look back for selecting pipeline runs",
             short_name="number of days to look back",
             default_value="90",
-            metrics=["average_issue_lead_time", "job_runs_within_time_period"],
+            metrics=["job_runs_within_time_period"],
+        ),
+        "lookback_days_issues": Days(
+            name="Number of days to look back for work items",
+            help="Work items are selected if they are completed and have been updated within the number of days "
+            "configured.",
+            short_name="number of days to look back",
+            default_value="90",
+            metrics=["average_issue_lead_time"],
         ),
         "failure_type": FailureType(
             values=["canceled", "failed", "no result", "partially succeeded"],

--- a/components/shared_code/src/shared_data_model/sources/gitlab.py
+++ b/components/shared_code/src/shared_data_model/sources/gitlab.py
@@ -145,7 +145,7 @@ profile/personal_access_tokens.html) with the scope `read_repository` in the pri
             metrics=["failed_jobs", "job_runs_within_time_period", "unused_jobs"],
         ),
         "lookback_days": Days(
-            name="Number of days to look back in selecting pipeline jobs to consider",
+            name="Number of days to look back for selecting pipeline jobs",
             short_name="number of days to look back",
             default_value="90",
             metrics=["failed_jobs", "job_runs_within_time_period", "source_up_to_dateness", "unused_jobs"],

--- a/components/shared_code/src/shared_data_model/sources/jenkins.py
+++ b/components/shared_code/src/shared_data_model/sources/jenkins.py
@@ -93,7 +93,7 @@ JENKINS = Source(
             metrics=["failed_jobs", "job_runs_within_time_period", "source_up_to_dateness", "unused_jobs"],
         ),
         lookback_days=Days(
-            name="Number of days to look back in selecting job builds to consider",
+            name="Number of days to look back for selecting job builds",
             short_name="number of days to look back",
             default_value="90",
             metrics=["job_runs_within_time_period"],

--- a/components/shared_code/src/shared_data_model/sources/jira.py
+++ b/components/shared_code/src/shared_data_model/sources/jira.py
@@ -78,7 +78,9 @@ JIRA = Source(
             ],
         ),
         lookback_days=Days(
-            name="Number of days to look back in selecting issues to consider",
+            name="Number of days to look back for selecting issues",
+            help="Issues are selected if they are completed and have been updated within the number of days "
+            "configured.",
             short_name="number of days to look back",
             default_value="90",
             metrics=["average_issue_lead_time"],

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 
 ### Fixed
 
+- When measuring average issue lead time, users can configure how far back *Quality-time* should look for selecting issues. Add a tool tip to this lookback parameter explaining which issues are selected: "Issues are selected if they are completed and have been updated within the number of days configured". Fixes [#6350](https://github.com/ICTU/quality-time/issues/6350).
 - Jira issue statuses were not collected. Fixes [#6435](https://github.com/ICTU/quality-time/issues/6435).
 - Jira issues created from *Quality-time* would have an incorrect unit in the issue title and description. Fixes [#6437](https://github.com/ICTU/quality-time/issues/6437).
 

--- a/docs/styles/Vocab/Base/accept.txt
+++ b/docs/styles/Vocab/Base/accept.txt
@@ -34,6 +34,7 @@ errored
 favicon
 hostnames?
 hotspots?
+lookback
 misconfigured
 mypy
 namespace


### PR DESCRIPTION
…ack Quality-time should look for selecting issues. Add a tool tip to this lookback parameter explaining which issues are selected: "Issues are selected if they are completed and have been updated within the number of days configured". Fixes #6350.