### PR TITLE
When expanding a metric, use the latest measurement instead of the ol…

### DIFF
--- a/components/api_server/src/database/measurements.py
+++ b/components/api_server/src/database/measurements.py
@@ -49,7 +49,7 @@ def all_metric_measurements(database: Database, metric_uuid: MetricId, max_iso_t
     measurement_filter: dict[str, str | dict[str, str]] = {"metric_uuid": str(metric_uuid)}
     if max_iso_timestamp:
         measurement_filter["start"] = {"$lte": max_iso_timestamp}
-    latest_measurement = database.measurements.find_one(measurement_filter, sort=START_ASCENDING, projection=NO_ID)
+    latest_measurement = database.measurements.find_one(measurement_filter, sort=START_DESCENDING, projection=NO_ID)
     if not latest_measurement:
         return []
     all_measurements_stripped = list(

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,7 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 
 - The example URL in the popup for the Azure DevOps Server URL parameter would overflow the popup. Fixes [#7144](https://github.com/ICTU/quality-time/issues/7144).
 - When hiding tags on the homepage, not only hide the metrics with the selected tags from the subject tables, but also from the subject cards in the dashboard. Fixes [#7433](https://github.com/ICTU/quality-time/issues/7433).
+- When expanding a metric, use the latest measurement instead of the oldest to show the measurement entities. Fixes [#7435](https://github.com/ICTU/quality-time/issues/7435).
 
 ## v5.3.0 - 2023-11-07
 


### PR DESCRIPTION
…dest to show the measurement entities. Fixes #7435.