### PR TITLE
Don't make the vertical axis of trend graphs 200 high when the maximu…

### DIFF
--- a/components/frontend/src/utils.js
+++ b/components/frontend/src/utils.js
@@ -225,7 +225,7 @@ export function pluralize(word, count) {
 }
 
 export function nice_number(number) {
-    let rounded_numbers = [10, 20, 30, 40, 50, 60, 70, 80, 90];
+    let rounded_numbers = [10, 12, 15, 20, 30, 50, 75];
     do {
         for (let rounded_number of rounded_numbers) {
             if (number <= ((9 * rounded_number) / 10)) {

--- a/components/frontend/src/utils.test.js
+++ b/components/frontend/src/utils.test.js
@@ -31,15 +31,23 @@ it('capitalizes strings', () => {
 });
 
 it('rounds numbers nicely', () => {
+    expect(nice_number(0)).toBe(10);
+    expect(nice_number(1)).toBe(10);
+    expect(nice_number(9)).toBe(10);
+    expect(nice_number(10)).toBe(12);
+    expect(nice_number(12)).toBe(15);
     expect(nice_number(15)).toBe(20);
     expect(nice_number(16)).toBe(20);
     expect(nice_number(17)).toBe(20);
     expect(nice_number(39)).toBe(50);
     expect(nice_number(40)).toBe(50);
     expect(nice_number(41)).toBe(50);
-    expect(nice_number(79)).toBe(90);
-    expect(nice_number(80)).toBe(90);
-    expect(nice_number(81)).toBe(90);
+    expect(nice_number(79)).toBe(100);
+    expect(nice_number(80)).toBe(100);
+    expect(nice_number(81)).toBe(100);
+    expect(nice_number(90)).toBe(100);
+    expect(nice_number(100)).toBe(120);
+    expect(nice_number(125)).toBe(150);
 });
 
 it('adds a scale', () => {

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -25,6 +25,7 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 - When accessing Harbor with invalid credentials, Harbor returns data from public projects only. To prevent the invalid credentials from going unnoticed, explicitly check Harbor credentials before retrieving data. Fixes [#6484](https://github.com/ICTU/quality-time/issues/6485).
 - Fix the landing URL for Harbor artifacts. Fixes [#6485](https://github.com/ICTU/quality-time/issues/6485).
 - When changing the metric type, don't remove tags the user added to the metric. Fixes [#6524](https://github.com/ICTU/quality-time/issues/6524).
+- Don't make the vertical axis of trend graphs 200 high when the maximum value is 100 (for example, when displaying metrics with a percentage scale). Fixes [#6621](https://github.com/ICTU/quality-time/issues/6621).
 
 ### Added
 


### PR DESCRIPTION
…m value is 100 (for example, when displaying metrics with a percentage scale). Fixes #6621.