### PR TITLE
Fix measurement spinner not disappearing.

### DIFF
--- a/components/collector/tests/database/test_measurements.py
+++ b/components/collector/tests/database/test_measurements.py
@@ -14,7 +14,12 @@ class TestMeasurements(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up fixtures."""
-        self.measurement_data = {
+        self.client: mongomock.MongoClient = mongomock.MongoClient()
+        self.database = self.client["quality_time_db"]
+
+    def measurement_data(self, first_seen: str = "2023-07-18", source_parameter_hash: str = "hash") -> dict:
+        """Create the measurement data."""
+        return {
             "start": "2023-07-19T16:50:47+00:000",
             "end": "2023-07-19T16:50:47+00:001",
             "has_error": False,
@@ -28,19 +33,18 @@ class TestMeasurements(unittest.TestCase):
                     "connection_error": None,
                     "value": "10",
                     "total": "100",
-                    "entities": [{"key": "key", "first_seen": "2023-07-18"}],
+                    "entities": [{"key": "key", "first_seen": first_seen}],
                 },
             ],
             "metric_uuid": METRIC_ID,
             "report_uuid": REPORT_ID,
+            "source_parameter_hash": source_parameter_hash,
         }
-        self.client: mongomock.MongoClient = mongomock.MongoClient()
-        self.database = self.client["quality_time_db"]
 
     def test_create_measurement_without_latest_measurement(self):
         """Test that create_measurement without a latest measurement inserts a new measurement."""
         self.database["reports"].insert_one(create_report(report_uuid=REPORT_ID))
-        create_measurement(self.database, self.measurement_data)
+        create_measurement(self.database, self.measurement_data())
         self.assertEqual(1, len(list(self.database.measurements.find())))
 
     def test_create_measurement_with_latest_measurement(self):
@@ -54,12 +58,12 @@ class TestMeasurements(unittest.TestCase):
                 ],
             },
         )
-        create_measurement(self.database, self.measurement_data)
+        create_measurement(self.database, self.measurement_data())
         self.assertEqual(2, len(list(self.database.measurements.find())))
 
     def test_create_measurement_with_no_latest_metric(self):
         """Test that create_measurement does not insert new measurement when the metric does not exist."""
-        create_measurement(self.database, self.measurement_data)
+        create_measurement(self.database, self.measurement_data())
         self.assertEqual(0, len(list(self.database.measurements.find())))
 
     def test_create_measurement_without_source(self):
@@ -67,22 +71,28 @@ class TestMeasurements(unittest.TestCase):
         report = create_report(report_uuid=REPORT_ID)
         del report["subjects"][SUBJECT_ID]["metrics"][METRIC_ID]["sources"][SOURCE_ID]
         self.database["reports"].insert_one(report)
-        create_measurement(self.database, self.measurement_data)
+        create_measurement(self.database, self.measurement_data())
         self.assertEqual(0, len(list(self.database.measurements.find())))
 
     def test_create_measurement_when_its_equal(self):
         """Test that create_measurement with equal measurement does not insert new measurement."""
         self.database["reports"].insert_one(create_report(report_uuid=REPORT_ID))
-        create_measurement(self.database, self.measurement_data)
-        create_measurement(self.database, self.measurement_data)
+        create_measurement(self.database, self.measurement_data())
+        create_measurement(self.database, self.measurement_data())
         self.assertEqual(1, len(list(self.database.measurements.find())))
+
+    def test_create_measurement_with_changed_source_parameter(self):
+        """Test that create_measurement create a new measurement if the source parameters changed."""
+        self.database["reports"].insert_one(create_report(report_uuid=REPORT_ID))
+        create_measurement(self.database, self.measurement_data())
+        create_measurement(self.database, self.measurement_data(source_parameter_hash="new hash"))
+        self.assertEqual(2, len(list(self.database.measurements.find())))
 
     def test_copy_first_seen_timestamps(self):
         """Test that the first seen timestamps are copied from the latest successful measurement."""
         self.database["reports"].insert_one(create_report(report_uuid=REPORT_ID))
-        create_measurement(self.database, self.measurement_data)
-        self.measurement_data["sources"][0]["entities"][0]["first_seen"] = "2023-07-19"
-        create_measurement(self.database, self.measurement_data)
+        create_measurement(self.database, self.measurement_data())
+        create_measurement(self.database, self.measurement_data(first_seen="2023-07-19"))
         self.assertEqual(
             "2023-07-18",
             next(self.database.measurements.find())["sources"][0]["entities"][0]["first_seen"],

--- a/components/shared_code/src/shared/model/measurement.py
+++ b/components/shared_code/src/shared/model/measurement.py
@@ -216,7 +216,8 @@ class Measurement(dict):
         scales_equal = all(self[scale] == other[scale] for scale in self.metric.scales())
         issues_statuses_equal = other.get("issue_status") == self.get("issue_status")
         sources_equal = other.sources() == self.sources()
-        return scales_equal and issues_statuses_equal and sources_equal
+        source_parameter_hashes_equal = other.source_parameter_hash() == self.source_parameter_hash()
+        return scales_equal and issues_statuses_equal and sources_equal and source_parameter_hashes_equal
 
     def debt_target_expired(self) -> bool:
         """Return whether the technical debt target is expired.
@@ -297,8 +298,12 @@ class Measurement(dict):
 
     def summarize_latest(self) -> Self:
         """Return a summary of this measurement, given that it is the latest measurement."""
-        if parameter_hash := self.get("source_parameter_hash"):  # pragma: no feature-test-cover
+        if parameter_hash := self.source_parameter_hash():  # pragma: no feature-test-cover
             if parameter_hash != self.metric.source_parameter_hash():
                 self["outdated"] = True
             del self["source_parameter_hash"]
         return self
+
+    def source_parameter_hash(self) -> str:
+        """Return the source parameter hash of this measurement."""
+        return str(self.get("source_parameter_hash", ""))

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 ### Fixed
 
 - Hiding metrics without issues would not hide metrics with deleted issues. Fixes [#8699](https://github.com/ICTU/quality-time/issues/8699).
+- The spinner indicating that the latest measurement of a metric is not up-to-date with the latest source configuration would not disappear if the measurement value made with the latest source configuration was equal to the measurement value made with the previous source configuration. Fixes [#8702](https://github.com/ICTU/quality-time/issues/8702).
 
 ## v5.12.0 - 2024-05-17
 


### PR DESCRIPTION
The spinner indicating that the latest measurement of a metric is not up-to-date with the latest source configuration would not disappear if the measurement value made with the latest source configuration was equal to the measurement value made with the previous source configuration.

Fixes #8702.