### PR TITLE
Fix time ago labels.

### DIFF
--- a/components/frontend/src/fields/DateInput.js
+++ b/components/frontend/src/fields/DateInput.js
@@ -12,17 +12,12 @@ import { ReadOnlyInput } from "./ReadOnlyInput"
 function EditableDateInput({ ariaLabelledBy, label, placeholder, required, set_value, value }) {
     value = value ? new Date(value) : null
     return (
-        <Form.Input
-            aria-labelledby={ariaLabelledBy}
-            error={required && !value}
-            label={label}
-            labelPosition="left"
-            required={required}
-        >
+        <Form.Input error={required && !value} label={label} labelPosition="left" required={required}>
             <Label>
                 <Icon fitted name="calendar" />
             </Label>
             <DatePicker
+                ariaLabelledBy={ariaLabelledBy}
                 selected={value}
                 isClearable={!required}
                 onChange={(newDate) => {

--- a/components/frontend/src/metric/MetricDebtParameters.js
+++ b/components/frontend/src/metric/MetricDebtParameters.js
@@ -74,7 +74,7 @@ function TechnicalDebtEndDate({ metric, metric_uuid, reload }) {
             requiredPermissions={[EDIT_REPORT_PERMISSION]}
             label={
                 <LabelWithDate
-                    date={Date(metric.debt_end_date)}
+                    date={metric.debt_end_date}
                     labelId={labelId}
                     help={help}
                     label="Technical debt end date"

--- a/components/frontend/src/metric/MetricDebtParameters.test.js
+++ b/components/frontend/src/metric/MetricDebtParameters.test.js
@@ -32,18 +32,19 @@ const data_model = {
     },
 }
 
-function renderMetricDebtParameters({ accept_debt = false } = {}) {
+function renderMetricDebtParameters({ accept_debt = false, debt_end_date = null } = {}) {
     render(
         <Permissions.Provider value={[EDIT_REPORT_PERMISSION]}>
             <DataModel.Provider value={data_model}>
                 <MetricDebtParameters
                     metric={{
-                        type: "violations",
-                        tags: [],
                         accept_debt: accept_debt,
-                        scale: "count",
+                        debt_end_date: debt_end_date,
                         issue_ids: [],
                         issue_status: [],
+                        scale: "count",
+                        tags: [],
+                        type: "violations",
                     }}
                     metric_uuid="metric_uuid"
                     reload={jest.fn()}
@@ -108,4 +109,9 @@ it("sets the technical debt end date", async () => {
         { debt_end_date: "2022-12-31" },
     )
     console.log = consoleLog
+})
+
+it("shows days ago for the technical debt end date", () => {
+    renderMetricDebtParameters({ debt_end_date: "2000-01-01" })
+    expect(screen.getAllByLabelText(/years ago/).length).toBe(1)
 })

--- a/components/frontend/src/widgets/LabelWithDate.js
+++ b/components/frontend/src/widgets/LabelWithDate.js
@@ -7,7 +7,7 @@ import { LabelWithHelp } from "./LabelWithHelp"
 export function LabelWithDate({ date, labelId, label, help }) {
     return (
         <LabelWithHelp
-            id={labelId}
+            labelId={labelId}
             label={
                 <>
                     {label}

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,7 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 
 - The "Missing metrics" and "Metrics" metrics were broken due to the change to the API in [#5791](https://github.com/ICTU/quality-time/issues/5791). Fixes [#8357](https://github.com/ICTU/quality-time/issues/8357).
 - The delete button for reports was not positioned correctly. Fixes [#8338](https://github.com/ICTU/quality-time/issues/8338).
+- The time ago or to go, shown in the labels of date fields, would be incorrect. Fixes [#8440](https://github.com/ICTU/quality-time/issues/8440).
 
 ### Changed
 


### PR DESCRIPTION
The time ago or to go, shown in the labels of date fields, would be incorrect.

Fixes #8440.