### PR TITLE
Show issues in the dashboard.

### DIFF
--- a/components/frontend/src/dashboard/CardDashboard.js
+++ b/components/frontend/src/dashboard/CardDashboard.js
@@ -1,8 +1,9 @@
-import { array, bool, func } from "prop-types"
+import { array, arrayOf, bool, func } from "prop-types"
 import { useEffect, useState } from "react"
 import RGL, { WidthProvider } from "react-grid-layout"
 
 import { accessGranted, EDIT_REPORT_PERMISSION, Permissions } from "../context/Permissions"
+import { Card } from "../semantic_ui_react_wrappers"
 
 const ReactGridLayout = WidthProvider(RGL)
 
@@ -22,7 +23,7 @@ function cardDivs(cards, dragging, isDragging) {
     ))
 }
 cardDivs.propTypes = {
-    cards: array,
+    cards: arrayOf(Card),
     dragging: bool,
     isDragging: func,
 }
@@ -105,7 +106,7 @@ export function CardDashboard({ cards, initialLayout, saveLayout }) {
     )
 }
 CardDashboard.propTypes = {
-    cards: array,
+    cards: arrayOf(Card),
     initialLayout: array,
     saveLayout: func,
 }

--- a/components/frontend/src/dashboard/IssuesCard.css
+++ b/components/frontend/src/dashboard/IssuesCard.css
@@ -1,0 +1,11 @@
+.ui.card.issues .table {
+    margin-top: 0.3em;
+}
+
+.ui.card.issues .header {
+    margin-bottom: 0.3em;
+}
+
+.ui.card.issues .header.blue {
+    color: #2185d0;
+}

--- a/components/frontend/src/dashboard/IssuesCard.js
+++ b/components/frontend/src/dashboard/IssuesCard.js
@@ -1,0 +1,63 @@
+import "./IssuesCard.css"
+
+import { bool, func } from "prop-types"
+
+import { Card, Header, Label, Table } from "../semantic_ui_react_wrappers"
+import { reportPropType } from "../sharedPropTypes"
+import { capitalize, ISSUE_STATUS_COLORS } from "../utils"
+
+function issueStatuses(report) {
+    // The issue status is unknown when the issue was added recently and the status hasn't been collected yet
+    // or when collecting the issue status from the issue tracker failed
+    const statuses = { todo: 0, doing: 0, done: 0, unknown: 0 }
+    Object.values(report.subjects).forEach((subject) => {
+        Object.values(subject.metrics).forEach((metric) => {
+            let nrIssuesWithKnownStatus = 0
+            const issueStatus = metric.issue_status ?? []
+            issueStatus.forEach((issue) => {
+                if (issue.status_category) {
+                    statuses[issue.status_category] += 1
+                    nrIssuesWithKnownStatus += 1
+                }
+            })
+            const nrIssues = metric.issue_ids?.length ?? 0
+            statuses["unknown"] += nrIssues - nrIssuesWithKnownStatus
+        })
+    })
+    return statuses
+}
+issueStatuses.propTypes = {
+    report: reportPropType,
+}
+
+export function IssuesCard({ onClick, report, selected }) {
+    const statuses = issueStatuses(report)
+    const tableRows = Object.keys(statuses).map((status) => (
+        <Table.Row key={status}>
+            <Table.Cell>{capitalize(status)}</Table.Cell>
+            <Table.Cell textAlign="right">
+                <Label size="small" color={ISSUE_STATUS_COLORS[status]}>
+                    {statuses[status]}
+                </Label>
+            </Table.Cell>
+        </Table.Row>
+    ))
+    const color = selected ? "blue" : null
+    return (
+        <Card className="issues" color={color} onClick={onClick} onKeyPress={onClick} tabIndex="0">
+            <Card.Content>
+                <Header as="h3" color={color} textAlign="center">
+                    {"Issues"}
+                </Header>
+                <Table basic="very" compact="very" size="small">
+                    <Table.Body>{tableRows}</Table.Body>
+                </Table>
+            </Card.Content>
+        </Card>
+    )
+}
+IssuesCard.propTypes = {
+    onClick: func,
+    report: reportPropType,
+    selected: bool,
+}

