### PR TITLE
Allow for filtering Dependency-Track projects.

### DIFF
--- a/components/collector/src/source_collectors/dependency_track/dependencies.py
+++ b/components/collector/src/source_collectors/dependency_track/dependencies.py
@@ -5,14 +5,7 @@ from typing import Literal, TypedDict
 from collector_utilities.type import URL
 from model import Entities, Entity, SourceResponses
 
-from .base import DependencyTrackBase
-
-
-class DependencyTrackProject(TypedDict):
-    """Project as returned by Dependency-Track."""
-
-    name: str
-    uuid: str
+from .base import DependencyTrackBase, DependencyTrackProject
 
 
 class DependencyTrackRepositoryMetaData(TypedDict):

--- a/components/collector/tests/source_collectors/dependency_track/test_dependencies.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_dependencies.py
@@ -1,5 +1,6 @@
 """Unit tests for the Dependency-Track security warnings collector."""
 
+from source_collectors.dependency_track.base import DependencyTrackProject
 from source_collectors.dependency_track.dependencies import DependencyTrackComponent
 
 from tests.source_collectors.source_collector_test_case import SourceCollectorTestCase
@@ -11,16 +12,15 @@ class DependencyTrackDependenciesTest(SourceCollectorTestCase):
     METRIC_TYPE = "dependencies"
     SOURCE_TYPE = "dependency_track"
 
-    def setUp(self) -> None:
-        """Extend to set up Dependency-Track projects."""
-        super().setUp()
-        self.projects = [{"uuid": "project uuid", "name": "project name"}]
+    def projects(self) -> list[DependencyTrackProject]:
+        """Create the Dependency-Track projects fixture."""
+        return [DependencyTrackProject(name="project name", uuid="project uuid", version="1.4", lastBomImport=0)]
 
-    def create_dependencies(self, latest_version: str) -> list[DependencyTrackComponent]:
+    def dependencies(self, latest_version: str) -> list[DependencyTrackComponent]:
         """Create a list of dependencies as returned by Dependency-Track."""
         dependency: DependencyTrackComponent = {
             "name": "component name",
-            "project": {"name": "project name", "uuid": "project uuid"},
+            "project": self.projects()[0],
             "uuid": "component-uuid",
             "version": "1.0",
         }
@@ -28,7 +28,7 @@ class DependencyTrackDependenciesTest(SourceCollectorTestCase):
             dependency["repositoryMeta"] = {"latestVersion": latest_version}
         return [dependency]
 
