### PR TITLE
Show spinner on first edit of source parameters.

### DIFF
--- a/components/api_server/src/initialization/migrations.py
+++ b/components/api_server/src/initialization/migrations.py
@@ -2,32 +2,39 @@
 
 import logging
 
+import pymongo
+from pymongo.collection import Collection
 from pymongo.database import Database
+
+from shared.model.metric import Metric
 
 
 def perform_migrations(database: Database) -> None:  # pragma: no feature-test-cover
     """Perform database migrations."""
-    change_accessibility_violation_metrics_to_violations(database)
-    fix_branch_parameters_without_value(database)
+    for report in database.reports.find(filter={"last": True, "deleted": {"$exists": False}}):
+        change_accessibility_violation_metrics_to_violations(database, report)
+        fix_branch_parameters_without_value(database, report)
+        add_source_parameter_hash(database, report)
 
 
-def change_accessibility_violation_metrics_to_violations(database: Database) -> None:  # pragma: no feature-test-cover
+def change_accessibility_violation_metrics_to_violations(  # pragma: no feature-test-cover
+    database: Database, report
+) -> None:
     """Replace accessibility metrics with the violations metric."""
     # Added after Quality-time v5.5.0, see https://github.com/ICTU/quality-time/issues/562
-    for report in database.reports.find(filter={"last": True, "deleted": {"$exists": False}}):
-        report_uuid = report["report_uuid"]
-        logging.info("Checking report for accessibility metrics: %s", report_uuid)
-        changed = False
-        for subject in report["subjects"].values():
-            for metric in subject["metrics"].values():
-                if metric["type"] == "accessibility":
-                    change_accessibility_violations_metric_to_violations(metric)
-                    changed = True
-        if changed:
-            logging.info("Updating report to change its accessibility metrics to violations metrics: %s", report_uuid)
-            replace_report(database, report)
-        else:
-            logging.info("No accessibility metrics found in report: %s", report_uuid)
+    report_uuid = report["report_uuid"]
+    logging.info("Checking report for accessibility metrics: %s", report_uuid)
+    changed = False
+    for subject in report["subjects"].values():
+        for metric in subject["metrics"].values():
+            if metric["type"] == "accessibility":
+                change_accessibility_violations_metric_to_violations(metric)
+                changed = True
+    if changed:
+        logging.info("Updating report to change its accessibility metrics to violations metrics: %s", report_uuid)
+        replace_document(database.reports, report)
+    else:
+        logging.info("No accessibility metrics found in report: %s", report_uuid)
 
 
 def change_accessibility_violations_metric_to_violations(metric: dict) -> None:  # pragma: no feature-test-cover
@@ -39,22 +46,21 @@ def change_accessibility_violations_metric_to_violations(metric: dict) -> None: 
         metric["unit"] = "accessibility violations"
 
 
-def fix_branch_parameters_without_value(database: Database) -> None:  # pragma: no feature-test-cover
+def fix_branch_parameters_without_value(database: Database, report) -> None:  # pragma: no feature-test-cover
     """Set the branch parameter of sources to 'master' (the previous default) if they have no value."""
     # Added after Quality-time v5.11.0, see https://github.com/ICTU/quality-time/issues/8045
-    for report in database.reports.find(filter={"last": True, "deleted": {"$exists": False}}):
-        report_uuid = report["report_uuid"]
-        logging.info("Checking report for sources with empty branch parameters: %s", report_uuid)
-        changed = False
-        for source in sources_with_branch_parameter(report):
-            if not source["parameters"].get("branch"):
-                source["parameters"]["branch"] = "master"
-                changed = True
-        if changed:
-            logging.info("Updating report to change sources with empty branch parameter: %s", report_uuid)
-            replace_report(database, report)
-        else:
-            logging.info("No sources with empty branch parameters found in report: %s", report_uuid)
+    report_uuid = report["report_uuid"]
+    logging.info("Checking report for sources with empty branch parameters: %s", report_uuid)
+    changed = False
+    for source in sources_with_branch_parameter(report):
+        if not source["parameters"].get("branch"):
+            source["parameters"]["branch"] = "master"
+            changed = True
+    if changed:
+        logging.info("Updating report to change sources with empty branch parameter: %s", report_uuid)
+        replace_document(database.reports, report)
+    else:
+        logging.info("No sources with empty branch parameters found in report: %s", report_uuid)
 
 
 METRICS_WITH_SOURCES_WITH_BRANCH_PARAMETER = {
@@ -87,8 +93,25 @@ def sources_with_branch_parameter(report: dict):  # pragma: no feature-test-cove
                         yield source
 
 
-def replace_report(database: Database, report) -> None:  # pragma: no feature-test-cover
-    """Replace the report in the database."""
-    report_id = report["_id"]
-    del report["_id"]
-    database.reports.replace_one({"_id": report_id}, report)
+def add_source_parameter_hash(database: Database, report) -> None:  # pragma: no feature-test-cover
+    """Add source parameter hashes to the latest measurements."""
+    # Added after Quality-time v5.12.0, see https://github.com/ICTU/quality-time/issues/8736
+    for subject in report["subjects"].values():
+        for metric_uuid, metric in subject["metrics"].items():
+            latest_measurement = database.measurements.find_one(
+                filter={"metric_uuid": metric_uuid},
+                sort=[("start", pymongo.DESCENDING)],
+            )
+            if not latest_measurement:
+                continue
+            if latest_measurement.get("source_parameter_hash"):
+                continue
+            latest_measurement["source_parameter_hash"] = Metric({}, metric, metric_uuid).source_parameter_hash()
+            replace_document(database.measurements, latest_measurement)
+
+
+def replace_document(collection: Collection, document) -> None:  # pragma: no feature-test-cover
+    """Replace the document in the collection."""
+    document_id = document["_id"]
+    del document["_id"]
+    collection.replace_one({"_id": document_id}, document)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,6 +19,7 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 - When creating an issue fails, show the reason in the toaster message instead of "undefined". Fixes [#8567](https://github.com/ICTU/quality-time/issues/8567).
 - Hiding metrics without issues would not hide metrics with deleted issues. Fixes [#8699](https://github.com/ICTU/quality-time/issues/8699).
 - The spinner indicating that the latest measurement of a metric is not up-to-date with the latest source configuration would not disappear if the measurement value made with the latest source configuration was equal to the measurement value made with the previous source configuration. Fixes [#8702](https://github.com/ICTU/quality-time/issues/8702).
+- The spinner indicating that the latest measurement of a metric is not up-to-date with the latest source configuration would not appear on the first edit of a metric after upgrading to v5.12.0. Fixes [#8736](https://github.com/ICTU/quality-time/issues/8736).
 
 ### Added
 


### PR DESCRIPTION
The spinner indicating that the latest measurement of a metric is not up-to-date with the latest source configuration would not appear on the first edit of a metric after upgrading to v5.12.0.

Fixes #8736.