### PR TITLE
Refactor TimeCollector.

### DIFF
--- a/components/collector/src/base_collectors/file_source_collector.py
+++ b/components/collector/src/base_collectors/file_source_collector.py
@@ -115,7 +115,7 @@ class JSONFileSourceCollector(FileSourceCollector, ABC):
 
     def _parse_json(self, json: JSON, filename: str) -> Entities:
         """Parse the entities from the JSON."""
-        raise NotImplementedError  # pragma: no cover
+        return Entities()  # Override in subclasses that return entities
 
 
 class XMLFileSourceCollector(FileSourceCollector, ABC):

--- a/components/collector/src/base_collectors/source_collector.py
+++ b/components/collector/src/base_collectors/source_collector.py
@@ -271,10 +271,10 @@ class SecurityWarningsSourceCollector(SourceCollector):
 class TimeCollector(SourceCollector):
     """Base class for time collectors."""
 
-    async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
-        """Override to get the datetime from the parse data time method that subclasses should implement."""
+    async def _parse_value(self, responses: SourceResponses) -> Value:
+        """Parse the value from the responses."""
         date_times = await self._parse_source_response_date_times(responses)
-        return SourceMeasurement(value=str(self.days(self.mininum(date_times))))
+        return str(self.days(self.mininum(date_times)))
 
     async def _parse_source_response_date_times(self, responses: SourceResponses) -> Sequence[datetime]:
         """Parse the source update datetimes from the responses and return the datetimes."""


### PR DESCRIPTION
TimeCollector would override _parse_source_responses, making it impossible for subclasses of TimeCollector to return entities. Override _parse_value instead of _parse_source_responses so that subclasses can implement _parse_entities.