### PR TITLE
Fix measurement entity sorting.

### DIFF
--- a/components/frontend/src/source/SourceEntities.test.js
+++ b/components/frontend/src/source/SourceEntities.test.js
@@ -79,6 +79,10 @@ const source = {
             minutes: "3",
         },
     ],
+    entity_user_data: {
+        1: { status: "confirmed", status_end_date: "2020-01-01", rationale: "R1" },
+        2: { status: "fixed", status_end_date: "2020-01-02", rationale: "R2" },
+    },
 }
 
 function assertOrder(expected) {
@@ -109,18 +113,18 @@ it("sorts the entities by status end date", async () => {
     renderSourceEntities()
     assertOrder(["C", "B", "A"])
     await userEvent.click(screen.getByText(/Status end date/))
-    assertOrder(["C", "B", "A"])
+    assertOrder(["A", "C", "B"])
     await userEvent.click(screen.getByText(/Status end date/))
-    assertOrder(["A", "B", "C"])
+    assertOrder(["B", "C", "A"])
 })
 
 it("sorts the entities by status rationale", async () => {
     renderSourceEntities()
     assertOrder(["C", "B", "A"])
     await userEvent.click(screen.getByText(/Status rationale/))
-    assertOrder(["C", "B", "A"])
+    assertOrder(["A", "C", "B"])
     await userEvent.click(screen.getByText(/Status rationale/))
-    assertOrder(["A", "B", "C"])
+    assertOrder(["B", "C", "A"])
 })
 
 it("sorts the entities by first seen date", async () => {

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Deployment notes
+
+If your currently installed *Quality-time* version is v4.10.0 or older, please read the v5.0.0 deployment notes first.
+
+### Fixed
+
+- Sorting measurement entities by status, status end date, and status rationale did not work. Fixes [#8508](https://github.com/ICTU/quality-time/issues/8508).
+
 ## v5.11.0 - 2024-04-22
 
 ### Deployment notes


### PR DESCRIPTION
Sorting measurement entities by status, status end date, and status rationale did not work.

Fixes #8508.