### PR TITLE
Performance improvements

### DIFF
--- a/components/api_server/src/database/measurements.py
+++ b/components/api_server/src/database/measurements.py
@@ -11,12 +11,21 @@ from shared.model.metric import Metric
 from shared.utils.functions import iso_timestamp
 from shared.utils.type import MetricId
 
+# Projection options
+NO_ID = {"_id": False}
+NO_SOURCE_DETAILS = NO_ID | {"sources.entities": False, "sources.entity_user_data": False}
+NO_MEASUREMENT_DETAILS = NO_SOURCE_DETAILS | {"issue_status": False}
+
+# Sort optins
+START_ASCENDING = [("start", pymongo.ASCENDING), ("end", pymongo.DESCENDING)]
+START_DESCENDING = [("start", pymongo.DESCENDING)]
+
 
 def changelog(database: Database, nr_changes: int, **uuids):
     """Return the changelog for the measurements belonging to the items with the specific uuids."""
     return database.measurements.find(
         filter={"delta.uuids": {"$in": list(uuids.values())}},
-        sort=[("start", pymongo.DESCENDING)],
+        sort=START_DESCENDING,
         limit=nr_changes,
         projection=["delta", "start"],
     )
@@ -27,52 +36,24 @@ def count_measurements(database: Database) -> int:
     return int(database.measurements.estimated_document_count())
 
 
-def measurements_by_metric(
-    database: Database,
-    *metric_uuids: MetricId,
-    min_iso_timestamp: str = "",
-    max_iso_timestamp: str = "",
-):
-    """Return recent measurements for the specified metrics, without entities and issue status."""
-    if not metric_uuids:
-        return []
-    measurement_filter: dict = {"metric_uuid": {"$in": metric_uuids}}
-    if min_iso_timestamp:  # pragma: no feature-test-cover
-        measurement_filter["end"] = {"$gt": min_iso_timestamp}
-    if max_iso_timestamp:  # pragma: no feature-test-cover
-        measurement_filter["start"] = {"$lt": max_iso_timestamp}
-    return list(
-        database.measurements.find(
-            measurement_filter,
-            sort=[("start", pymongo.ASCENDING)],
-            projection={
-                "_id": False,
-                "sources.entities": False,
-                "sources.entity_user_data": False,
-                "issue_status": False,
-            },
-        ),
-    )
+def measurements_in_period(database: Database, min_iso_timestamp: str, max_iso_timestamp: str):
+    """Return recent measurements for the specified metrics, without source details and issue status."""
+    measurement_filter = {"start": {"$lte": max_iso_timestamp or iso_timestamp()}, "end": {"$gte": min_iso_timestamp}}
+    return list(database.measurements.find(measurement_filter, sort=START_ASCENDING, projection=NO_MEASUREMENT_DETAILS))
 
 
-def all_metric_measurements(
-    database: Database,
-    metric_uuid: MetricId,
-    max_iso_timestamp: str = "",
-):
+def all_metric_measurements(database: Database, metric_uuid: MetricId, max_iso_timestamp: str):
     """Return all measurements for one metric, without entities and issue status, except for the most recent one."""
-    measurement_filter: dict = {"metric_uuid": metric_uuid}
+    measurement_filter: dict[str, str | dict[str, str]] = {"metric_uuid": str(metric_uuid)}
     if max_iso_timestamp:
-        measurement_filter["start"] = {"$lt": max_iso_timestamp}
-    latest_measurement_complete = database.measurements.find_one(
-        measurement_filter,
-        sort=[("start", pymongo.DESCENDING)],
-        projection={"_id": False},
-    )
-    if not latest_measurement_complete:
+        measurement_filter["start"] = {"$lte": max_iso_timestamp}
+    latest_measurement = database.measurements.find_one(measurement_filter, sort=START_ASCENDING, projection=NO_ID)
+    if not latest_measurement:
         return []
