### PR TITLE
Fix error message on issue creation failure.

### DIFF
--- a/components/api_server/src/model/issue_tracker.py
+++ b/components/api_server/src/model/issue_tracker.py
@@ -127,8 +127,9 @@ class IssueTracker:
         try:
             response_json = self.__post_json(api_url, json)
         except Exception as reason:
-            logging.warning("Creating a new issue at %s failed: %s", api_url, reason)
-            return "", str(reason)
+            error = str(reason) if str(reason) else reason.__class__.__name__
+            logging.warning("Creating a new issue at %s failed: %s", api_url, error)
+            return "", error
         return response_json["key"], ""  # pragma: no feature-test-cover
 
     def get_options(self) -> Options:  # pragma: no feature-test-cover

--- a/components/api_server/tests/model/test_issue_tracker.py
+++ b/components/api_server/tests/model/test_issue_tracker.py
@@ -96,3 +96,17 @@ class IssueTrackerTest(unittest.TestCase):
         """Test that without a URL an error message is returned."""
         issue_tracker = IssueTracker("", self.issue_parameters)
         self.assertEqual(("", "Issue tracker has no URL configured."), issue_tracker.create_issue(self.ISSUE_SUMMARY))
+
+    @disable_logging
+    @patch("requests.post")
+    def test_create_issue_with_exception(self, requests_post):
+        """Test that the exception is returned when something goes wrong."""
+        requests_post.side_effect = [OSError("Something went wrong")]
+        self.assertEqual(("", "Something went wrong"), self.issue_tracker.create_issue(self.ISSUE_SUMMARY))
+
+    @disable_logging
+    @patch("requests.post")
+    def test_create_issue_with_empty_exception(self, requests_post):
+        """Test that the exception is returned when something goes wrong."""
+        requests_post.side_effect = [OSError]
+        self.assertEqual(("", "OSError"), self.issue_tracker.create_issue(self.ISSUE_SUMMARY))

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 
 ### Fixed
 
+- When creating an issue fails, show the reason in the toaster message instead of "undefined". Fixes [#8567](https://github.com/ICTU/quality-time/issues/8567).
 - Hiding metrics without issues would not hide metrics with deleted issues. Fixes [#8699](https://github.com/ICTU/quality-time/issues/8699).
 
 ## v5.12.0 - 2024-05-17


### PR DESCRIPTION
When creating an issue fails, show the reason in the toaster message instead of "undefined".

Fixes #8567.