### PR TITLE
When accessing Harbor with invalid credentials, Harbor returns data f…

### DIFF
--- a/components/shared_code/src/shared_data_model/sources/harbor.py
+++ b/components/shared_code/src/shared_data_model/sources/harbor.py
@@ -48,8 +48,6 @@ HARBOR = Source(
                     "help": "URL of the Harbor instance, with port if necessary, but without path. For example "
                     "'https://demo.goharbor.io'.",
                 },
-                "username": {"mandatory": True},
-                "password": {"mandatory": True},
             },
         ),
     ),

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,6 +19,7 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 - Notify the user that editing is not possible when they open a tag report or time travel. Fixes [#3380](https://github.com/ICTU/quality-time/issues/3380).
 - When changing the metric type, tags in the tags field would not be updated immediately. Fixes [#5116](https://github.com/ICTU/quality-time/issues/5116).
 - Show warning message when the user session expires. Fixes [#5327](https://github.com/ICTU/quality-time/issues/5327).
+- When accessing Harbor with invalid credentials, Harbor returns data from public projects only. To prevent the invalid credentials from going unnoticed, explicitly check Harbor credentials before retrieving data. Fixes [#6484](https://github.com/ICTU/quality-time/issues/6485).
 - Fix the landing URL for Harbor artifacts. Fixes [#6485](https://github.com/ICTU/quality-time/issues/6485).
 - When changing the metric type, don't remove tags the user added to the metric. Fixes [#6524](https://github.com/ICTU/quality-time/issues/6524).
 


### PR DESCRIPTION
…rom public projects only. To prevent the invalid credentials from going unnoticed, explicitly check Harbor credentials before retrieving data. Fixes #6484.