### PR TITLE
Speed up the CI build.

### DIFF
--- a/.github/workflows/feature-tests.yml
+++ b/.github/workflows/feature-tests.yml
@@ -13,11 +13,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Quality
-        run: |
-          cd tests/feature_tests
-          ci/pip-install.sh
-          ci/quality.sh
       - name: Run feature tests
         run: ./tests/feature_tests/ci/test.sh
       - name: Upload artifacts


### PR DESCRIPTION
The feature test and checking the quality of the feature test were split across two parallel GitHub actions, but the feature test did still also check the quality. Removed checking the quality of the feature test from the GitHub action for running the feature test.