### PR TITLE
Change default value of branch parameters to main

### DIFF
--- a/components/collector/tests/source_collectors/azure_devops/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/azure_devops/test_source_up_to_dateness.py
@@ -37,7 +37,7 @@ class AzureDevopsSourceUpToDatenessTest(AzureDevopsTestCase):
         self.assert_measurement(
             response,
             value=self.expected_age,
-            landing_url=f"{self.url}/_git/repo?path=README.md&version=GBmaster",
+            landing_url=f"{self.url}/_git/repo?path=README.md&version=GBmain",
         )
 
     async def test_age_of_pipeline(self):

--- a/components/collector/tests/source_collectors/sonarqube/base.py
+++ b/components/collector/tests/source_collectors/sonarqube/base.py
@@ -16,8 +16,8 @@ class SonarQubeTestCase(SourceCollectorTestCase):
         """Extend to set up the SonarQube source fixture and some URLs."""
         super().setUp()
         self.set_source_parameter("component", "id")
-        self.issues_landing_url = "https://sonarqube/project/issues?id=id&branch=master&resolved=false"
-        self.metric_landing_url = "https://sonarqube/component_measures?id=id&branch=master&metric={0}"
+        self.issues_landing_url = "https://sonarqube/project/issues?id=id&branch=main&resolved=false"
+        self.metric_landing_url = "https://sonarqube/component_measures?id=id&branch=main&metric={0}"
 
     @staticmethod
     def entity(  # noqa: PLR0913
@@ -36,9 +36,9 @@ class SonarQubeTestCase(SourceCollectorTestCase):
     ) -> Entity:
         """Create an entity."""
         url = (
-            f"https://sonarqube/security_hotspots?id=id&branch=master&hotspots={key}"
+            f"https://sonarqube/security_hotspots?id=id&branch=main&hotspots={key}"
             if entity_type == "security_hotspot"
-            else f"https://sonarqube/project/issues?id=id&branch=master&issues={key}&open={key}"
+            else f"https://sonarqube/project/issues?id=id&branch=main&issues={key}&open={key}"
         )
         entity = Entity(
             key=key,

--- a/components/collector/tests/source_collectors/sonarqube/test_remediation_effort.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_remediation_effort.py
@@ -44,7 +44,7 @@ class SonarQubeRemediationEffortTest(SonarQubeTestCase):
                     "url": self.metric_landing_url.format("reliability_remediation_effort"),
                 },
             ],
-            landing_url="https://sonarqube/component_measures?id=id&branch=master",
+            landing_url="https://sonarqube/component_measures?id=id&branch=main",
         )
 
     async def test_remediation_effort_one_metric(self):

--- a/components/collector/tests/source_collectors/sonarqube/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_security_warnings.py
@@ -10,7 +10,7 @@ class SonarQubeSecurityWarningsTest(SonarQubeTestCase):
     SONARQUBE_URL = "https://sonarqube"
     API_URL = f"{SONARQUBE_URL}/api"
     LANDING_URL = f"{SONARQUBE_URL}/project"
-    BRANCH = "&branch=master"
+    BRANCH = "&branch=main"
     DASHBOARD_URL = f"{SONARQUBE_URL}/dashboard?id=id{BRANCH}"
     HOTSPOTS_API = f"{API_URL}/hotspots/search?projectKey=id{BRANCH}&ps=500"
     HOTSPOTS_LANDING_URL = f"{LANDING_URL}/security_hotspots?id=id{BRANCH}"

--- a/components/collector/tests/source_collectors/sonarqube/test_software_version.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_software_version.py
@@ -16,5 +16,5 @@ class SonarQubeSoftwareVersionTest(SonarQubeTestCase):
         self.assert_measurement(
             response,
             value="1.2.1",
-            landing_url="https://sonarqube/project/activity?id=id&branch=master",
+            landing_url="https://sonarqube/project/activity?id=id&branch=main",
         )