-    all_measurements_stripped = measurements_by_metric(database, metric_uuid, max_iso_timestamp=max_iso_timestamp)
-    return list(all_measurements_stripped)[:-1] + [latest_measurement_complete]
+    all_measurements_stripped = list(
+        database.measurements.find(measurement_filter, sort=START_ASCENDING, projection=NO_MEASUREMENT_DETAILS),
+    )
+    return list(all_measurements_stripped)[:-1] + [latest_measurement]
 
 
 def recent_measurements(
@@ -81,21 +62,15 @@ def recent_measurements(
     max_iso_timestamp: str = "",
     days: int = 7,
 ) -> dict[MetricId, list[Measurement]]:
-    """Return all recent measurements, or only those of the specified metrics."""
+    """Return all recent measurements."""
     max_iso_timestamp = max_iso_timestamp or iso_timestamp()
     min_iso_timestamp = (datetime.fromisoformat(max_iso_timestamp) - timedelta(days=days)).isoformat()
-    measurement_filter: dict[str, Any] = {"end": {"$gte": min_iso_timestamp}, "start": {"$lte": max_iso_timestamp}}
-    measurement_filter["metric_uuid"] = {"$in": list(metrics_dict.keys())}
-    projection = {"_id": False, "sources.entities": False, "entity_user_data": False}
-    measurements = database.measurements.find(
-        measurement_filter,
-        sort=[("start", pymongo.ASCENDING)],
-        projection=projection,
-    )
+    measurement_filter: dict[str, Any] = {"start": {"$lte": max_iso_timestamp}, "end": {"$gte": min_iso_timestamp}}
+    measurements = database.measurements.find(measurement_filter, sort=START_ASCENDING, projection=NO_SOURCE_DETAILS)
     measurements_by_metric_uuid: dict[MetricId, list] = {}
     for measurement_dict in measurements:
         metric_uuid = measurement_dict["metric_uuid"]
-        metric = metrics_dict[metric_uuid]
-        measurement = Measurement(metric, measurement_dict)
-        measurements_by_metric_uuid.setdefault(metric_uuid, []).append(measurement)
+        if metric := metrics_dict.get(metric_uuid):  # pragma: no feature-test-cover
+            measurement = Measurement(metric, measurement_dict)
+            measurements_by_metric_uuid.setdefault(metric_uuid, []).append(measurement)
     return measurements_by_metric_uuid

--- a/components/api_server/src/database/reports.py
+++ b/components/api_server/src/database/reports.py
@@ -81,7 +81,7 @@ def latest_reports(database: Database) -> list[Report]:
 
 def latest_reports_before_timestamp(database: Database, data_model: dict, max_iso_timestamp: str) -> list[Report]:
     """Return the latest, undeleted, reports in the reports collection before the max timestamp."""
-    report_filter = {"timestamp": {"$lt": max_iso_timestamp}} if max_iso_timestamp else {}
+    report_filter = {"timestamp": {"$lte": max_iso_timestamp}} if max_iso_timestamp else {}
     report_uuids = database.reports.distinct("report_uuid", report_filter)
     report_dicts = []
     for report_uuid in report_uuids:
@@ -122,7 +122,7 @@ def insert_new_reports_overview(database: Database, delta_description: str, repo
 
 def latest_reports_overview(database: Database, max_iso_timestamp: str = "") -> dict:
     """Return the latest reports overview."""
-    timestamp_filter = {"timestamp": {"$lt": max_iso_timestamp}} if max_iso_timestamp else None
+    timestamp_filter = {"timestamp": {"$lte": max_iso_timestamp}} if max_iso_timestamp else None
     overview = database.reports_overviews.find_one(timestamp_filter, sort=TIMESTAMP_DESCENDING)
     if overview:  # pragma: no feature-test-cover
         overview["_id"] = str(overview["_id"])

--- a/components/api_server/src/initialization/database.py
+++ b/components/api_server/src/initialization/database.py
@@ -44,9 +44,9 @@ def create_indexes(database: Database) -> None:
     database.datamodels.create_index("timestamp")
     database.reports.create_index([("timestamp", pymongo.ASCENDING), ("report_uuid", pymongo.ASCENDING)])
     database.users.create_index("username", unique=True)
-    start_index = pymongo.IndexModel([("start", pymongo.ASCENDING), ("end", pymongo.DESCENDING)])
+    period_index = pymongo.IndexModel([("start", pymongo.ASCENDING), ("end", pymongo.DESCENDING)])
     latest_measurement_index = pymongo.IndexModel([("metric_uuid", pymongo.ASCENDING), ("start", pymongo.DESCENDING)])
     latest_successful_measurement_index = pymongo.IndexModel(
         [("metric_uuid", pymongo.ASCENDING), ("has_error", pymongo.ASCENDING), ("start", pymongo.DESCENDING)],
     )
-    database.measurements.create_indexes([start_index, latest_measurement_index, latest_successful_measurement_index])
+    database.measurements.create_indexes([period_index, latest_measurement_index, latest_successful_measurement_index])

--- a/components/api_server/src/initialization/database.py
+++ b/components/api_server/src/initialization/database.py
@@ -42,9 +42,9 @@ def set_feature_compatibility_version(admin_database: Database) -> None:
 def create_indexes(database: Database) -> None:
     """Create any indexes."""
     database.datamodels.create_index("timestamp")
-    database.reports.create_index("timestamp")
+    database.reports.create_index([("timestamp", pymongo.ASCENDING), ("report_uuid", pymongo.ASCENDING)])
     database.users.create_index("username", unique=True)
-    start_index = pymongo.IndexModel([("start", pymongo.ASCENDING)])
+    start_index = pymongo.IndexModel([("start", pymongo.ASCENDING), ("end", pymongo.DESCENDING)])
     latest_measurement_index = pymongo.IndexModel([("metric_uuid", pymongo.ASCENDING), ("start", pymongo.DESCENDING)])
     latest_successful_measurement_index = pymongo.IndexModel(
         [("metric_uuid", pymongo.ASCENDING), ("has_error", pymongo.ASCENDING), ("start", pymongo.DESCENDING)],

--- a/components/api_server/src/routes/report.py
+++ b/components/api_server/src/routes/report.py
@@ -65,9 +65,10 @@ def get_report(database: Database, report_uuid: ReportId | None = None):
     data_model = latest_datamodel(database, date_time)
     reports = latest_reports_before_timestamp(database, data_model, date_time)
     summarized_reports = []
+    metrics_dict = {metric_uuid: metric for report in reports for metric_uuid, metric in report.metrics_dict.items()}
+    measurements = recent_measurements(database, metrics_dict, date_time)
     for report in reports:
         if not report_uuid or report["report_uuid"] == report_uuid:
-            measurements = recent_measurements(database, report.metrics_dict, date_time)
             summarized_reports.append(report.summarize(measurements))
         else:
             summarized_reports.append(report)

--- a/components/api_server/tests/database/test_measurements.py
+++ b/components/api_server/tests/database/test_measurements.py
@@ -1,6 +1,6 @@
 """Test the measurements collection."""
 
-from database.measurements import all_metric_measurements, measurements_by_metric, recent_measurements
+from database.measurements import all_metric_measurements, measurements_in_period, recent_measurements
 
 from shared.model.metric import Metric
 
@@ -27,26 +27,10 @@ class MeasurementsByMetricTest(DatabaseTestCase):
         ]
         self.database.measurements.find_one.return_value = self.measurements[0]
 
-    def test_recent_measurements_for_one_metric(self):
-        """Test that we get all three measurement fields."""
-        self.database.measurements.find.return_value = self.measurements[0:3]
-        measurements = measurements_by_metric(self.database, METRIC_ID)
-        self.assertEqual(len(measurements), 3)
-        for measurement in measurements:
-            self.assertEqual(measurement["metric_uuid"], METRIC_ID)
-
-    def test_get_recent_measurements_for_multiple_metrics(self):
-        """Test that we get all three measurement fields."""
-        self.database.measurements.find.return_value = self.measurements[0:6]
-        measurements = measurements_by_metric(self.database, *[METRIC_ID, METRIC_ID2])
-        self.assertEqual(len(measurements), 6)
-        for measurement in measurements:
-            self.assertIn(measurement["metric_uuid"], [METRIC_ID, METRIC_ID2])
-
-    def test_get_recent_measurements_with_timestamp_restriction(self):
-        """Test that we get all three measurement fields."""
+    def test_measurements_in_period(self):
+        """Test that all three measurements are returned."""
         self.database.measurements.find.return_value = self.measurements[0:2]
-        measurements = measurements_by_metric(self.database, METRIC_ID, min_iso_timestamp="0.5", max_iso_timestamp="4")
+        measurements = measurements_in_period(self.database, min_iso_timestamp="0.5", max_iso_timestamp="4")
         self.assertEqual(len(measurements), 2)
         for measurement in measurements:
             self.assertEqual(measurement["metric_uuid"], METRIC_ID)
@@ -55,14 +39,14 @@ class MeasurementsByMetricTest(DatabaseTestCase):
     def test_get_all_measurements_for_one_metric(self):
         """Test that we get all three measurement fields."""
         self.database.measurements.find.return_value = self.measurements[0:3]
-        measurements = all_metric_measurements(self.database, METRIC_ID)
+        measurements = all_metric_measurements(self.database, METRIC_ID, max_iso_timestamp="8")
         self.assertEqual(len(measurements), 3)
         for measurement in measurements:
             self.assertEqual(measurement["metric_uuid"], METRIC_ID)
 
     def test_recent_measurements(self):
         """Test that we get all measurements with all metric ids."""
-        self.database.measurements.find.return_value = self.measurements[0:6]
+        self.database.measurements.find.return_value = self.measurements
         metric_1 = Metric({}, {}, METRIC_ID)
         metric_2 = Metric({}, {}, METRIC_ID2)
         measurements = recent_measurements(self.database, metrics_dict={METRIC_ID: metric_1, METRIC_ID2: metric_2})

--- a/components/api_server/tests/routes/test_measurement.py
+++ b/components/api_server/tests/routes/test_measurement.py
@@ -33,8 +33,8 @@ class GetMetricMeasurementsTest(DatabaseTestCase):
 
         def find_side_effect(query, projection, sort=None) -> list[dict[str, str]]:  # noqa: ARG001
             """Side effect for mocking the database measurements."""
-            min_iso_timestamp = query["end"]["$gt"] if "end" in query else ""
-            max_iso_timestamp = query["start"]["$lt"] if "start" in query else ""
+            min_iso_timestamp = query["end"]["$gte"] if "end" in query else ""
+            max_iso_timestamp = query["start"]["$lte"] if "start" in query else ""
             return [
                 m
                 for m in database_entries
@@ -76,29 +76,8 @@ class GetMeasurementsTest(DataModelTestCase):
         }
         self.database.measurements.find.return_value = [self.measurement]
 
-    def test_no_reports(self):
-        """Test no reports."""
-        self.database.reports.distinct.return_value = []
-        self.assertEqual({"measurements": []}, get_measurements(self.database))
-
-    def test_with_report(self):
-        """Test a report with measurements."""
-        self.database.reports.distinct.return_value = [REPORT_ID]
-        self.database.reports.find_one.return_value = {
-            "report_uuid": REPORT_ID,
-            "subjects": {SUBJECT_ID: {"metrics": {METRIC_ID: {}}}},
-        }
-        self.assertEqual({"measurements": [self.measurement]}, get_measurements(self.database))
-
-    @patch("bottle.request")
-    def test_with_report_and_time_travel(self, request):
-        """Test a report with measurements."""
-        request.query = {"report_date": "2022-04-19T23:59:59.000Z"}
-        self.database.reports.distinct.return_value = [REPORT_ID]
-        self.database.reports.find_one.return_value = {
-            "report_uuid": REPORT_ID,
-            "subjects": {SUBJECT_ID: {"metrics": {METRIC_ID: {}}}},
-        }
+    def test_get_measurements(self):
+        """Test that measurements are returned."""
         self.assertEqual({"measurements": [self.measurement]}, get_measurements(self.database))
 
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -35,6 +35,7 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 
 - When measuring the number of job runs within a time period using Jenkins as source, filters to include and exclude jobs would be ignored. Fixes [#7172](https://github.com/ICTU/quality-time/issues/7172).
 - Speed up the rendering of the dashboard to prevent exported PDFs from containing a partly rendered dashboard. Fixes [#7208](https://github.com/ICTU/quality-time/issues/7208).
+- Speed up the retrieval of measurements from the database. Fixes [#7371](https://github.com/ICTU/quality-time/issues/7371).
 - Don't crash the UI if the technical debt end date is not a valid date.
 
 ## v5.2.0 - 2023-09-29

--- a/tests/feature_tests/src/features/measurement.feature
+++ b/tests/feature_tests/src/features/measurement.feature
@@ -122,6 +122,11 @@ Feature: measurement
     Then the metric has 2 measurements
     And the metric had 0 measurements
 
+  Scenario: retrieve all measurements
+    Given an existing source
+    When the collector measures "0"
+    Then the report has "1" measurements
+
   Scenario: get the reports overview measurements
     When the client gets the current reports overview measurements
     Then the server returns the reports overview measurements

--- a/tests/feature_tests/src/features/report.feature
+++ b/tests/feature_tests/src/features/report.feature
@@ -184,19 +184,3 @@ Feature: report
   Scenario: get non-existent report
     When the client gets a non-existing report
     Then the report does not exist
-
-  Scenario: get recent measurements of report
-    Given an existing report
-    And an existing subject
-    And an existing metric
-    And an existing source
-    When the collector measures "0"
-    Then the report has "1" measurements
-
-  Scenario: recent report has no old measurements
-    Given an existing report
-    And an existing subject
-    And an existing metric
-    And an existing source
-    When the collector measures "0"
-    Then the report had "0" measurements

--- a/tests/feature_tests/src/steps/measurement.py
+++ b/tests/feature_tests/src/steps/measurement.py
@@ -131,12 +131,14 @@ def check_nr_of_measurements_stream(context: Context, message_type: str) -> None
 @when("the client gets {the_current_or_past} reports overview measurements")
 def get_reports_overview_measurements(context: Context, the_current_or_past: str) -> None:
     """Get the reports overview measurements."""
+    now = datetime.now(tz=UTC)
+    last_week = now - timedelta(days=7)
+    context.min_report_date = last_week.isoformat()
     if the_current_or_past == "past":
-        now = datetime.now(tz=UTC)
         just_now = now - timedelta(seconds=1)
-        last_week = now - timedelta(days=7)
         context.report_date = just_now.isoformat()
-        context.min_report_date = last_week.isoformat()
+    else:
+        context.report_date = now.isoformat()
     context.get("measurements")
 
 

--- a/tests/feature_tests/src/steps/report.py
+++ b/tests/feature_tests/src/steps/report.py
@@ -3,7 +3,7 @@
 import json
 import time
 import urllib
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from asserts import assert_equal, assert_not_in
 from behave import then, when
@@ -137,6 +137,10 @@ def get_measurements(context: Context, has_or_had: str, expected_number: str) ->
     if has_or_had == "had":
         context.report_date = "2020-11-17T10:00:00Z"
         context.min_report_date = "2020-11-16T00:00:00Z"
+    else:
+        now = datetime.now(tz=UTC).replace(microsecond=0)
+        context.report_date = (now + timedelta(days=10)).isoformat()[: -len("+00:00")] + "Z"
+        context.min_report_date = (now - timedelta(days=10)).isoformat()[: -len("+00:00")] + "Z"
 
     response = context.get("measurements")
     report_measurements = [m for m in response["measurements"] if m["report_uuid"] == context.uuid["report"]]

--- a/tests/feature_tests/src/steps/report.py
+++ b/tests/feature_tests/src/steps/report.py
@@ -131,17 +131,12 @@ def import_failed(context: Context) -> None:
     assert_equal("application/json", context.response.headers["Content-Type"])
 
 
-@then('the report {has_or_had} "{expected_number}" measurements')
-def get_measurements(context: Context, has_or_had: str, expected_number: str) -> None:
+@then('the report has "{expected_number}" measurements')
+def get_measurements(context: Context, expected_number: str) -> None:
     """Get the recent measurements of a report."""
-    if has_or_had == "had":
-        context.report_date = "2020-11-17T10:00:00Z"
-        context.min_report_date = "2020-11-16T00:00:00Z"
-    else:
-        now = datetime.now(tz=UTC).replace(microsecond=0)
-        context.report_date = (now + timedelta(days=10)).isoformat()[: -len("+00:00")] + "Z"
-        context.min_report_date = (now - timedelta(days=10)).isoformat()[: -len("+00:00")] + "Z"
-
+    now = datetime.now(tz=UTC).replace(microsecond=0)
+    context.report_date = (now + timedelta(days=10)).isoformat()
+    context.min_report_date = (now - timedelta(days=10)).isoformat()
     response = context.get("measurements")
     report_measurements = [m for m in response["measurements"] if m["report_uuid"] == context.uuid["report"]]
     assert_equal(int(expected_number), len(report_measurements))


### PR DESCRIPTION
- In the /api/v3/report endpoint, get the recent measurements for all metrics in one database call, instead of using one database call per report.
- Create a measurements index on both the start and the end field instead of just on the start field.
- Create an index on the report_uuid field of the reports to speed up the `distinct` query.