### PR TITLE
Fix measurement entity status menu items.

### DIFF
--- a/components/frontend/src/report/ReportTitle.js
+++ b/components/frontend/src/report/ReportTitle.js
@@ -5,7 +5,6 @@ import { delete_report, set_report_attribute } from "../api/report"
 import { activeTabIndex, tabChangeHandler } from "../app_ui_settings"
 import { ChangeLog } from "../changelog/ChangeLog"
 import { EDIT_REPORT_PERMISSION, ReadOnlyOrEditable } from "../context/Permissions"
-import { defaultDesiredResponseTimes } from "../defaults"
 import { Comment } from "../fields/Comment"
 import { IntegerInput } from "../fields/IntegerInput"
 import { StringInput } from "../fields/StringInput"
@@ -13,7 +12,7 @@ import { NotificationDestinations } from "../notification/NotificationDestinatio
 import { Label, Segment, Tab } from "../semantic_ui_react_wrappers"
 import { Share } from "../share/Share"
 import { reportPropType, settingsPropType } from "../sharedPropTypes"
-import { STATUS_DESCRIPTION, STATUS_NAME } from "../utils"
+import { getDesiredResponseTime, STATUS_DESCRIPTION, STATUS_NAME } from "../utils"
 import { DeleteButton } from "../widgets/Button"
 import { FocusableTab } from "../widgets/FocusableTab"
 import { HeaderWithDetails } from "../widgets/HeaderWithDetails"
@@ -92,7 +91,7 @@ function ReactionTimes({ reload, report }) {
                                     )
                                 }}
                                 unit="days"
-                                value={desiredResponseTimes["unknown"] ?? defaultDesiredResponseTimes["unknown"]}
+                                value={getDesiredResponseTime(report, "unknown")}
                             />
                         </Grid.Column>
                         <Grid.Column>
@@ -116,10 +115,7 @@ function ReactionTimes({ reload, report }) {
                                     )
                                 }}
                                 unit="days"
-                                value={
-                                    desiredResponseTimes["target_not_met"] ??
-                                    defaultDesiredResponseTimes["target_not_met"]
-                                }
+                                value={getDesiredResponseTime(report, "target_not_met")}
                             />
                         </Grid.Column>
                         <Grid.Column>
@@ -143,10 +139,7 @@ function ReactionTimes({ reload, report }) {
                                     )
                                 }}
                                 unit="days"
-                                value={
-                                    desiredResponseTimes["near_target_met"] ??
-                                    defaultDesiredResponseTimes["near_target_met"]
-                                }
+                                value={getDesiredResponseTime(report, "near_target_met")}
                             />
                         </Grid.Column>
                         <Grid.Column>
@@ -171,10 +164,7 @@ function ReactionTimes({ reload, report }) {
                                     )
                                 }}
                                 unit="days"
-                                value={
-                                    desiredResponseTimes["debt_target_met"] ??
-                                    defaultDesiredResponseTimes["debt_target_met"]
-                                }
+                                value={getDesiredResponseTime(report, "debt_target_met")}
                             />
                         </Grid.Column>
                     </Grid.Row>
@@ -207,7 +197,7 @@ function ReactionTimes({ reload, report }) {
                                     )
                                 }}
                                 unit="days"
-                                value={desiredResponseTimes["confirmed"] ?? defaultDesiredResponseTimes["confirmed"]}
+                                value={getDesiredResponseTime(report, "confirmed")}
                             />
                         </Grid.Column>
                         <Grid.Column>
@@ -231,7 +221,7 @@ function ReactionTimes({ reload, report }) {
                                     )
                                 }}
                                 unit="days"
-                                value={desiredResponseTimes["fixed"] ?? defaultDesiredResponseTimes["fixed"]}
+                                value={getDesiredResponseTime(report, "fixed")}
                             />
                         </Grid.Column>
                         <Grid.Column>
@@ -255,10 +245,7 @@ function ReactionTimes({ reload, report }) {
                                     )
                                 }}
                                 unit="days"
-                                value={
-                                    desiredResponseTimes["false_positive"] ??
-                                    defaultDesiredResponseTimes["false_positive"]
-                                }
+                                value={getDesiredResponseTime(report, "false_positive")}
                             />
                         </Grid.Column>
                         <Grid.Column>
@@ -282,7 +269,7 @@ function ReactionTimes({ reload, report }) {
                                     )
                                 }}
                                 unit="days"
-                                value={desiredResponseTimes["wont_fix"] ?? defaultDesiredResponseTimes["wont_fix"]}
+                                value={getDesiredResponseTime(report, "wont_fix")}
                             />
                         </Grid.Column>
                     </Grid.Row>

--- a/components/frontend/src/source/SourceEntityDetails.js
+++ b/components/frontend/src/source/SourceEntityDetails.js
@@ -7,7 +7,7 @@ import { DateInput } from "../fields/DateInput"
 import { SingleChoiceInput } from "../fields/SingleChoiceInput"
 import { TextInput } from "../fields/TextInput"
 import { entityPropType, entityStatusPropType, reportPropType } from "../sharedPropTypes"
-import { capitalize } from "../utils"
+import { capitalize, getDesiredResponseTime } from "../utils"
 import { LabelWithDate } from "../widgets/LabelWithDate"
 import { source_entity_status_name as status_name } from "./source_entity_status"
 