--- a/components/frontend/src/dashboard/IssuesCard.test.js
+++ b/components/frontend/src/dashboard/IssuesCard.test.js
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react"
+
+import { IssuesCard } from "./IssuesCard"
+
+const report = {
+    subjects: {
+        subject_uuid: {
+            metrics: {
+                metric_uuid: {
+                    issue_ids: ["ID-1"],
+                    issue_status: [{ status_category: "doing" }],
+                },
+                another_metric_uuid: {
+                    issue_ids: ["ID-2", "ID-3"],
+                    issue_status: [{ connection_error: "oops" }],
+                },
+            },
+        },
+    },
+}
+
+function renderIssuesCard({ selected = false } = {}) {
+    render(<IssuesCard report={report} selected={selected} />)
+}
+
+it("shows the correct title", () => {
+    renderIssuesCard()
+    expect(screen.getByText(/Issues/)).toBeInTheDocument()
+})
+
+it("shows the title in blue when selected", () => {
+    renderIssuesCard({ selected: true })
+    expect(screen.getByText(/Issues/)).toHaveClass("blue")
+})
+
+it("shows the number of issues", () => {
+    renderIssuesCard()
+    expect(screen.getByRole("row", { name: "Todo 0" })).toBeInTheDocument()
+    expect(screen.getByRole("row", { name: "Doing 1" })).toBeInTheDocument()
+    expect(screen.getByRole("row", { name: "Done 0" })).toBeInTheDocument()
+    expect(screen.getByRole("row", { name: "Unknown 2" })).toBeInTheDocument()
+})

--- a/components/frontend/src/dashboard/MetricSummaryCard.js
+++ b/components/frontend/src/dashboard/MetricSummaryCard.js
@@ -1,6 +1,6 @@
 import "./MetricSummaryCard.css"
 
-import { func, number, object, oneOfType, string } from "prop-types"
+import { bool, func, number, object, oneOfType, string } from "prop-types"
 import { useContext } from "react"
 import { VictoryContainer, VictoryLabel, VictoryPortal, VictoryTooltip } from "victory"
 
@@ -45,7 +45,7 @@ function ariaChartLabel(summary) {
     return label
 }
 
