### PR TITLE
When measuring velocity using Jira as source, the number of sprints t…

### DIFF
--- a/components/shared_code/src/shared_data_model/sources/jira.py
+++ b/components/shared_code/src/shared_data_model/sources/jira.py
@@ -118,6 +118,9 @@ JIRA = Source(
         test_result=TestResult(metrics=["test_cases"], values=["errored", "failed", "passed", "skipped", "untested"]),
         velocity_sprints=IntegerParameter(
             name="Number of sprints to base velocity on",
+            help="Velocity is defined as the number of user story points realized per sprint. By default, velocity "
+            "is calculated by averaging the number of user story points realized in the three most recently "
+            "completed sprints. The number of sprints to use can be changed via this parameter.",
             short_name="number of sprints",
             mandatory=True,
             unit=Unit.SPRINTS,

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 
 ### Fixed
 
+- When measuring velocity using Jira as source, the number of sprints to base velocity on can be changed via a parameter. Add help text to the parameter to explain how velocity is calculated. Fixes [#6349](https://github.com/ICTU/quality-time/issues/6349).
 - When measuring average issue lead time, users can configure how far back *Quality-time* should look for selecting issues. Add a tool tip to this lookback parameter explaining which issues are selected: "Issues are selected if they are completed and have been updated within the number of days configured". Fixes [#6350](https://github.com/ICTU/quality-time/issues/6350).
 - Jira issue statuses were not collected. Fixes [#6435](https://github.com/ICTU/quality-time/issues/6435).
 - Jira issues created from *Quality-time* would have an incorrect unit in the issue title and description. Fixes [#6437](https://github.com/ICTU/quality-time/issues/6437).


### PR DESCRIPTION
…o base velocity on can be changed via a paramter. Add help text to the parameter to explain how velocity is calculated. Fixes #6349.