--- a/components/collector/tests/source_collectors/sonarqube/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_source_up_to_dateness.py
@@ -22,5 +22,5 @@ class SonarQubeSourceUpToDatenessTest(SonarQubeTestCase):
         self.assert_measurement(
             response,
             value=str(expected_age),
-            landing_url="https://sonarqube/project/activity?id=id&branch=master",
+            landing_url="https://sonarqube/project/activity?id=id&branch=main",
         )

--- a/components/collector/tests/source_collectors/sonarqube/test_suppressed_violations.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_suppressed_violations.py
@@ -72,7 +72,7 @@ class SonarQubeSuppressedViolationsTest(SonarQubeTestCase):
             value="2",
             total="4",
             entities=expected_entities,
-            landing_url="https://sonarqube/project/issues?id=id&branch=master",
+            landing_url="https://sonarqube/project/issues?id=id&branch=main",
         )
 
     async def test_suppressed_with_rationale_violations(self):
@@ -129,5 +129,5 @@ class SonarQubeSuppressedViolationsTest(SonarQubeTestCase):
             value="1",
             total="1",
             entities=expected_entities,
-            landing_url="https://sonarqube/project/issues?id=id&branch=master",
+            landing_url="https://sonarqube/project/issues?id=id&branch=main",
         )

--- a/components/collector/tests/source_collectors/sonarqube/test_tests.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_tests.py
@@ -10,7 +10,7 @@ class SonarQubeTestsTest(SonarQubeTestCase):
 
     def assert_measurement(self, measurement, *, source_index: int = 0, **attributes: list | str | None) -> None:
         """Extend to add the landing url."""
-        attributes["landing_url"] = "https://sonarqube/component_measures?id=id&branch=master&metric=tests"
+        attributes["landing_url"] = "https://sonarqube/component_measures?id=id&branch=main&metric=tests"
         super().assert_measurement(measurement, source_index=source_index, **attributes)
 
     async def test_nr_of_tests(self):

--- a/components/shared_code/src/shared_data_model/parameters.py
+++ b/components/shared_code/src/shared_data_model/parameters.py
@@ -147,7 +147,7 @@ class Branch(StringParameter):
     """Branch name parameter."""
 
     name: str = "Branch"
-    default_value: str | list[str] = "master"
+    default_value: str | list[str] = "main"
     metrics: list[str] = ["source_up_to_dateness"]
 
 

--- a/components/shared_code/src/shared_data_model/sources/sonarqube.py
+++ b/components/shared_code/src/shared_data_model/sources/sonarqube.py
@@ -332,7 +332,7 @@ SONARQUBE = Source(
             name="Branch (only supported by commercial SonarQube editions)",
             short_name="branch",
             help_url=HttpUrl("https://docs.sonarqube.org/latest/branches/overview/"),
-            default_value="master",
+            default_value="main",
             metrics=PROJECT_METRICS,
         ),
         "languages_to_ignore": MultipleChoiceWithAdditionParameter(

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -26,6 +26,10 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 - When adding a metric to a subject, add an option to choose from all metric types in addition to the metric types officially supported by the subject type. Closes [#8176](https://github.com/ICTU/quality-time/issues/8176).
 - When a report has a configured issue tracker, show a card in the dashboard with the number of issues per issue status (open, in progress, done). The card can be hidden via the Settings panel. Clicking the card or setting "Visible metrics" to "Metrics with issues" in the Settings panel hides metrics without issues. Closes [#8222](https://github.com/ICTU/quality-time/issues/8222).
 
+### Changed
+
+- Make the default value of branch parameters `main` instead of `master`. Closes [#8045](https://github.com/ICTU/quality-time/issues/8045).
+
 ## v5.11.0 - 2024-04-22
 
 ### Deployment notes


### PR DESCRIPTION
Make the default value of branch parameters `main` instead of `master`.

Note: no migration code is needed because Quality-time only uses the default value of the branch parameter upon creation of a source. Changing the default value of the branch parameter does not impact existing sources.

Closes #8045.