### PR TITLE
Measurement detail table, small improvements.

### DIFF
--- a/components/frontend/src/source/SourceEntity.js
+++ b/components/frontend/src/source/SourceEntity.js
@@ -45,11 +45,12 @@ export function SourceEntity({
         return null
     }
     const style = ignoredEntity ? { textDecoration: "line-through" } : {}
+    style["maxWidth"] = "60em"
     let statusClassName = "unknown_status"
     for (let entity_attribute of entity_attributes) {
-        let cell_contents = entity[entity_attribute.key]
-        if (entity_attribute.color?.[cell_contents]) {
-            statusClassName = entity_attribute.color[cell_contents] + "_status"
+        let cellContents = entity[entity_attribute.key]
+        if (entity_attribute.color?.[cellContents]) {
+            statusClassName = entity_attribute.color[cellContents] + "_status"
             break
         }
     }

--- a/components/frontend/src/source/SourceEntityAttribute.js
+++ b/components/frontend/src/source/SourceEntityAttribute.js
@@ -3,26 +3,29 @@ import { HyperLink } from "../widgets/HyperLink"
 import { TimeAgoWithDate } from "../widgets/TimeAgoWithDate"
 
 export function SourceEntityAttribute({ entity, entity_attribute }) {
-    let cell_contents = entity[entity_attribute.key] ?? ""
+    let cellContents = entity[entity_attribute.key] ?? ""
+    if (typeof cellContents === "string" && cellContents.length >= 250) {
+        cellContents = cellContents.slice(0, 247) + "..."
+    }
     const type = entity_attribute.type ?? ""
-    cell_contents =
-        cell_contents && type === "datetime" ? <TimeAgoWithDate dateFirst date={cell_contents} /> : cell_contents
-    cell_contents =
-        cell_contents && type === "date" ? <TimeAgoWithDate dateFirst noTime date={cell_contents} /> : cell_contents
-    cell_contents = cell_contents && type.includes("integer") ? Math.round(cell_contents).toString() : cell_contents
-    cell_contents = cell_contents && type.includes("percentage") ? cell_contents + "%" : cell_contents
-    cell_contents = cell_contents && type === "status" ? <StatusIcon status={cell_contents} /> : cell_contents
-    cell_contents = entity[entity_attribute.url] ? (
-        <HyperLink url={entity[entity_attribute.url]}>{cell_contents}</HyperLink>
+    cellContents =
+        cellContents && type === "datetime" ? <TimeAgoWithDate dateFirst date={cellContents} /> : cellContents
+    cellContents =
+        cellContents && type === "date" ? <TimeAgoWithDate dateFirst noTime date={cellContents} /> : cellContents
+    cellContents = cellContents && type.includes("integer") ? Math.round(cellContents).toString() : cellContents
+    cellContents = cellContents && type.includes("percentage") ? cellContents + "%" : cellContents
+    cellContents = cellContents && type === "status" ? <StatusIcon status={cellContents} /> : cellContents
+    cellContents = entity[entity_attribute.url] ? (
+        <HyperLink url={entity[entity_attribute.url]}>{cellContents}</HyperLink>
     ) : (
-        cell_contents
+        cellContents
     )
-    cell_contents = entity_attribute.pre ? (
+    cellContents = entity_attribute.pre ? (
         <pre data-testid="pre-wrapped" style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
-            {cell_contents}
+            {cellContents}
         </pre>
     ) : (
-        <div style={{ wordBreak: "break-word" }}>{cell_contents}</div>
+        <div style={{ wordBreak: "break-word" }}>{cellContents}</div>
     )
-    return cell_contents
+    return cellContents
 }

--- a/components/frontend/src/source/SourceEntityAttribute.test.js
+++ b/components/frontend/src/source/SourceEntityAttribute.test.js
@@ -6,6 +6,18 @@ function renderSourceEntityAttribute(entity, entity_attribute) {
     return render(<SourceEntityAttribute entity={entity} entity_attribute={entity_attribute} />)
 }
 
+it("renders a short string", () => {
+    renderSourceEntityAttribute({ text: "short text" }, { key: "text" })
+    expect(screen.queryAllByText(/short text/).length).toBe(1)
+})
+
+it("renders a long string", () => {
+    const longText = "long text ".repeat(100)
+    renderSourceEntityAttribute({ text: longText }, { key: "text" })
+    const expectedText = longText.slice(0, 247) + "..."
+    expect(screen.queryAllByText(expectedText).length).toBe(1)
+})
+
 it("renders an empty string", () => {
     renderSourceEntityAttribute({ other: "will not be shown" }, { key: "missing" })
     expect(screen.queryAllByText(/will not be shown/).length).toBe(0)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 ### Changed
 
 - In PDF-exports, don't include the footer but put the report metadata (report date, date the PDF was generated, and Quality-time version) in a card at the top. Closes [#3156](https://github.com/ICTU/quality-time/issues/3156).
+- In measurement detail tables, prevent columns from getting too wide and cut off values that are longer than 250 characters.
 
 ## v5.9.0 - 2024-03-22
 


### PR DESCRIPTION
In measurement detail tables, prevent columns from getting too wide and cut off values that are longer than 250 characters.