### PR TITLE
Remove dead code and fix Sonarcloud issues.

### DIFF
--- a/components/frontend/src/fields/TextInput.js
+++ b/components/frontend/src/fields/TextInput.js
@@ -19,7 +19,7 @@ ReadOnlyTextInput.propTypes = {
 }
 
 function EditableTextInput(props) {
-    let { editableLabel, label, required, set_value, ...otherProps } = props
+    let { label, required, set_value, ...otherProps } = props
     const initialValue = props.value || ""
     const [text, setText] = useState(initialValue)
 
@@ -44,7 +44,7 @@ function EditableTextInput(props) {
             <Form.TextArea
                 {...otherProps}
                 error={required && text === ""}
-                label={editableLabel || label}
+                label={label}
                 onBlur={submit}
                 onChange={(event) => setText(event.target.value)}
                 onKeyDown={onKeyDown}
@@ -55,7 +55,6 @@ function EditableTextInput(props) {
     )
 }
 EditableTextInput.propTypes = {
-    editableLabel: labelPropType,
     label: labelPropType,
     required: bool,
     set_value: func,

--- a/components/frontend/src/fields/TextInput.test.js
+++ b/components/frontend/src/fields/TextInput.test.js
@@ -74,8 +74,3 @@ it("shows the label", () => {
     render(<TextInput label="Label" />)
     expect(screen.queryByText("Label")).not.toBe(null)
 })
-
-it("shows the editable label", () => {
-    render(<TextInput editableLabel="Label" />)
-    expect(screen.queryByText("Label")).not.toBe(null)
-})

--- a/components/frontend/src/header_footer/Menubar.js
+++ b/components/frontend/src/header_footer/Menubar.js
@@ -179,13 +179,13 @@ export function Menubar({
                                 event.preventDefault()
                                 setSettingsPanelVisible(!settingsPanelVisible)
                             }}
-                            tabIndex={0}
                         >
                             <Menu.Item
                                 onClick={(event) => {
                                     event.stopPropagation()
                                     setSettingsPanelVisible(!settingsPanelVisible)
                                 }}
+                                tabIndex={0}
                             >
                                 <Icon size="large" name={`caret ${settingsPanelVisible ? "down" : "right"}`} />
                                 Settings

--- a/components/frontend/src/widgets/TableRowWithDetails.css
+++ b/components/frontend/src/widgets/TableRowWithDetails.css
@@ -1,0 +1,3 @@
+.ui.basic.button.expandcollapse:not(:hover, :focus) {
+    box-shadow: 0 0 0 0px transparent;
+}

--- a/components/frontend/src/widgets/TableRowWithDetails.js
+++ b/components/frontend/src/widgets/TableRowWithDetails.js
@@ -1,6 +1,8 @@
+import "./TableRowWithDetails.css"
+
 import { bool, func, object } from "prop-types"
 
-import { Icon, Table } from "../semantic_ui_react_wrappers"
+import { Button, Icon, Table } from "../semantic_ui_react_wrappers"
 import { childrenPropType } from "../sharedPropTypes"
 
 export function TableRowWithDetails(props) {
@@ -8,20 +10,14 @@ export function TableRowWithDetails(props) {
     return (
         <>
             <Table.Row {...otherProps}>
-                <Table.Cell
-                    aria-label="Expand/collapse"
-                    collapsing
-                    onClick={() => onExpand(!expanded)}
-                    onKeyPress={(event) => {
-                        event.preventDefault()
-                        onExpand(!expanded)
-                    }}
-                    tabIndex="0"
-                    textAlign="center"
-                    style={style}
-                    role="button"
-                >
-                    <Icon size="large" name={expanded ? "caret down" : "caret right"} />
+                <Table.Cell collapsing textAlign="center" style={style}>
+                    <Button
+                        aria-label="Expand/collapse"
+                        basic
+                        className="expandcollapse"
+                        icon={<Icon name={expanded ? "caret down" : "caret right"} size="large" />}
+                        onClick={() => onExpand(!expanded)}
+                    />
                 </Table.Cell>
                 {children}
             </Table.Row>


### PR DESCRIPTION
- Remove the `editableLabel` prop of `EditableTextInput`, it's not used anywhere.
- Move the `tabIndex` from the `div` containing the Settings menu item to the menu item itself, where it belongs. 
- Instead of having the first table cell of the `TableRowWithDetails` pretending it is a button, give it a proper button. This should improve accessibility. Also add some styling to only show the button appearance when the button has focus or is hovered so that the subject table does not get cluttered with a whole column of expand/collapse buttons.