### PR TITLE
Notification improvements: use 'unknown' instead of '? units' and not…

### DIFF
--- a/components/notifier/src/destinations/ms_teams.py
+++ b/components/notifier/src/destinations/ms_teams.py
@@ -20,10 +20,10 @@ def metric_section(metric: MetricNotificationData, report_url: str) -> pymsteams
     section.addFact("Status:", f"{metric.new_metric_status}{old_status_text}")
     unit = metric.metric_unit
     unit_text = unit if (not unit or unit.startswith("%")) else f" {unit}"
-    new_value = "?" if metric.new_metric_value is None else metric.new_metric_value
-    old_value = "?" if metric.old_metric_value is None else metric.old_metric_value
-    old_value_text = " (unchanged)" if new_value == old_value else f", was {old_value}{unit_text}"
-    section.addFact("Value:", f"{new_value}{unit_text}{old_value_text}")
+    new_value = "unknown" if metric.new_metric_value is None else f"{metric.new_metric_value}{unit_text}"
+    old_value = "unknown" if metric.old_metric_value is None else f"{metric.old_metric_value}{unit_text}"
+    old_value_text = " (unchanged)" if metric.new_metric_value == metric.old_metric_value else f", was {old_value}"
+    section.addFact("Value:", f"{new_value}{old_value_text}")
     section.linkButton("View metric", f"{report_url}#{metric.metric_uuid}")
     return section
 

--- a/components/notifier/tests/destinations/test_teams.py
+++ b/components/notifier/tests/destinations/test_teams.py
@@ -133,7 +133,7 @@ class BuildNotificationMessageTests(MsTeamsTestCase):
                 "Metric",
                 "unknown",
                 "unknown (white), was near target met (yellow)",
-                "? units, was 0 units",
+                "unknown, was 0 units",
                 "metric_uuid",
             )
         )

--- a/components/shared_code/src/shared/model/measurement.py
+++ b/components/shared_code/src/shared/model/measurement.py
@@ -96,11 +96,9 @@ class ScaleMeasurement(dict):
 
     def __calculate_status_without_measurement(self) -> Status | None:
         """Determine the status of the measurement if there is no measurement value."""
-        # Allow for accepted debt if there is no measurement yet so that the fact that a metric does not have a
-        # source can be accepted as technical debt
-        if not self._metric.sources and self._metric.accept_debt() and not self._metric.debt_end_date_passed():
-            return "debt_target_met"
-        return None
+        # Allow for accepted debt if there is no measurement so that the fact that a metric does not have a
+        # source, or has a source that's unavailable, can be accepted as technical debt
+        return "debt_target_met" if self._metric.accept_debt() and not self._metric.debt_end_date_passed() else None
 
     @abstractmethod
     def _better_or_equal(self, value1: str | None, value2: str | None) -> bool:

--- a/components/shared_code/tests/shared/model/test_measurement.py
+++ b/components/shared_code/tests/shared/model/test_measurement.py
@@ -320,6 +320,22 @@ class MeasurementTest(MeasurementTestCase):
         )
         self.assertEqual("informative", measurement.status())
 
+    def test_status_debt_target_with_failing_source(self):
+        """Test the measurement status is debt target met if the metric has failing sources and tech debt accepted."""
+        measurement = self.measurement(
+            self.metric(accept_debt=True, debt_target="100"),
+            sources=[
+                {
+                    "source_uuid": SOURCE_ID,
+                    "value": None,
+                    "total": None,
+                    "parse_error": "Failed!",
+                    "connection_error": None,
+                },
+            ],
+        )
+        self.assertEqual("debt_target_met", measurement.status())
+
     def test_debt_target_expired(self):
         """Test that the debt target is considered to be expired when all issues have been done."""
         measurement = self.measurement(


### PR DESCRIPTION
…ify when a metric without valid measurement values changes status.