### PR TITLE
When hiding tags on the homepage, not only hide the metrics with the …

### DIFF
--- a/components/collector/ci/quality.sh
+++ b/components/collector/ci/quality.sh
@@ -10,7 +10,8 @@ run pipx run `spec mypy` --python-executable=$(which python) src tests
 
 # pip-audit
 unset PYTHONDEVMODE  # Suppress ResourceWarnings given by pip-audit in dev mode
-run pipx run `spec pip-audit` --strict --progress-spinner=off -r requirements/requirements.txt -r requirements/requirements-dev.txt
+# See https://github.com/aio-libs/aiohttp/issues/6772 for why we ignore the CVE
+run pipx run `spec pip-audit` --strict --progress-spinner=off --ignore-vuln PYSEC-2022-43059 -r requirements/requirements.txt -r requirements/requirements-dev.txt
 export PYTHONDEVMODE=1
 
 # Safety

--- a/components/frontend/src/report/Report.js
+++ b/components/frontend/src/report/Report.js
@@ -7,7 +7,6 @@ import {
     reportsPropType,
     settingsPropType,
     stringsPropType,
-    stringsURLSearchQueryPropType
 } from '../sharedPropTypes';
 import { DataModel } from '../context/DataModel';
 import { Subjects } from '../subject/Subjects';
@@ -61,7 +60,7 @@ function ReportDashboard(
     const nrMetrics = Math.max(nrMetricsInReport(report), 1);
     const subjectCards = []
     Object.entries(report.subjects).forEach(([subject_uuid, subject]) => {
-        const metrics = visibleMetrics(subject.metrics, "none", hiddenTags.value)
+        const metrics = visibleMetrics(subject.metrics, "none", hiddenTags)
         if (Object.keys(metrics).length > 0) {
             const summary = {}
             dates.forEach((date) => {
@@ -78,8 +77,8 @@ function ReportDashboard(
             )
         }
     })
-    const anyTagsHidden = hiddenTags.value.length > 0
-    const tagCards = getReportTags(report, hiddenTags.value).map((tag) => {
+    const anyTagsHidden = hiddenTags.length > 0
+    const tagCards = getReportTags(report, hiddenTags).map((tag) => {
         const summary = {}
         dates.forEach((date) => {
             summary[date] = summarizeTagOnDate(report, measurements, tag, date)
@@ -104,7 +103,7 @@ function ReportDashboard(
 }
 ReportDashboard.propTypes = {
     dates: datesPropType,
-    hiddenTags: stringsURLSearchQueryPropType,
+    hiddenTags: stringsPropType,
     measurements: PropTypes.array,
     onClick: PropTypes.func,
     onClickTag: PropTypes.func,
@@ -148,7 +147,7 @@ export function Report({
             <CommentSegment comment={report.comment} />
             <ReportDashboard
                 dates={dates}
-                hiddenTags={settings.hiddenTags}
+                hiddenTags={settings.hiddenTags.value}
                 measurements={reversedMeasurements}
                 onClick={(e, s) => navigate_to_subject(e, s)}
                 onClickTag={(tag) => {

--- a/components/notifier/ci/quality.sh
+++ b/components/notifier/ci/quality.sh
@@ -10,7 +10,8 @@ run pipx run `spec mypy` --python-executable=$(which python) src
 
 # pip-audit
 unset PYTHONDEVMODE  # Suppress ResourceWarnings given by pip-audit in dev mode
-run pipx run `spec pip-audit` --strict --progress-spinner=off -r requirements/requirements.txt -r requirements/requirements-dev.txt
+# See https://github.com/aio-libs/aiohttp/issues/6772 for why we ignore the CVE
+run pipx run `spec pip-audit` --strict --progress-spinner=off --ignore-vuln PYSEC-2022-43059 -r requirements/requirements.txt -r requirements/requirements-dev.txt
 export PYTHONDEVMODE=1
 
 # Safety

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 ### Fixed
 
 - The example URL in the popup for the Azure DevOps Server URL parameter would overflow the popup. Fixes [#7144](https://github.com/ICTU/quality-time/issues/7144).
+- When hiding tags on the homepage, not only hide the metrics with the selected tags from the subject tables, but also from the subject cards in the dashboard. Fixes [#7433](https://github.com/ICTU/quality-time/issues/7433).
 
 ## v5.3.0 - 2023-11-07
 


### PR DESCRIPTION
…selected tags from the subject tables, but also from the subject cards in the dashboard. Fixes #7433.