### PR TITLE
Add metrics not supported by subject type.

### DIFF
--- a/components/frontend/src/metric/MetricType.js
+++ b/components/frontend/src/metric/MetricType.js
@@ -21,6 +21,10 @@ export function metricTypeOptions(dataModel, subjectType) {
     return dataModel.subjects[subjectType].metrics.map((key) => metricTypeOption(key, dataModel.metrics[key]))
 }
 
+export function allMetricTypeOptions(dataModel) {
+    return Object.keys(dataModel.metrics).map((key) => metricTypeOption(key, dataModel.metrics[key]))
+}
+
 export function MetricType({ subjectType, metricType, metric_uuid, reload }) {
     const dataModel = useContext(DataModel)
     const options = metricTypeOptions(dataModel, subjectType)

--- a/components/frontend/src/semantic_ui_react_wrappers.js
+++ b/components/frontend/src/semantic_ui_react_wrappers.js
@@ -1,6 +1,7 @@
 export { Breadcrumb } from "./semantic_ui_react_wrappers/Breadcrumb"
 export { Button } from "./semantic_ui_react_wrappers/Button"
 export { Card } from "./semantic_ui_react_wrappers/Card"
+export { Checkbox } from "./semantic_ui_react_wrappers/Checkbox"
 export { Dropdown } from "./semantic_ui_react_wrappers/Dropdown"
 export { Feed } from "./semantic_ui_react_wrappers/Feed"
 export { Form } from "./semantic_ui_react_wrappers/Form"

--- a/components/frontend/src/semantic_ui_react_wrappers/Checkbox.js
+++ b/components/frontend/src/semantic_ui_react_wrappers/Checkbox.js
@@ -1,0 +1,9 @@
+import { useContext } from "react"
+import { Checkbox as SemanticUICheckbox } from "semantic-ui-react"
+
+import { DarkMode } from "../context/DarkMode"
+import { addInvertedClassNameWhenInDarkMode } from "./dark_mode"
+
+export function Checkbox(props) {
+    return <SemanticUICheckbox {...addInvertedClassNameWhenInDarkMode(props, useContext(DarkMode))} />
+}

--- a/components/frontend/src/subject/SubjectTableFooter.js
+++ b/components/frontend/src/subject/SubjectTableFooter.js
@@ -5,7 +5,7 @@ import { Table } from "semantic-ui-react"
 import { add_metric, copy_metric, move_metric } from "../api/metric"
 import { DataModel } from "../context/DataModel"
 import { EDIT_REPORT_PERMISSION, ReadOnlyOrEditable } from "../context/Permissions"
-import { metricTypeOptions } from "../metric/MetricType"
+import { allMetricTypeOptions, metricTypeOptions } from "../metric/MetricType"
 import { reportsPropType, subjectPropType } from "../sharedPropTypes"
 import { AddDropdownButton, CopyButton, MoveButton } from "../widgets/Button"
 import { metric_options } from "../widgets/menu_options"
@@ -16,6 +16,7 @@ function SubjectTableFooterButtonRow({ subject, subjectUuid, reload, reports, st
         <Table.Row>
             <Table.HeaderCell colSpan="99">
                 <AddDropdownButton
+                    allItemSubtypes={allMetricTypeOptions(dataModel)}
                     itemType="metric"
                     itemSubtypes={metricTypeOptions(dataModel, subject.type)}
                     onClick={(subtype) => {

--- a/components/frontend/src/widgets/Button.js
+++ b/components/frontend/src/widgets/Button.js
@@ -2,7 +2,7 @@ import { array, bool, func, string } from "prop-types"
 import { useRef, useState } from "react"
 import { Icon, Input } from "semantic-ui-react"
 
-import { Button, Dropdown, Label, Popup } from "../semantic_ui_react_wrappers"
+import { Button, Checkbox, Dropdown, Label, Popup } from "../semantic_ui_react_wrappers"
 import { popupContentPropType } from "../sharedPropTypes"
 import { showMessage } from "../widgets/toast"
 import { ItemBreadcrumb } from "./ItemBreadcrumb"
@@ -32,12 +32,14 @@ ActionButton.propTypes = {
     position: string,
 }
 
-export function AddDropdownButton({ itemSubtypes, itemType, onClick }) {
+export function AddDropdownButton({ itemSubtypes, itemType, onClick, allItemSubtypes }) {
     const [selectedItem, setSelectedItem] = useState(0) // Index of selected item in the dropdown
     const [query, setQuery] = useState("") // Search query to filter item subtypes
     const [menuOpen, setMenuOpen] = useState(false) // Is the menu open?
     const [popupTriggered, setPopupTriggered] = useState(false) // Is the popup triggered by hover or focus?
-    const options = itemSubtypes.filter((itemSubtype) => itemSubtype.text.toLowerCase().includes(query.toLowerCase()))
+    const [showAllItems, setShowAllItems] = useState(false) // Show all itemSubTypes or only supported itemSubTypes?
+    const items = showAllItems ? allItemSubtypes : itemSubtypes
+    const options = items.filter((itemSubtype) => itemSubtype.text.toLowerCase().includes(query.toLowerCase()))
     const inputRef = useRef(null)
     return (
         <Popup
@@ -99,28 +101,42 @@ export function AddDropdownButton({ itemSubtypes, itemType, onClick }) {
                 >
                     <Dropdown.Menu>
                         <Dropdown.Header>{`Available ${itemType} types`}</Dropdown.Header>
-                        {itemSubtypes.length > 5 && (
-                            <>
-                                <Dropdown.Divider />
-                                <Input
-                                    className="search"
-                                    focus
-                                    icon="search"
-                                    iconPosition="left"
-                                    onChange={(_event, { value }) => setQuery(value)}
-                                    onClick={(event) => {
-                                        event.stopPropagation()
-                                    }}
-                                    onKeyDown={(event) => {
-                                        if (event.key === " ") {
-                                            event.stopPropagation() // Prevent space from closing menu
-                                        }
-                                    }}
-                                    ref={inputRef}
-                                    placeholder={`Filter available ${itemType} types`}
-                                    value={query}
-                                />
-                            </>
+                        <Dropdown.Divider />
+                        <Input
+                            className="search"
+                            focus
+                            icon="search"
+                            iconPosition="left"
+                            onBlur={(event) => {
+                                if (allItemSubtypes) {
+                                    event.stopPropagation()
+                                } // Prevent tabbing to the checkbox from clearing the input
+                            }}
+                            onChange={(_event, { value }) => setQuery(value)}
+                            onClick={(event) => event.stopPropagation()}
+                            onKeyDown={(event) => {
+                                if (event.key === " ") {
+                                    event.stopPropagation() // Prevent space from closing menu
+                                }
+                            }}
+                            ref={inputRef}
+                            placeholder={`Filter ${itemType} types`}
+                            value={query}
+                        />
+                        {allItemSubtypes && (
+                            <Checkbox
+                                label={`Select from all ${itemType} types`}
+                                onChange={() => setShowAllItems(!showAllItems)}
+                                onClick={(event) => event.stopPropagation()}
+                                onKeyDown={(event) => {
+                                    if (event.key === " ") {
+                                        event.stopPropagation() // Prevent space from closing menu
+                                    }
+                                }}
+                                style={{ paddingLeft: "10pt", paddingBottom: "10pt" }}
+                                tabIndex={0}
+                                value={showAllItems ? 1 : 0}
+                            />
                         )}
                         <Dropdown.Menu scrolling>
                             {options.map((option, index) => (
@@ -139,6 +155,7 @@ export function AddDropdownButton({ itemSubtypes, itemType, onClick }) {
     )
 }
 AddDropdownButton.propTypes = {
+    allItemSubtypes: array,
     itemSubtypes: array,
     itemType: string,
     onClick: func,

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -20,8 +20,9 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 
 ### Added
 
-- When a report has a configured issue tracker, show a card in the dashboard with the number of issues per issue status (open, in progress, done). The card can be hidden via the Settings panel. Clicking the card or setting "Visible metrics" to "Metrics with issues" in the Settings panel hides metrics without issues. Closes [#8222](https://github.com/ICTU/quality-time/issues/8222).
 - Allow for hiding the legend card via the Settings panel.
+- When adding a metric to a subject, add an option to choose from all metric types in addition to the metric types officially supported by the subject type. Closes [#8176](https://github.com/ICTU/quality-time/issues/8176).
+- When a report has a configured issue tracker, show a card in the dashboard with the number of issues per issue status (open, in progress, done). The card can be hidden via the Settings panel. Clicking the card or setting "Visible metrics" to "Metrics with issues" in the Settings panel hides metrics without issues. Closes [#8222](https://github.com/ICTU/quality-time/issues/8222).
 
 ## v5.11.0 - 2024-04-22
 


### PR DESCRIPTION
When adding a metric to a subject, add an option to choose from all metric types in addition to the metric types officially supported by the subject type.

Closes #8176.