### PR TITLE
Rename the 'will be fixed' status of measurement entities (violations…

### DIFF
--- a/components/frontend/src/report/ReportTitle.js
+++ b/components/frontend/src/report/ReportTitle.js
@@ -175,8 +175,8 @@ function ReactionTimes({ report, reload }) {
                                 label={
                                     <LabelWithHelp
                                         labelFor="desired-response-time-fixed"
-                                        label="Will be fixed"
-                                        help="Will be fixed means that an entity can be ignored because it will be fixed shortly and thus disappear."
+                                        label="Fixed"
+                                        help="Fixed means that an entity can be ignored because it has been fixed, or will be fixed shortly, and thus disappear."
                                     />
                                 }
                                 requiredPermissions={[EDIT_REPORT_PERMISSION]}

--- a/components/frontend/src/report/ReportTitle.test.js
+++ b/components/frontend/src/report/ReportTitle.test.js
@@ -108,11 +108,11 @@ it('sets the false positive measurement entity status reaction time', async () =
     expect(report_api.set_report_attribute).toHaveBeenLastCalledWith("report_uuid", "desired_response_times", { "false_positive": 70 }, reload);
 })
 
-it('sets the will be fixed measurement entity status reaction time', async () => {
+it('sets the fixed measurement entity status reaction time', async () => {
     render_report_title();
     fireEvent.click(screen.getByTitle(/expand/));
     await act(async () => { fireEvent.click(screen.getByText(/reaction times/)) });
-    await userEvent.type(screen.getByLabelText(/Will be fixed/), '80{Enter}}', { initialSelectionStart: 0, initialSelectionEnd: 3 });
+    await userEvent.type(screen.getByLabelText(/Fixed/), '80{Enter}}', { initialSelectionStart: 0, initialSelectionEnd: 3 });
     expect(report_api.set_report_attribute).toHaveBeenLastCalledWith("report_uuid", "desired_response_times", { "fixed": 80 }, reload);
 })
 

--- a/components/frontend/src/source/SourceEntity.test.js
+++ b/components/frontend/src/source/SourceEntity.test.js
@@ -30,7 +30,7 @@ it('renders the unconfirmed status', () => {
 
 it('renders the fixed status', () => {
     renderSourceEntity({ status: "fixed" });
-    expect(screen.getAllByText(/Will be fixed/).length).toBe(1);
+    expect(screen.getAllByText(/Fixed/).length).toBe(1);
 })
 
 it('renders the status end date', () => {
@@ -51,5 +51,5 @@ it('renders the status and rationale past end date', () => {
 
 it('renders nothing if the status is to be ignored', () => {
     renderSourceEntity({ status: "fixed", hide_ignored_entities: true });
-    expect(screen.queryAllByText(/Will be fixed/).length).toBe(0);
+    expect(screen.queryAllByText(/Fixed/).length).toBe(0);
 })

--- a/components/frontend/src/source/SourceEntityDetails.js
+++ b/components/frontend/src/source/SourceEntityDetails.js
@@ -19,13 +19,13 @@ function entity_status_options(entity_type, report) {
     const desired_response_times = report?.desired_response_times ?? {}
     const unconfirmed_subheader = `This ${entity_type} should be reviewed to decide what to do with it.`
     const confirmed_subheader = `This ${entity_type} has been reviewed and should be dealt with within ${desired_response_times["confirmed"]} days.`
-    const fixed_subheader = `Ignore this ${entity_type} for ${desired_response_times["fixed"]} days because it will be fixed shortly.`
+    const fixed_subheader = `Ignore this ${entity_type} for ${desired_response_times["fixed"]} days because it has been fixed or will be fixed shortly.`
     const false_positive_subheader = `Ignore this ${entity_type} for ${desired_response_times["false_positive"]} days because it's been incorrectly identified as ${entity_type}.`
     const wont_fix_subheader = `Ignore this ${entity_type} for ${desired_response_times["wont_fix"]} days because it will not be fixed.`
     return [
         entity_status_option('unconfirmed', status_name.unconfirmed, 'Unconfirm', unconfirmed_subheader),
         entity_status_option('confirmed', status_name.confirmed, "Confirm", confirmed_subheader),
-        entity_status_option('fixed', status_name.fixed, "Resolve as will be fixed", fixed_subheader),
+        entity_status_option('fixed', status_name.fixed, "Resolve as fixed", fixed_subheader),
         entity_status_option('false_positive', status_name.false_positive, "Resolve as false positive", false_positive_subheader),
         entity_status_option('wont_fix', status_name.wont_fix, "Resolve as won't fix", wont_fix_subheader),
     ]

--- a/components/frontend/src/source/source_entity_status.js
+++ b/components/frontend/src/source/source_entity_status.js
@@ -1,7 +1,7 @@
 export const source_entity_status_name = {
     unconfirmed: "Unconfirmed",
     confirmed: "Confirmed",
-    fixed: "Will be fixed",
+    fixed: "Fixed",
     false_positive: "False positive",
     wont_fix: "Won't fix"
 }

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -31,6 +31,10 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 - Add SonarQube Swift rules for complex units, methods with too many lines and functions with too many parameters. Closes [#6493](https://github.com/ICTU/quality-time/issues/6493).
 - Add a note to the [reference manual](https://quality-time.readthedocs.io/en/latest/reference.html#jenkins) about how to configure Jenkins private tokens in *Quality-time*. Closes [#6557](https://github.com/ICTU/quality-time/issues/6557).
 
+### Changed
+
+- Rename the 'will be fixed' status of measurement entities (violations, warnings, issues, etc.) to 'fixed'. Closes [#6556](https://github.com/ICTU/quality-time/issues/6556).
+
 ## v5.0.1 - 2023-06-26
 
 ### Deployment notes

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -351,9 +351,9 @@ An entity is a measured entity like for example one single failed job in GitLab 
 
 To add a source to a metric, expand the metric in the metric table and then click the tab with the source name. It will show a list of entities with all its details.
 
-When clicking on one of the entities, it can be expanded and edited. Options are for example mark an entity as false positive or as fixed. Entities marked as false positive, will be fixed, or won't fix are crossed out and subtracted from the measurement value. For example, if a source reports 14 security warnings and two are marked as false positive, the measurement value will be 12.
+When clicking on one of the entities, it can be expanded and edited. Options are for example mark an entity as false positive or as fixed. Entities marked as fixed, false positive, or won't fix are crossed out and subtracted from the measurement value. For example, if a source reports 14 security warnings and two are marked as false positive, the measurement value will be 12.
 
-When setting the status of an entity, the end date of that status is also set. By default, the status end date is set to 180 days after the current date for confirmed, false positive, and won't fix. The status end date for will be fixed is 7 days as 'will be fixed' means the entity should disappear shortly. These defaults can be customized, see the [Desired reaction times](#desired-reaction-times) section below.
+When setting the status of an entity, the end date of that status is also set. By default, the status end date is set to 180 days after the current date for confirmed, false positive, and won't fix. The status end date for fixed is 7 days as 'fixed' means the entity should disappear shortly. These defaults can be customized, see the [Desired reaction times](#desired-reaction-times) section below.
 
 ## Customizing quality reports
 
@@ -389,7 +389,7 @@ When showing multiple dates in the metric table (this can be done via the Settin
 
 #### Desired time after which to review measurement entities
 
-Measurement entities (violations, issues, security warnings, etc.) can have one of five possible status: unconfirmed, confirmed, false positive, will be fixed, and won't fix. When setting the state of a measurement entity to a state other than unconfirmed, the end date of the status is also set. The reason is to encourage the status of measurement entities to be periodically reviewed. The default values can be changed.
+Measurement entities (violations, issues, security warnings, etc.) can have one of five possible status: unconfirmed, confirmed, fixed, false positive, and won't fix. When setting the state of a measurement entity to a state other than unconfirmed, the end date of the status is also set. The reason is to encourage the status of measurement entities to be periodically reviewed. The default values can be changed.
 
 ```{index} Trend table
 ```


### PR DESCRIPTION
…, warnings, issues, etc.) to 'fixed'. Closes #6556.