### PR TITLE
Fix "Missing metrics" and "Metrics" metrics.

### DIFF
--- a/components/collector/src/source_collectors/quality_time/base.py
+++ b/components/collector/src/source_collectors/quality_time/base.py
@@ -5,18 +5,11 @@ from typing import Any
 
 from base_collectors import SourceCollector
 from collector_utilities.exceptions import CollectorError
-from collector_utilities.type import URL, Response
+from collector_utilities.type import Response
 
 
 class QualityTimeCollector(SourceCollector, ABC):
     """Base collector for Quality-time metrics."""
-
-    EXTERNAL_API_VERSION = "v3"
-
-    async def _api_url(self) -> URL:
-        """Get the api url for this api version."""
-        api_url = await super()._api_url()
-        return URL(f"{api_url}/api/{self.EXTERNAL_API_VERSION}")
 
     async def _get_reports(self, response: Response) -> list[dict[str, Any]]:
         """Get the relevant reports from the reports response."""

--- a/components/collector/src/source_collectors/quality_time/metrics.py
+++ b/components/collector/src/source_collectors/quality_time/metrics.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime
 from typing import cast
-from urllib import parse
 
 from shared.utils.date_time import now
 from shared_data_model import DATA_MODEL
@@ -21,9 +20,7 @@ class QualityTimeMetrics(QualityTimeCollector):
 
     async def _api_url(self) -> URL:
         """Extend to add the reports API path."""
-        parts = parse.urlsplit(await super()._api_url())
-        netloc = f"{parts.netloc.split(':')[0]}"
-        return URL(parse.urlunsplit((parts.scheme, netloc, f"{parts.path}/report", "", "")))
+        return URL(await super()._api_url() + "/api/internal/report")
 
     async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
         """Get the metric entities from the responses."""

--- a/components/collector/src/source_collectors/quality_time/missing_metrics.py
+++ b/components/collector/src/source_collectors/quality_time/missing_metrics.py
@@ -13,6 +13,10 @@ from .base import QualityTimeCollector
 class QualityTimeMissingMetrics(QualityTimeCollector):
     """Collector to get the number of missing metrics from Quality-time."""
 
+    async def _api_url(self) -> URL:
+        """Extend to add the reports API path."""
+        return URL(await super()._api_url() + "/api/internal")
+
     async def _get_source_responses(self, *urls: URL) -> SourceResponses:
         """Get responses for reports and the datamodel."""
         api_url = urls[0]

--- a/components/collector/src/source_collectors/quality_time/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/quality_time/source_up_to_dateness.py
@@ -1,7 +1,6 @@
 """Quality-time source up-to-dateness collector."""
 
 from datetime import datetime
-from urllib import parse
 
 from base_collectors import TimePassedCollector
 from collector_utilities.date_time import MIN_DATETIME, parse_datetime
@@ -15,9 +14,7 @@ class QualityTimeSourceUpToDateness(QualityTimeCollector, TimePassedCollector):
 
     async def _api_url(self) -> URL:
         """Extend to add the reports API path."""
-        parts = parse.urlsplit(await super()._api_url())
-        netloc = f"{parts.netloc.split(':')[0]}"
-        return URL(parse.urlunsplit((parts.scheme, netloc, f"{parts.path}/reports", "", "")))
+        return URL(await super()._api_url() + "/api/internal/report")
 
     async def _parse_source_response_date_time(self, response: Response) -> datetime:
         """Override to parse the oldest datetime from the recent measurements."""

--- a/components/collector/tests/source_collectors/quality_time/test_metrics.py
+++ b/components/collector/tests/source_collectors/quality_time/test_metrics.py
@@ -13,7 +13,7 @@ class QualityTimeMetricsTest(QualityTimeTestCase):
     def setUp(self):
         """Set up test data."""
         super().setUp()
-        self.api_url = f"{self.url}/api/v3/report"
+        self.api_url = f"{self.url}/api/internal/report"
         self.entities = [
             {
                 "key": "m2",

--- a/components/collector/tests/source_collectors/quality_time/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/quality_time/test_source_up_to_dateness.py
@@ -18,7 +18,7 @@ class QualityTimeSourceUpToDatenessTest(QualityTimeTestCase):
     def setUp(self):
         """Set up test data."""
         super().setUp()
-        self.api_url = f"{self.url}/api/v3/reports"
+        self.api_url = f"{self.url}/api/internal/report"
 
     async def test_source_up_to_dateness(self):
         """Test that the source up-to-dateness of all reports can be measured."""

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 
 ### Fixed
 
+- The "Missing metrics" and "Metrics" metrics were broken due to the change to the API in [#5791](https://github.com/ICTU/quality-time/issues/5791). Fixes [#8357](https://github.com/ICTU/quality-time/issues/8357).
 - The delete button for reports was not positioned correctly. Fixes [#8338](https://github.com/ICTU/quality-time/issues/8338).
 
 ### Changed


### PR DESCRIPTION
The "Missing metrics" and "Metrics" metrics were broken due to the change to the API in #5791.

Fixes #8357.