### PR TITLE
Replace deprecated GitHub Action step.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.4
-      - name: Get release version from the pushed tag
-        id: get_version
-        uses: battila7/get-version-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
@@ -26,46 +23,46 @@ jobs:
         uses: docker/build-push-action@v5.3.0
         with:
           context: components/database
-          tags: ictu/quality-time_database:${{ steps.get_version.outputs.version }}
+          tags: ictu/quality-time_database:${{ github.ref_name }}
           push: true
       - name: Push Renderer to Docker Hub
         uses: docker/build-push-action@v5.3.0
         with:
           context: components/renderer
-          tags: ictu/quality-time_renderer:${{ steps.get_version.outputs.version }}
+          tags: ictu/quality-time_renderer:${{ github.ref_name }}
           push: true
       - name: Push Proxy to Docker Hub
         uses: docker/build-push-action@v5.3.0
         with:
           context: components/proxy
-          tags: ictu/quality-time_proxy:${{ steps.get_version.outputs.version }}
+          tags: ictu/quality-time_proxy:${{ github.ref_name }}
           push: true
       - name: Push Collector to Docker Hub
         uses: docker/build-push-action@v5.3.0
         with:
           context: components
           file: components/collector/Dockerfile
-          tags: ictu/quality-time_collector:${{ steps.get_version.outputs.version }}
+          tags: ictu/quality-time_collector:${{ github.ref_name }}
           push: true
       - name: Push Notifier to Docker Hub
         uses: docker/build-push-action@v5.3.0
         with:
           context: components
           file: components/notifier/Dockerfile
-          tags: ictu/quality-time_notifier:${{ steps.get_version.outputs.version }}
+          tags: ictu/quality-time_notifier:${{ github.ref_name }}
           push: true
       - name: Push API-server to Docker Hub
         uses: docker/build-push-action@v5.3.0
         with:
           context: components
           file: components/api_server/Dockerfile
-          tags: ictu/quality-time_api_server:${{ steps.get_version.outputs.version }}
+          tags: ictu/quality-time_api_server:${{ github.ref_name }}
           push: true
       - name: Push Frontend to Docker Hub
         uses: docker/build-push-action@v5.3.0
         with:
           context: components/frontend
-          tags: ictu/quality-time_frontend:${{ steps.get_version.outputs.version }}
+          tags: ictu/quality-time_frontend:${{ github.ref_name }}
           push: true
       - name: Anchore SBOM Action
         uses: anchore/sbom-action@v0.15.10


### PR DESCRIPTION
Fix this warning in the Release workflow: "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: battila7/get-version-action@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/."

After merging this PR:

- [ ] Create release candidate to test the workflow.

Closes #8502.