-    def create_entities(self, latest_version: str, latest_version_status: str) -> list[dict[str, str]]:
+    def entities(self, latest_version: str, latest_version_status: str) -> list[dict[str, str]]:
         """Create a list of expected entities."""
         return [
             {
@@ -50,26 +50,51 @@ class DependencyTrackDependenciesTest(SourceCollectorTestCase):
 
     async def test_no_vulnerabilities(self):
         """Test one project without dependencies."""
-        response = await self.collect(get_request_json_side_effect=[self.projects, []])
+        response = await self.collect(get_request_json_side_effect=[self.projects(), []])
         self.assert_measurement(response, value="0", entities=[])
 
     async def test_updateable_dependencies(self):
         """Test one project with a component that can be updated."""
-        response = await self.collect(get_request_json_side_effect=[self.projects, self.create_dependencies("1.1")])
-        self.assert_measurement(response, value="1", entities=self.create_entities("1.1", "update possible"))
+        response = await self.collect(get_request_json_side_effect=[self.projects(), self.dependencies("1.1")])
+        self.assert_measurement(response, value="1", entities=self.entities("1.1", "update possible"))
 
     async def test_up_to_date_dependencies(self):
         """Test one project with a component that is up to date."""
-        response = await self.collect(get_request_json_side_effect=[self.projects, self.create_dependencies("1.0")])
-        self.assert_measurement(response, value="1", entities=self.create_entities("1.0", "up-to-date"))
+        response = await self.collect(get_request_json_side_effect=[self.projects(), self.dependencies("1.0")])
+        self.assert_measurement(response, value="1", entities=self.entities("1.0", "up-to-date"))
 
     async def test_unknown_latest_version(self):
         """Test one project with a component whose latest version is unknown."""
-        response = await self.collect(get_request_json_side_effect=[self.projects, self.create_dependencies("")])
-        self.assert_measurement(response, value="1", entities=self.create_entities("unknown", "unknown"))
+        response = await self.collect(get_request_json_side_effect=[self.projects(), self.dependencies("")])
+        self.assert_measurement(response, value="1", entities=self.entities("unknown", "unknown"))
 
     async def test_filter_by_latest_version_status(self):
         """Test that components can be filtered by latest version status."""
         self.set_source_parameter("latest_version_status", ["update possible"])
-        response = await self.collect(get_request_json_side_effect=[self.projects, self.create_dependencies("1.0")])
+        response = await self.collect(get_request_json_side_effect=[self.projects(), self.dependencies("1.0")])
         self.assert_measurement(response, value="0", entities=[])
+
+    async def test_filter_by_project_name(self):
+        """Test filtering projects by name."""
+        self.set_source_parameter("project_names", ["other project"])
+        response = await self.collect(get_request_json_return_value=self.projects())
+        self.assert_measurement(response, value="0", entities=[])
+
+    async def test_filter_by_project_regular_expression(self):
+        """Test filtering projects by regular expression."""
+        self.set_source_parameter("project_names", ["project .*"])
+        response = await self.collect(get_request_json_side_effect=[self.projects(), self.dependencies("1.0")])
+        self.assert_measurement(response, value="1", entities=self.entities("1.0", "up-to-date"))
+
+    async def test_filter_by_project_version(self):
+        """Test filtering projects by version."""
+        self.set_source_parameter("project_versions", ["1.2", "1.3"])
+        response = await self.collect(get_request_json_return_value=self.projects())
+        self.assert_measurement(response, value="0", entities=[])
+
+    async def test_filter_by_project_name_and_version(self):
+        """Test filtering projects by name and version."""
+        self.set_source_parameter("project_names", ["project .*"])
+        self.set_source_parameter("project_versions", ["1.3", "1.4"])
+        response = await self.collect(get_request_json_side_effect=[self.projects(), self.dependencies("1.0")])
+        self.assert_measurement(response, value="1", entities=self.entities("1.0", "up-to-date"))

--- a/components/collector/tests/source_collectors/dependency_track/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_source_up_to_dateness.py
@@ -4,6 +4,8 @@ from datetime import datetime, timedelta
 
 from dateutil.tz import tzlocal
 
+from source_collectors.dependency_track.base import DependencyTrackProject
+
 from tests.source_collectors.source_collector_test_case import SourceCollectorTestCase
 
 
@@ -13,35 +15,63 @@ class DependencyTrackSourceUpToDatenessVersionTest(SourceCollectorTestCase):
     METRIC_ADDITION = "min"
     METRIC_TYPE = "source_up_to_dateness"
     SOURCE_TYPE = "dependency_track"
+    LANDING_URL = "https://dependency_track"
+
+    def projects(self) -> list[DependencyTrackProject]:
+        """Create Dependency-Track projects fixture."""
+        now = datetime.now(tz=tzlocal()).replace(microsecond=0)
+        self.yesterday = now - timedelta(days=1)
+        yesterday_timestamp = round(self.yesterday.timestamp() * 1000)
+        self.last_week = now - timedelta(days=7)
+        last_week_timestamp = round(self.last_week.timestamp() * 1000)
+        return [
+            DependencyTrackProject(name="Project 1", version="1.1", uuid="p1", lastBomImport=yesterday_timestamp),
+            DependencyTrackProject(name="Project 2", version="1.2", uuid="p2", lastBomImport=last_week_timestamp),
+        ]
+
+    def entities(self) -> list[dict[str, str]]:
+        """Create the expected entities."""
+        return [
+            {
+                "key": "p1",
+                "last_bom_import": self.yesterday.isoformat(),
+                "project": "Project 1",
+                "project_landing_url": "/projects/p1",
+            },
+            {
+                "key": "p2",
+                "last_bom_import": self.last_week.isoformat(),
+                "project": "Project 2",
+                "project_landing_url": "/projects/p2",
+            },
+        ]
 
     async def test_source_up_to_dateness(self):
         """Test that the source up-to-dateness can be measured."""
-        now = datetime.now(tz=tzlocal()).replace(microsecond=0)
-        yesterday = now - timedelta(days=1)
-        yesterday_timestamp = yesterday.timestamp() * 1000  # To be prepared, test a timestamp that is a float...
-        last_week = now - timedelta(days=7)
-        last_week_timestamp = str(int(last_week.timestamp() * 1000))  # ... and test a string containing an integer
-        projects = [
-            {"name": "Project 1", "lastBomImport": yesterday_timestamp, "uuid": "p1"},
-            {"name": "Project 2", "lastBomImport": str(int(last_week_timestamp)), "uuid": "p2"},
-        ]
-        response = await self.collect(get_request_json_return_value=projects)
-        self.assert_measurement(
-            response,
-            value="7",
-            landing_url="https://dependency_track",
-            entities=[
-                {
-                    "key": "p1",
-                    "last_bom_import": yesterday.isoformat(),
-                    "project": "Project 1",
-                    "project_landing_url": "/projects/p1",
-                },
-                {
-                    "key": "p2",
-                    "last_bom_import": last_week.isoformat(),
-                    "project": "Project 2",
-                    "project_landing_url": "/projects/p2",
-                },
-            ],
-        )
+        response = await self.collect(get_request_json_return_value=self.projects())
+        self.assert_measurement(response, value="7", landing_url=self.LANDING_URL, entities=self.entities())
+
+    async def test_filter_by_project_name(self):
+        """Test that projects can be filtered by name."""
+        self.set_source_parameter("project_names", ["other project"])
+        response = await self.collect(get_request_json_return_value=self.projects())
+        self.assert_measurement(response, parse_error="No projects found")
+
+    async def test_filter_by_regular_expression(self):
+        """Test that projects can be filtered by regular expression."""
+        self.set_source_parameter("project_names", ["Project .*"])
+        response = await self.collect(get_request_json_return_value=self.projects())
+        self.assert_measurement(response, value="7", landing_url=self.LANDING_URL, entities=self.entities())
+
+    async def test_filter_by_project_version(self):
+        """Test filtering projects by version."""
+        self.set_source_parameter("project_versions", ["1.2", "1.3"])
+        response = await self.collect(get_request_json_return_value=self.projects())
+        self.assert_measurement(response, value="7", landing_url=self.LANDING_URL, entities=self.entities()[1:])
+
+    async def test_filter_by_project_name_and_version(self):
+        """Test filtering projects by name and version."""
+        self.set_source_parameter("project_names", ["Project .*"])
+        self.set_source_parameter("project_versions", ["1.3", "1.4"])
+        response = await self.collect(get_request_json_return_value=self.projects())
+        self.assert_measurement(response, parse_error="No projects found")

--- a/components/shared_code/src/shared_data_model/sources/dependency_track.py
+++ b/components/shared_code/src/shared_data_model/sources/dependency_track.py
@@ -4,7 +4,14 @@ from pydantic import HttpUrl
 
 from shared_data_model.meta.entity import Color, Entity, EntityAttribute, EntityAttributeType
 from shared_data_model.meta.source import Source
-from shared_data_model.parameters import URL, LandingURL, MultipleChoiceParameter, PrivateToken, Severities
+from shared_data_model.parameters import (
+    URL,
+    LandingURL,
+    MultipleChoiceParameter,
+    MultipleChoiceWithAdditionParameter,
+    PrivateToken,
+    Severities,
+)
 
 ALL_DEPENDENCY_TRACK_METRICS = ["dependencies", "security_warnings", "source_up_to_dateness", "source_version"]
 DEPENDENCY_TRACK_URL = HttpUrl("https://dependencytrack.org")
@@ -36,6 +43,18 @@ DEPENDENCY_TRACK = Source(
             name="API key",
             help_url=HttpUrl("https://docs.dependencytrack.org/integrations/rest-api/"),
             metrics=["dependencies", "source_up_to_dateness", "security_warnings"],
+        ),
+        "project_names": MultipleChoiceWithAdditionParameter(
+            name="Project names (regular expressions or project names)",
+            placeholder="all project names",
+            short_name="project names",
+            metrics=["dependencies", "security_warnings", "source_up_to_dateness"],
+        ),
+        "project_versions": MultipleChoiceWithAdditionParameter(
+            name="Project versions (regular expressions or versions)",
+            placeholder="all project versions",
+            short_name="project versions",
+            metrics=["dependencies", "security_warnings", "source_up_to_dateness"],
         ),
         "latest_version_status": MultipleChoiceParameter(
             name="Latest version statuses",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -20,6 +20,10 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 - Hiding metrics without issues would not hide metrics with deleted issues. Fixes [#8699](https://github.com/ICTU/quality-time/issues/8699).
 - The spinner indicating that the latest measurement of a metric is not up-to-date with the latest source configuration would not disappear if the measurement value made with the latest source configuration was equal to the measurement value made with the previous source configuration. Fixes [#8702](https://github.com/ICTU/quality-time/issues/8702).
 
+### Added
+
+- When using Dependency-Track as source for dependencies, security warnings, or source-up-to-dateness, allow for filtering by project name and version. Closes [#8686](https://github.com/ICTU/quality-time/issues/8686).
+
 ## v5.12.0 - 2024-05-17
 
 ### Deployment notes


### PR DESCRIPTION
When using Dependency-Track as source for dependencies, security warnings, or source-up-to-dateness, allow for filtering by project name or identifier.

Closes #8686.