-export function MetricSummaryCard({ header, onClick, summary, maxY }) {
+export function MetricSummaryCard({ header, onClick, selected, summary, maxY }) {
     const [boundingBox, ref] = useBoundingBox()
     const animate = { duration: 0, onLoad: { duration: 0 } }
     const colors = STATUSES.map((status) => STATUS_COLORS_RGB[status])
@@ -87,8 +87,9 @@ export function MetricSummaryCard({ header, onClick, summary, maxY }) {
         tooltip: tooltip,
         width: Math.max(bbWidth, 1), // Prevent "Failed prop type: Invalid prop range supplied to VictoryBar"
     }
+    const color = selected ? "blue" : null
     return (
-        <Card style={{ height: "100%" }} onClick={onClick} onKeyPress={onClick} tabIndex="0">
+        <Card color={color} style={{ height: "100%" }} onClick={onClick} onKeyPress={onClick} tabIndex="0">
             <div ref={ref} style={{ width: "100%", height: "72%" }} aria-label={ariaChartLabel(summary)}>
                 <VictoryContainer width={bbWidth} height={bbHeight}>
                     {dates.length > 1 ? (
@@ -107,6 +108,7 @@ export function MetricSummaryCard({ header, onClick, summary, maxY }) {
 MetricSummaryCard.propTypes = {
     header: oneOfType([object, string]),
     onClick: func,
+    selected: bool,
     summary: object,
     maxY: number,
 }

--- a/components/frontend/src/header_footer/SettingsPanel.js
+++ b/components/frontend/src/header_footer/SettingsPanel.js
@@ -50,6 +50,8 @@ export function SettingsPanel({ atReportsOverview, handleSort, settings, tags })
                 <Menu {...menuProps}>
                     <VisibleCardsMenuItem cards={atReportsOverview ? "reports" : "subjects"} {...cardsMenuItemProps} />
                     <VisibleCardsMenuItem cards="tags" {...cardsMenuItemProps} />
+                    <VisibleCardsMenuItem cards="issues" {...cardsMenuItemProps} />
+                    <VisibleCardsMenuItem cards="legend" {...cardsMenuItemProps} />
                 </Menu>
             </Segment>
             <Segment inverted color="black">
@@ -57,6 +59,7 @@ export function SettingsPanel({ atReportsOverview, handleSort, settings, tags })
                 <Menu {...menuProps}>
                     <MetricMenuItem hide="none" {...metricMenuItemProps} />
                     <MetricMenuItem hide="no_action_needed" {...metricMenuItemProps} />
+                    <MetricMenuItem hide="no_issues" {...metricMenuItemProps} />
                     <MetricMenuItem hide="all" {...metricMenuItemProps} />
                 </Menu>
             </Segment>
@@ -247,7 +250,7 @@ SettingsPanel.propTypes = {
 
 function VisibleCardsMenuItem({ cards, hiddenCards }) {
     return (
-        <SettingsMenuItem active={!hiddenCards.includes(cards)} onClick={hiddenCards.toggle} onClickData={cards}>
+        <SettingsMenuItem active={hiddenCards.excludes(cards)} onClick={hiddenCards.toggle} onClickData={cards}>
             {capitalize(cards)}
         </SettingsMenuItem>
     )
@@ -259,7 +262,7 @@ VisibleCardsMenuItem.propTypes = {
 
 function VisibleTagMenuItem({ tag, hiddenTags }) {
     return (
-        <SettingsMenuItem active={!hiddenTags.includes(tag)} onClick={hiddenTags.toggle} onClickData={tag}>
+        <SettingsMenuItem active={hiddenTags.excludes(tag)} onClick={hiddenTags.toggle} onClickData={tag}>
             {tag}
         </SettingsMenuItem>
     )
@@ -272,7 +275,7 @@ VisibleTagMenuItem.propTypes = {
 function VisibleColumnMenuItem({ column, disabled, hiddenColumns, help, itemText }) {
     return (
         <SettingsMenuItem
-            active={disabled ? false : !hiddenColumns.includes(column)}
+            active={disabled ? false : hiddenColumns.excludes(column)}
             disabled={disabled}
             disabledHelp={help}
             onClick={hiddenColumns.toggle}
@@ -379,6 +382,7 @@ function MetricMenuItem({ hide, metricsToHide }) {
                 {
                     none: "All metrics",
                     no_action_needed: "Metrics requiring action",
+                    no_issues: "Metrics with issues",
                     all: "No metrics",
                 }[hide]
             }

--- a/components/frontend/src/hooks/url_search_query.js
+++ b/components/frontend/src/hooks/url_search_query.js
@@ -67,6 +67,7 @@ export function useArrayURLSearchQuery(key) {
     }
 
     let hook = createHook(key, value, defaultValue, setValue)
+    hook.excludes = (item) => !value.includes(item)
     hook.includes = (item) => value.includes(item)
     hook.toggle = toggleURLSearchQuery
     return hook

--- a/components/frontend/src/issue/IssueStatus.js
+++ b/components/frontend/src/issue/IssueStatus.js
@@ -3,7 +3,7 @@ import TimeAgo from "react-timeago"
 
 import { Label, Popup } from "../semantic_ui_react_wrappers"
 import { issueStatusPropType, metricPropType, settingsPropType, stringsPropType } from "../sharedPropTypes"
-import { getMetricIssueIds } from "../utils"
+import { getMetricIssueIds, ISSUE_STATUS_COLORS } from "../utils"
 import { HyperLink } from "../widgets/HyperLink"
 import { TimeAgoWithDate } from "../widgets/TimeAgoWithDate"
 
@@ -119,7 +119,8 @@ prefixName.propType = {
 }
 
 function issueLabel(issueStatus, settings, error) {
-    const color = error ? "red" : { todo: "grey", doing: "blue", done: "green" }[issueStatus.status_category ?? "todo"]
+    // The issue status can be unknown when the issue was added recently and the status hasn't been collected yet
+    const color = error ? "red" : ISSUE_STATUS_COLORS[issueStatus.status_category ?? "unknown"]
     const label = (
         <Label basic={!error} color={color}>
             {issueStatus.issue_id}

--- a/components/frontend/src/issue/IssueStatus.test.js
+++ b/components/frontend/src/issue/IssueStatus.test.js
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event"
 import history from "history/browser"
 
 import { createTestableSettings } from "../__fixtures__/fixtures"
+import { ISSUE_STATUS_COLORS } from "../utils"
 import { IssueStatus } from "./IssueStatus"
 
 function renderIssueStatus({
@@ -85,9 +86,13 @@ it("displays the status category done", () => {
     expect(screen.getByText(/123/).className).toContain("green")
 })
 
-it("displays a missing status category as todo", () => {
+it("displays a missing status category as unknown", () => {
     renderIssueStatus()
-    expect(screen.getByText(/123/).className).toContain("grey")
+    Object.values(ISSUE_STATUS_COLORS)
+        .filter((color) => color !== null)
+        .forEach((color) => {
+            expect(screen.getByText(/123/).className).not.toContain(color)
+        })
 })
 
 it("displays the issue landing url", async () => {

--- a/components/frontend/src/report/Report.js
+++ b/components/frontend/src/report/Report.js
@@ -33,8 +33,11 @@ export function Report({
 }) {
     function navigate_to_subject(event, subject_uuid) {
         event.preventDefault()
-        document.getElementById(subject_uuid).scrollIntoView()
-        window.scrollBy(0, 163) // Correct for menubar and subject title margin
+        const element = document.getElementById(subject_uuid)
+        if (element) {
+            element.scrollIntoView()
+            window.scrollBy(0, 163) // Correct for menubar and subject title margin
+        }
     }
 
     if (!report) {

--- a/components/frontend/src/report/Report.test.js
+++ b/components/frontend/src/report/Report.test.js
@@ -164,3 +164,26 @@ it("hides subjects if empty", async () => {
     renderReport({ reportToRender: report })
     expect(screen.queryAllByText(/Subject title/).length).toBe(0)
 })
+
+it("navigates to subject", async () => {
+    const mockScroll = jest.fn()
+    window.HTMLElement.prototype.scrollIntoView = mockScroll
+    const mockScrollBy = jest.fn()
+    window.scrollBy = mockScrollBy
+    renderReport({ reportToRender: report })
+    fireEvent.click(screen.getAllByText(/Subject title/)[0])
+    expect(mockScroll).toHaveBeenCalledWith()
+    expect(mockScrollBy).toHaveBeenCalledWith(0, 163)
+})
+
+it("does not navigate to a subject that is hidden", async () => {
+    history.push("?metrics_to_hide=no_issues")
+    const mockScroll = jest.fn()
+    window.HTMLElement.prototype.scrollIntoView = mockScroll
+    const mockScrollBy = jest.fn()
+    window.scrollBy = mockScrollBy
+    renderReport({ reportToRender: report })
+    fireEvent.click(screen.getAllByText(/Subject title/)[0])
+    expect(mockScroll).not.toHaveBeenCalled()
+    expect(mockScrollBy).not.toHaveBeenCalled()
+})

--- a/components/frontend/src/report/ReportsOverviewDashboard.js
+++ b/components/frontend/src/report/ReportsOverviewDashboard.js
@@ -82,7 +82,7 @@ export function ReportsOverviewDashboard({
         })
     })
     let report_cards = []
-    if (!settings.hiddenCards.includes("reports")) {
+    if (settings.hiddenCards.excludes("reports")) {
         report_cards = reports.map((report) => (
             <MetricSummaryCard
                 key={report.report_uuid}
@@ -97,10 +97,10 @@ export function ReportsOverviewDashboard({
         ))
     }
     let tagCards = []
-    if (!settings.hiddenCards.includes("tags")) {
+    if (settings.hiddenCards.excludes("tags")) {
         const anyTagsHidden = settings.hiddenTags.value.length > 0
         tagCards = tags
-            .filter((tag) => !settings.hiddenTags.includes(tag))
+            .filter((tag) => settings.hiddenTags.excludes(tag))
             .map((tag) => (
                 <MetricSummaryCard
                     key={tag}

--- a/components/frontend/src/sharedPropTypes.js
+++ b/components/frontend/src/sharedPropTypes.js
@@ -78,9 +78,9 @@ export const sortDirectionURLSearchQueryPropType = shape({
     value: sortDirectionPropType,
 })
 
-export const hiddenCardsPropType = oneOf(["reports", "subjects", "tags"])
+export const hiddenCardsPropType = oneOf(["reports", "subjects", "tags", "issues", "legend"])
 
-export const metricsToHidePropType = oneOf(["none", "all", "no_action_needed"])
+export const metricsToHidePropType = oneOf(["all", "none", "no_action_needed", "no_issues"])
 
 export const metricsToHideURLSearchQueryPropType = shape({
     isDefault: func,

--- a/components/frontend/src/subject/SubjectTableHeader.js
+++ b/components/frontend/src/subject/SubjectTableHeader.js
@@ -286,13 +286,13 @@ export function SubjectTableHeader({ columnDates, handleSort, settings }) {
                 {nrDates > 1 && (
                     <MeasurementHeaderCells
                         columnDates={columnDates}
-                        showDeltaColumns={!settings.hiddenColumns.includes("delta")}
+                        showDeltaColumns={settings.hiddenColumns.excludes("delta")}
                     />
                 )}
-                {nrDates === 1 && !settings.hiddenColumns.includes("trend") && (
+                {nrDates === 1 && settings.hiddenColumns.excludes("trend") && (
                     <UnsortableTableHeaderCell width="2" label="Trend (7 days)" help={trendHelp} />
                 )}
-                {nrDates === 1 && !settings.hiddenColumns.includes("status") && (
+                {nrDates === 1 && settings.hiddenColumns.excludes("status") && (
                     <SortableTableHeaderCell
                         column="status"
                         label="Status"
@@ -301,7 +301,7 @@ export function SubjectTableHeader({ columnDates, handleSort, settings }) {
                         {...sortProps}
                     />
                 )}
-                {nrDates === 1 && !settings.hiddenColumns.includes("measurement") && (
+                {nrDates === 1 && settings.hiddenColumns.excludes("measurement") && (
                     <SortableTableHeaderCell
                         column="measurement"
                         label="Measurement"
@@ -310,7 +310,7 @@ export function SubjectTableHeader({ columnDates, handleSort, settings }) {
                         {...sortProps}
                     />
                 )}
-                {nrDates === 1 && !settings.hiddenColumns.includes("target") && (
+                {nrDates === 1 && settings.hiddenColumns.excludes("target") && (
                     <SortableTableHeaderCell
                         column="target"
                         label="Target"
@@ -319,25 +319,25 @@ export function SubjectTableHeader({ columnDates, handleSort, settings }) {
                         {...sortProps}
                     />
                 )}
-                {!settings.hiddenColumns.includes("unit") && (
+                {settings.hiddenColumns.excludes("unit") && (
                     <SortableTableHeaderCell column="unit" label="Unit" help={unitHelp} {...sortProps} />
                 )}
-                {!settings.hiddenColumns.includes("source") && (
+                {settings.hiddenColumns.excludes("source") && (
                     <SortableTableHeaderCell column="source" label="Sources" help={sourcesHelp} {...sortProps} />
                 )}
-                {!settings.hiddenColumns.includes("time_left") && (
+                {settings.hiddenColumns.excludes("time_left") && (
                     <SortableTableHeaderCell column="time_left" label="Time left" help={timeLeftHelp} {...sortProps} />
                 )}
-                {nrDates > 1 && !settings.hiddenColumns.includes("overrun") && (
+                {nrDates > 1 && settings.hiddenColumns.excludes("overrun") && (
                     <SortableTableHeaderCell column="overrun" label="Overrun" help={overrunHelp} {...sortProps} />
                 )}
-                {!settings.hiddenColumns.includes("comment") && (
+                {settings.hiddenColumns.excludes("comment") && (
                     <SortableTableHeaderCell column="comment" label="Comment" help={commentHelp} {...sortProps} />
                 )}
-                {!settings.hiddenColumns.includes("issues") && (
+                {settings.hiddenColumns.excludes("issues") && (
                     <SortableTableHeaderCell column="issues" label="Issues" help={issuesHelp} {...sortProps} />
                 )}
-                {!settings.hiddenColumns.includes("tags") && (
+                {settings.hiddenColumns.excludes("tags") && (
                     <SortableTableHeaderCell column="tags" label="Tags" help={tagsHelp} {...sortProps} />
                 )}
             </Table.Row>

--- a/components/frontend/src/subject/SubjectTableRow.js
+++ b/components/frontend/src/subject/SubjectTableRow.js
@@ -153,7 +153,7 @@ DeltaCell.propTypes = {
 
 function MeasurementCells({ dates, metric, metric_uuid, measurements, settings }) {
     const dataModel = useContext(DataModel)
-    const showDeltaColumns = !settings.hiddenColumns.includes("delta")
+    const showDeltaColumns = settings.hiddenColumns.excludes("delta")
     const dateOrderAscending = settings.dateOrder.value === "ascending"
     const scale = getMetricScale(metric, dataModel)
     const cells = []
@@ -270,38 +270,38 @@ export function SubjectTableRow({
                     settings={settings}
                 />
             )}
-            {nrDates === 1 && !settings.hiddenColumns.includes("trend") && (
+            {nrDates === 1 && settings.hiddenColumns.excludes("trend") && (
                 <Table.Cell>
                     <TrendSparkline measurements={metric.recent_measurements} report_date={reportDate} scale={scale} />
                 </Table.Cell>
             )}
-            {nrDates === 1 && !settings.hiddenColumns.includes("status") && (
+            {nrDates === 1 && settings.hiddenColumns.excludes("status") && (
                 <Table.Cell textAlign="center">
                     <StatusIcon status={metric.status} status_start={metric.status_start} />
                 </Table.Cell>
             )}
-            {nrDates === 1 && !settings.hiddenColumns.includes("measurement") && (
+            {nrDates === 1 && settings.hiddenColumns.excludes("measurement") && (
                 <Table.Cell textAlign="right">
                     <MeasurementValue metric={metric} reportDate={reportDate} />
                 </Table.Cell>
             )}
-            {nrDates === 1 && !settings.hiddenColumns.includes("target") && (
+            {nrDates === 1 && settings.hiddenColumns.excludes("target") && (
                 <Table.Cell textAlign="right">
                     <MeasurementTarget metric={metric} />
                 </Table.Cell>
             )}
-            {!settings.hiddenColumns.includes("unit") && <Table.Cell style={style}>{unit}</Table.Cell>}
-            {!settings.hiddenColumns.includes("source") && (
+            {settings.hiddenColumns.excludes("unit") && <Table.Cell style={style}>{unit}</Table.Cell>}
+            {settings.hiddenColumns.excludes("source") && (
                 <Table.Cell style={style}>
                     <MeasurementSources metric={metric} />
                 </Table.Cell>
             )}
-            {!settings.hiddenColumns.includes("time_left") && (
+            {settings.hiddenColumns.excludes("time_left") && (
                 <Table.Cell style={style}>
                     <TimeLeft metric={metric} report={report} />
                 </Table.Cell>
             )}
-            {nrDates > 1 && !settings.hiddenColumns.includes("overrun") && (
+            {nrDates > 1 && settings.hiddenColumns.excludes("overrun") && (
                 <Table.Cell style={style}>
                     <Overrun
                         metric={metric}
@@ -312,17 +312,17 @@ export function SubjectTableRow({
                     />
                 </Table.Cell>
             )}
-            {!settings.hiddenColumns.includes("comment") && (
+            {settings.hiddenColumns.excludes("comment") && (
                 <Table.Cell style={style}>
                     <div style={{ wordBreak: "break-word" }} dangerouslySetInnerHTML={{ __html: metric.comment }} />
                 </Table.Cell>
             )}
-            {!settings.hiddenColumns.includes("issues") && (
+            {settings.hiddenColumns.excludes("issues") && (
                 <Table.Cell style={style}>
                     <IssueStatus metric={metric} issueTrackerMissing={!report.issue_tracker} settings={settings} />
                 </Table.Cell>
             )}
-            {!settings.hiddenColumns.includes("tags") && (
+            {settings.hiddenColumns.excludes("tags") && (
                 <Table.Cell style={style}>
                     {getMetricTags(metric).map((tag) => (
                         <Tag key={tag} tag={tag} />

--- a/components/frontend/src/utils.test.js
+++ b/components/frontend/src/utils.test.js
@@ -317,18 +317,26 @@ it("does not return hidden tags", () => {
     ).toStrictEqual(["tag"])
 })
 
-it("hides metrics not requiring action", () => {
+it("hides metrics not requiring action or without issues", () => {
     expect(visibleMetrics({}, "no_action_needed", [])).toStrictEqual({})
+    expect(visibleMetrics({}, "no_issues", [])).toStrictEqual({})
     expect(visibleMetrics({}, "all", [])).toStrictEqual({})
     expect(visibleMetrics({}, "none", [])).toStrictEqual({})
     const metricNotRequiringAction = { metric_uuid: { status: "informative" } }
     expect(visibleMetrics(metricNotRequiringAction, "no_action_needed", [])).toStrictEqual({})
+    expect(visibleMetrics(metricNotRequiringAction, "no_issues", [])).toStrictEqual({})
     expect(visibleMetrics(metricNotRequiringAction, "all", [])).toStrictEqual({})
     expect(visibleMetrics(metricNotRequiringAction, "none", [])).toStrictEqual(metricNotRequiringAction)
     const metricRequiringAction = { metric_uuid: { status: "target_not_met" } }
     expect(visibleMetrics(metricRequiringAction, "no_action_needed", [])).toStrictEqual(metricRequiringAction)
+    expect(visibleMetrics(metricRequiringAction, "no_issues", [])).toStrictEqual({})
     expect(visibleMetrics(metricRequiringAction, "none", [])).toStrictEqual(metricRequiringAction)
     expect(visibleMetrics(metricRequiringAction, "all", [])).toStrictEqual({})
+    const metricWithIssue = { metric_uuid: { status: "target_met", issue_ids: ["ID-1"] } }
+    expect(visibleMetrics(metricWithIssue, "no_action_needed", [])).toStrictEqual({})
+    expect(visibleMetrics(metricWithIssue, "no_issues", [])).toStrictEqual(metricWithIssue)
+    expect(visibleMetrics(metricWithIssue, "none", [])).toStrictEqual(metricWithIssue)
+    expect(visibleMetrics(metricWithIssue, "all", [])).toStrictEqual({})
 })
 
 it("hides metrics with hidden tags", () => {

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,11 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 
 - Sorting measurement entities by status, status end date, and status rationale did not work. Fixes [#8508](https://github.com/ICTU/quality-time/issues/8508).
 
+### Added
+
+- When a report has a configured issue tracker, show a card in the dashboard with the number of issues per issue status (open, in progress, done). The card can be hidden via the Settings panel. Clicking the card or setting "Visible metrics" to "Metrics with issues" in the Settings panel hides metrics without issues. Closes [#8222](https://github.com/ICTU/quality-time/issues/8222).
+- Allow for hiding the legend card via the Settings panel.
+
 ## v5.11.0 - 2024-04-22
 
 ### Deployment notes


### PR DESCRIPTION
- When a report has a configured issue tracker, show a card in the dasbboard with the number of issues per issue status (open, in progress, done). The card can be hidden via the Settings panel.
- Allow for hiding the legend card via the Settings panel.

Closes #8222.