### PR TITLE
Use default for CircleCI machine images per https://discuss.circleci.…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
 
   unittest_docs:
     machine:
-      image: ubuntu-2204:2023.07.2
+      image: default
     steps:
       - checkout
       - run: |
@@ -66,7 +66,7 @@ jobs:
 
   application_tests:
     machine:
-      image: ubuntu-2204:2023.07.2
+      image: default
     parallelism: 1
     steps:
       - checkout
@@ -90,7 +90,7 @@ jobs:
 
   feature_tests:
     machine:
-      image: ubuntu-2204:2023.07.2
+      image: default
     parallelism: 1
     steps:
       - checkout


### PR DESCRIPTION
…com/t/linux-image-deprecations-and-eol-for-2024/50177.