### PR TITLE
Don't log tracebacks when saving the healthcheck fails.

### DIFF
--- a/components/collector/src/base_collectors/collector.py
+++ b/components/collector/src/base_collectors/collector.py
@@ -38,8 +38,8 @@ class Collector:
         try:
             with filename.open("w", encoding="utf-8") as health_check:
                 health_check.write(datetime.now(tz=UTC).isoformat())
-        except OSError:
-            logging.exception("Could not write health check time stamp to %s", filename)
+        except OSError as reason:
+            logging.error("Could not write health check time stamp to %s: %s", filename, reason)  # noqa: TRY400
 
     async def start(self) -> NoReturn:
         """Start fetching measurements indefinitely."""

--- a/components/collector/tests/base_collectors/test_collector.py
+++ b/components/collector/tests/base_collectors/test_collector.py
@@ -308,7 +308,7 @@ class CollectorTest(unittest.IsolatedAsyncioTestCase):
         mocked_open.side_effect = OSError("Some error")
         self.collector.record_health()
         mocked_log.assert_called_once_with(
-            "Could not write health check time stamp to %s",
+            "Could not write health check time stamp to %s: %s",
             pathlib.Path("/home/collector/health_check.txt"),
-            exc_info=True,
+            mocked_open.side_effect,
         )


### PR DESCRIPTION
It pollutes the log and the logged OS error should provide enough information to solve any problems.