### PR TITLE
When measuring source up-to-dateness with GitLab as pipelines, if the…

### DIFF
--- a/components/collector/src/base_collectors/source_collector.py
+++ b/components/collector/src/base_collectors/source_collector.py
@@ -150,6 +150,9 @@ class SourceCollector(ABC):
             return SourceMeasurement(connection_error=responses.connection_error)
         try:
             return await self._parse_source_responses(responses)
+        except CollectorError as reason:
+            error = self.__logsafe_exception(reason)
+            return SourceMeasurement(parse_error=error)
         except Exception:
             return SourceMeasurement(parse_error=stable_traceback(traceback.format_exc()))
 

--- a/components/collector/tests/source_collectors/gitlab/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/gitlab/test_source_up_to_dateness.py
@@ -75,6 +75,13 @@ class GitLabSourceUpToDatenessTest(GitLabTestCase):
             response = await self.collect(get_request_json_return_value=pipeline_json)
         self.assert_measurement(response, value=str(expected_age), landing_url="https://gitlab/project/-/pipelines/1")
 
+    async def test_source_up_to_dateness_pipeline_missing(self):
+        """Test that the age of a pipeline results in an error message if no pipeline can be found."""
+        self.set_source_parameter("file_path", "")
+        with self.patched_client_session_head():
+            response = await self.collect(get_request_json_return_value=[])
+        self.assert_measurement(response, value=None, parse_error="No pipelines found within the lookback period")
+
     async def test_file_landing_url_on_failure(self):
         """Test that the landing url is the API url when GitLab cannot be reached."""
         response = await self.collect(get_request_json_side_effect=[ConnectionError])

--- a/components/collector/tests/source_collectors/owasp_dependency_check/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/owasp_dependency_check/test_security_warnings.py
@@ -116,8 +116,8 @@ class OWASPDependencyCheckSecurityWarningsTest(OWASPDependencyCheckTestCase):
         response = await self.collect(get_request_text=xml)
         self.assert_measurement(
             response,
-            parse_error=f"""XMLRootElementError: The XML root element should be one of \
+            parse_error=f"""The XML root element should be one of \
 "{OWASPDependencyCheckBase.allowed_root_tags}" but is \
-"{{https://jeremylong.github.io/DependencyCheck/dependency-check.1.8.xsd}}analysis"
+"{{https://jeremylong.github.io/DependencyCheck/dependency-check.1.8.xsd}}analysis"\
 """,
         )

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 ### Fixed
 
 - When showing many toaster messages, collapse similar messages to prevent a long list of messages. Fixes [#7625](https://github.com/ICTU/quality-time/issues/7625).
+- When measuring source up-to-dateness with GitLab as pipelines, if there are no pipelines in the lookback period, don't show the number of days since 1-1-1970 as value, but show an error. Fixes [#7947](https://github.com/ICTU/quality-time/issues/7947).
 - When manually exporting a report to PDF, the report header would not be collapsed before generating the PDF. Prevent the need for collapsing the header by moving the PDF button to the menu bar. Fixes [#8054](https://github.com/ICTU/quality-time/issues/8054).
 
 ## v5.7.0 - 2024-01-31


### PR DESCRIPTION
…re are no pipelines in the lookback period, don't show the number of days since 1-1-1970 as value, but show an error. Fixes #7947.