### PR TITLE
Set the MongoDB feature compatibility version to v7.

### DIFF
--- a/components/api_server/src/initialization/database.py
+++ b/components/api_server/src/initialization/database.py
@@ -38,7 +38,7 @@ def set_feature_compatibility_version(admin_database: Database) -> None:
 
     See https://docs.mongodb.com/manual/reference/command/setFeatureCompatibilityVersion/
     """
-    admin_database.command("setFeatureCompatibilityVersion", "6.0", confirm=True)
+    admin_database.command("setFeatureCompatibilityVersion", "7.0", confirm=True)
 
 
 def create_indexes(database: Database) -> None:

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -35,6 +35,7 @@ If your currently installed *Quality-time* version is not v5.13.0, please first 
 
   In addition:
   - A new parameter 'clean code attributes category' is added.
+- Set the MongoDB feature compatibility version to v7. Closes [#8896](https://github.com/ICTU/quality-time/issues/8896).
 
 ## v5.13.0 - 2024-05-23
 

--- a/docs/src/versioning.md
+++ b/docs/src/versioning.md
@@ -21,7 +21,7 @@ The table below contains the *Quality-time* releases since the last minor of the
 
 | Version    | Date         | Mongo  | FC     | Migrations | Downgrade      | Upgrade         |
 |------------|--------------|--------|--------|------------|----------------|-----------------|
-| v5.14.0    | (unreleased) | v7     | v6     | added      | not possible   | n/a             |
+| v5.14.0    | (unreleased) | v7     | **v7** | added      | not possible   | n/a             |
 | v5.13.0    | 2024-05-23   | v7     | v6     | added      | not possible   | v5.14.0         |
 | v5.12.0    | 2024-05-17   | v7     | v6     | added      | not possible   | v5.13.0-v5.14.0 |
 | v5.11.0    | 2024-04-22   | v7     | v6     |            | v5.6.0-v5.10.0 | v5.12.0-v5.14.0 |


### PR DESCRIPTION
Closes #8896.

Todo:
- [x] Update the version overview after merging and rebasing on #8748.