### PR TITLE
Fix application tests on CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   unittest_backend:
     docker:
-      - image: cimg/python:3.12.1
+      - image: cimg/python:3.12.3
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -39,7 +39,7 @@ jobs:
 
   unittest_frontend:
     docker:
-      - image: cimg/node:21.7.2
+      - image: cimg/node:22.1.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -78,7 +78,9 @@ jobs:
           export COMPOSE_PATH_SEPARATOR=':'
           export COMPOSE_FILE=docker/docker-compose.yml:docker/docker-compose.ci.yml
           docker compose build && docker compose up -d
-          docker run -it -w `pwd` -v `pwd`:`pwd` --network=container:quality-time-www-1 python:3.12.3-bookworm tests/application_tests/ci/test.sh
+          docker ps
+          docker run -it -w `pwd` -v `pwd`:`pwd` --network=container:docker-www-1 python:3.12.3-bookworm tests/application_tests/ci/test.sh
+          docker ps
           docker compose logs > build/containers.log
       - run:
           name: Save container logs on failure


### PR DESCRIPTION
Work around "docker: Error response from daemon: No such container: quality-time-www-1." when running the application tests on CircleCI. See https://app.circleci.com/pipelines/github/ICTU/quality-time/20226/workflows/debbee21-2a8d-43af-a95d-fcc653d0d790/jobs/102953.