### PR TITLE
Move filtering failed CI-jobs to GitLab.

### DIFF
--- a/components/collector/src/source_collectors/gitlab/failed_jobs.py
+++ b/components/collector/src/source_collectors/gitlab/failed_jobs.py
@@ -1,5 +1,6 @@
 """GitLab failed jobs collector."""
 
+from collector_utilities.type import URL
 from model import Entity
 
 from .base import GitLabJobsBase
@@ -7,6 +8,12 @@ from .base import GitLabJobsBase
 
 class GitLabFailedJobs(GitLabJobsBase):
     """Collector class to get failed job counts from GitLab."""
+
+    async def _api_url(self) -> URL:
+        """Extend to add the scope parameter of the jobs API."""
+        failure_types = list(self._parameter("failure_type"))
+        scopes = "&".join([f"scope[]={failure_type}" for failure_type in failure_types])
+        return URL(f"{await super()._api_url()}&{scopes}")
 
     def _include_entity(self, entity: Entity) -> bool:
         """Return whether the job has failed."""

--- a/components/collector/tests/metric_collectors/test_change_failure_rate.py
+++ b/components/collector/tests/metric_collectors/test_change_failure_rate.py
@@ -61,7 +61,10 @@ class ChangeFailureRateTest(unittest.IsolatedAsyncioTestCase):
         self.jenkins_url = "https://jenkins"
         self.jira_url = "https://jira"
         self.tickets_json = {"total": 1, "issues": [self.jira_issue()]}
-        self.gitlab_source_config = {"type": "gitlab", "parameters": {"url": self.gitlab_url, "project": "project"}}
+        self.gitlab_source_config = {
+            "type": "gitlab",
+            "parameters": {"url": self.gitlab_url, "project": "project", "lookback_days": "100000"},
+        }
         self.jenkins_source_config = {"type": "jenkins", "parameters": {"url": self.jenkins_url}}
         self.jira_source_config = {"type": "jira", "parameters": {"url": self.jira_url, "jql": "jql"}}
 

--- a/components/collector/tests/source_collectors/gitlab/base.py
+++ b/components/collector/tests/source_collectors/gitlab/base.py
@@ -7,13 +7,15 @@ class GitLabTestCase(SourceCollectorTestCase):
     """Base class for testing GitLab collectors."""
 
     SOURCE_TYPE = "gitlab"
+    LOOKBACK_DAYS = "100000"
 
     def setUp(self):
         """Extend to add generic test fixtures."""
         super().setUp()
-        self.set_source_parameter("project", "namespace/project")
-        self.set_source_parameter("file_path", "file")
         self.set_source_parameter("branch", "branch")
+        self.set_source_parameter("file_path", "file")
+        self.set_source_parameter("lookback_days", self.LOOKBACK_DAYS)
+        self.set_source_parameter("project", "namespace/project")
         self.gitlab_jobs_json = [
             {
                 "id": "1",

--- a/components/collector/tests/source_collectors/gitlab/test_failed_jobs.py
+++ b/components/collector/tests/source_collectors/gitlab/test_failed_jobs.py
@@ -20,6 +20,12 @@ class GitLabFailedJobsTest(CommonGitLabJobsTestsMixin, GitLabTestCase):
         response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
         self.assert_measurement(response, value="0", entities=[])
 
+    async def test_no_jobs_in_lookback_period(self):
+        """Test that the number of failed jobs is returned."""
+        self.set_source_parameter("lookback_days", "3")
+        response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
+        self.assert_measurement(response, value="0", entities=[])
+
     async def test_ignore_previous_runs_of_jobs(self):
         """Test that previous runs of the same job are ignored."""
         self.gitlab_jobs_json.extend(
@@ -54,5 +60,8 @@ class GitLabFailedJobsTest(CommonGitLabJobsTestsMixin, GitLabTestCase):
         self.assert_measurement(
             response,
             value="2",
-            api_url="https://gitlab/api/v4/projects/namespace%2Fproject/jobs?per_page=100",
+            api_url=(
+                "https://gitlab/api/v4/projects/namespace%2Fproject/jobs?per_page=100&"
+                "scope[]=canceled&scope[]=failed&scope[]=skipped"
+            ),
         )

--- a/components/collector/tests/source_collectors/gitlab/test_job_runs_within_time_period.py
+++ b/components/collector/tests/source_collectors/gitlab/test_job_runs_within_time_period.py
@@ -8,6 +8,7 @@ from .base import GitLabTestCase
 class GitLabJobRunsWithinTimePeriodTest(GitLabTestCase):
     """Unit tests for the GitLab job runs within time period collector."""
 
+    LOOKBACK_DAYS = "3"
     METRIC_TYPE = "job_runs_within_time_period"
 
     _job3_url = "https://gitlab/job3"  # extending gitlab_jobs_json which already includes job 1 and job 2
@@ -15,8 +16,6 @@ class GitLabJobRunsWithinTimePeriodTest(GitLabTestCase):
 
     async def test_job_lookback_days(self):
         """Test that the job lookback_days are verified."""
-        self.set_source_parameter("lookback_days", "3")
-
         now_dt = datetime.now(tz=UTC)
         now_timestamp = now_dt.isoformat()
         last_week_timestamp = (now_dt - timedelta(weeks=1)).isoformat()
@@ -78,10 +77,10 @@ class GitLabJobRunsWithinTimePeriodTest(GitLabTestCase):
                 {
                     "id": "4",
                     "status": "failed",
-                    "name": "job4",
+                    "name": "job3",
                     "stage": "stage",
                     "created_at": yesterday_timestamp,
-                    "web_url": self._job4_url,
+                    "web_url": self._job3_url,
                     "ref": "main",
                 },
             ],
@@ -100,8 +99,8 @@ class GitLabJobRunsWithinTimePeriodTest(GitLabTestCase):
             },
             {
                 "key": "4",
-                "name": "job4",
-                "url": self._job4_url,
+                "name": "job3",
+                "url": self._job3_url,
                 "build_status": "failed",
                 "branch": "main",
                 "stage": "stage",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,9 +16,10 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 
 ### Fixed
 
-- The "Missing metrics" and "Metrics" metrics were broken due to the change to the API in [#5791](https://github.com/ICTU/quality-time/issues/5791). Fixes [#8357](https://github.com/ICTU/quality-time/issues/8357).
 - The delete button for reports was not positioned correctly. Fixes [#8338](https://github.com/ICTU/quality-time/issues/8338).
+- The "Missing metrics" and "Metrics" metrics were broken due to the change to the API in [#5791](https://github.com/ICTU/quality-time/issues/5791). Fixes [#8357](https://github.com/ICTU/quality-time/issues/8357).
 - The time ago or to go, shown in the labels of date fields, would be incorrect. Fixes [#8440](https://github.com/ICTU/quality-time/issues/8440).
+- When measuring failed CI-jobs with GitLab as source, don't download all jobs and then filter them by failure status (canceled, failed, and/or skipped), but rather pass the failure states to the GitLab API endpoint so the filtering is done by GitLab. Fixes [#8444](https://github.com/ICTU/quality-time/issues/8444).
 
 ### Changed
 


### PR DESCRIPTION
When measuring failed CI-jobs with GitLab as source, don't download all jobs and then filter them by failure status (canceled, failed, and/or skipped), but rather pass the failure states to the GitLab API endpoint so the filtering is done by GitLab.

Fixes #8444.