### PR TITLE
Ignore CVE-2018-20225 reported by Safety

### DIFF
--- a/components/api_server/ci/quality.sh
+++ b/components/api_server/ci/quality.sh
@@ -15,7 +15,13 @@ run pipx run `spec pip-audit` --strict --progress-spinner=off -r requirements/re
 export PYTHONDEVMODE=1
 
 # Safety
-run pipx run `spec safety` check --bare -r requirements/requirements.txt -r requirements/requirements-dev.txt
+# Vulnerability ID: 67599
+# ADVISORY: ** DISPUTED ** An issue was discovered in pip (all versions) because it installs the version with the
+# highest version number, even if the user had intended to obtain a private package from a private index. This only
+# affects use of the --extra-index-url option, and exploitation requires that the...
+# CVE-2018-20225
+# For more information about this vulnerability, visit https://data.safetycli.com/v/67599/97c
+run pipx run `spec safety` check --bare --ignore 67599 -r requirements/requirements.txt -r requirements/requirements-dev.txt
 
 # Bandit
 run pipx run `spec bandit` --quiet --recursive src/

--- a/components/collector/ci/quality.sh
+++ b/components/collector/ci/quality.sh
@@ -16,7 +16,13 @@ run pipx run `spec pip-audit` --strict --progress-spinner=off -r requirements/re
 export PYTHONDEVMODE=1
 
 # Safety
-run pipx run `spec safety` check --bare -r requirements/requirements.txt -r requirements/requirements-dev.txt
+# Vulnerability ID: 67599
+# ADVISORY: ** DISPUTED ** An issue was discovered in pip (all versions) because it installs the version with the
+# highest version number, even if the user had intended to obtain a private package from a private index. This only
+# affects use of the --extra-index-url option, and exploitation requires that the...
+# CVE-2018-20225
+# For more information about this vulnerability, visit https://data.safetycli.com/v/67599/97c
+run pipx run `spec safety` check --bare --ignore 67599 -r requirements/requirements.txt -r requirements/requirements-dev.txt
 
 # Bandit
 run pipx run `spec bandit` --quiet --recursive src/

--- a/components/notifier/ci/quality.sh
+++ b/components/notifier/ci/quality.sh
@@ -16,7 +16,13 @@ run pipx run `spec pip-audit` --strict --progress-spinner=off -r requirements/re
 export PYTHONDEVMODE=1
 
 # Safety
-run pipx run `spec safety` check --bare -r requirements/requirements.txt -r requirements/requirements-dev.txt
+# Vulnerability ID: 67599
+# ADVISORY: ** DISPUTED ** An issue was discovered in pip (all versions) because it installs the version with the
+# highest version number, even if the user had intended to obtain a private package from a private index. This only
+# affects use of the --extra-index-url option, and exploitation requires that the...
+# CVE-2018-20225
+# For more information about this vulnerability, visit https://data.safetycli.com/v/67599/97c
+run pipx run `spec safety` check --bare --ignore 67599 -r requirements/requirements.txt -r requirements/requirements-dev.txt
 
 # Bandit
 run pipx run `spec bandit` --quiet --recursive src/

--- a/components/shared_code/ci/quality.sh
+++ b/components/shared_code/ci/quality.sh
@@ -18,7 +18,13 @@ run pipx run `spec pip-audit` --strict --progress-spinner=off -r requirements/re
 export PYTHONDEVMODE=1
 
 # Safety
-run pipx run `spec safety` check --bare -r requirements/requirements-dev.txt
+# Vulnerability ID: 67599
+# ADVISORY: ** DISPUTED ** An issue was discovered in pip (all versions) because it installs the version with the
+# highest version number, even if the user had intended to obtain a private package from a private index. This only
+# affects use of the --extra-index-url option, and exploitation requires that the...
+# CVE-2018-20225
+# For more information about this vulnerability, visit https://data.safetycli.com/v/67599/97c
+run pipx run `spec safety` check --bare --ignore 67599 -r requirements/requirements-dev.txt
 
 # Bandit
 run pipx run `spec bandit` --quiet --recursive src/

--- a/tests/feature_tests/ci/quality.sh
+++ b/tests/feature_tests/ci/quality.sh
@@ -15,7 +15,13 @@ run pipx run `spec pip-audit` --strict --progress-spinner=off -r requirements/re
 export PYTHONDEVMODE=1
 
 # Safety
-run pipx run `spec safety` check --bare -r requirements/requirements-dev.txt
+# Vulnerability ID: 67599
+# ADVISORY: ** DISPUTED ** An issue was discovered in pip (all versions) because it installs the version with the
+# highest version number, even if the user had intended to obtain a private package from a private index. This only
+# affects use of the --extra-index-url option, and exploitation requires that the...
+# CVE-2018-20225
+# For more information about this vulnerability, visit https://data.safetycli.com/v/67599/97c
+run pipx run `spec safety` check --bare --ignore 67599 -r requirements/requirements-dev.txt
 
 # Bandit
 run pipx run `spec bandit` --quiet --recursive src/


### PR DESCRIPTION
Vulnerability ID: 67599
ADVISORY: ** DISPUTED ** An issue was discovered in pip (all versions) because it installs the version with the highest version number, even if the user had intended to obtain a private package from a private index. This only affects use of the --extra-index-url option, and exploitation requires that the... CVE-2018-20225
For more information about this vulnerability, visit https://data.safetycli.com/v/67599/97c