@@ -27,12 +27,11 @@ entityStatusOption.propTypes = {
 }
 
 function entityStatusOptions(entityType, report) {
-    const desiredResponseTimes = report?.desired_response_times ?? {}
     const unconfirmedSubheader = `This ${entityType} should be reviewed to decide what to do with it.`
-    const confirmedSubheader = `This ${entityType} has been reviewed and should be dealt with within ${desiredResponseTimes["confirmed"]} days.`
-    const fixedSubheader = `Ignore this ${entityType} for ${desiredResponseTimes["fixed"]} days because it has been fixed or will be fixed shortly.`
-    const falsePositiveSubheader = `Ignore this ${entityType} for ${desiredResponseTimes["false_positive"]} days because it's been incorrectly identified as ${entityType}.`
-    const wontFixSubheader = `Ignore this ${entityType} for ${desiredResponseTimes["wont_fix"]} days because it will not be fixed.`
+    const confirmedSubheader = `This ${entityType} has been reviewed and should be addressed within ${getDesiredResponseTime(report, "confirmed")} days.`
+    const fixedSubheader = `Ignore this ${entityType} for ${getDesiredResponseTime(report, "fixed")} days because it has been fixed or will be fixed shortly.`
+    const falsePositiveSubheader = `Ignore this "${entityType}" for ${getDesiredResponseTime(report, "false_positive")} days because it has been incorrectly identified as ${entityType}.`
+    const wontFixSubheader = `Ignore this ${entityType} for ${getDesiredResponseTime(report, "wont_fix")} days because it will not be fixed.`
     return [
         entityStatusOption("unconfirmed", status_name.unconfirmed, "Unconfirm", unconfirmedSubheader),
         entityStatusOption("confirmed", status_name.confirmed, "Confirm", confirmedSubheader),

--- a/components/frontend/src/source/SourceEntityDetails.test.js
+++ b/components/frontend/src/source/SourceEntityDetails.test.js
@@ -26,6 +26,20 @@ function renderSourceEntityDetails() {
     )
 }
 
+it("shows the default desired response times when the report has no desired response times", () => {
+    renderSourceEntityDetails()
+    fireEvent.click(screen.getByText(/Unconfirmed/))
+    const expectedMenuItemDescriptions = [
+        "This violation has been reviewed and should be addressed within 180 days.",
+        "Ignore this violation for 7 days because it has been fixed or will be fixed shortly.",
+        'Ignore this "violation" for 180 days because it has been incorrectly identified as violation.',
+        "Ignore this violation for 180 days because it will not be fixed.",
+    ]
+    expectedMenuItemDescriptions.forEach((description) => {
+        expect(screen.queryAllByText(description).length).toBe(1)
+    })
+})
+
 it("changes the entity status", () => {
     source.set_source_entity_attribute = jest.fn()
     renderSourceEntityDetails()

--- a/components/frontend/src/utils.js
+++ b/components/frontend/src/utils.js
@@ -96,7 +96,7 @@ export function getMetricResponseDeadline(metric, report) {
         }
     } else if (status in defaultDesiredResponseTimes && metric.status_start) {
         deadline = new Date(metric.status_start)
-        deadline.setDate(deadline.getDate() + getMetricDesiredResponseTime(report, status))
+        deadline.setDate(deadline.getDate() + getDesiredResponseTime(report, status))
     }
     return deadline
 }
@@ -132,7 +132,7 @@ export function getMetricResponseOverrun(metric_uuid, metric, report, measuremen
     consolidatedMeasurements.forEach((measurement) => {
         const status = measurement?.[scale]?.status || "unknown"
         if (status in defaultDesiredResponseTimes) {
-            const desiredResponseTime = getMetricDesiredResponseTime(report, status) * MILLISECONDS_PER_DAY
+            const desiredResponseTime = getDesiredResponseTime(report, status) * MILLISECONDS_PER_DAY
             const actualResponseTime = new Date(measurement.end).getTime() - new Date(measurement.start).getTime()
             const overrun = Math.max(0, actualResponseTime - desiredResponseTime)
             if (overrun > 0) {
@@ -151,7 +151,7 @@ export function getMetricResponseOverrun(metric_uuid, metric, report, measuremen
     return { totalOverrun: days(totalOverrun), overruns: overruns }
 }
 
-function getMetricDesiredResponseTime(report, status) {
+export function getDesiredResponseTime(report, status) {
     // Precondition: status is a key of defaultDesiredResponseTimes
     return report?.desired_response_times?.[status] ?? defaultDesiredResponseTimes[status]
 }

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -21,6 +21,7 @@ If your currently installed *Quality-time* version is v4.10.0 or older, please r
 ### Added
 
 - Group digits in numbers. Closes [#8076](https://github.com/ICTU/quality-time/issues/8076).
+- In the measurement entity status menu, the description of the menu items would say "undefined days" if the desired response time for the status had not been changed from its default value. Fixes [#8284](https://github.com/ICTU/quality-time/issues/8284).
 
 ## v5.13.0 - 2024-05-23
 


### PR DESCRIPTION
In the measurement entity status menu, the description of the menu items would say "undefined days" if the desired response time for the status had not been changed from its default value.

Fixes #8284.