### PR TITLE
Always show trend graph tab.

### DIFF
--- a/components/frontend/src/metric/TrendGraph.test.js
+++ b/components/frontend/src/metric/TrendGraph.test.js
@@ -11,20 +11,19 @@ const dataModel = {
     },
 }
 
-function renderTrendgraph({ measurements = [], darkMode = false } = {}) {
+function renderTrendgraph({ measurements = [], darkMode = false, scale = "count", loading = "loaded" } = {}) {
     return render(
         <DarkMode.Provider value={darkMode}>
             <DataModel.Provider value={dataModel}>
-                <TrendGraph metric={{ type: "violations", scale: "count" }} measurements={measurements} />
+                <TrendGraph
+                    metric={{ type: "violations", scale: scale }}
+                    measurements={measurements}
+                    loading={loading}
+                />
             </DataModel.Provider>
         </DarkMode.Provider>,
     )
 }
-
-it("renders the time axis", () => {
-    renderTrendgraph()
-    expect(screen.getAllByText(/Time/).length).toBe(1)
-})
 
 it("renders the measurements", () => {
     renderTrendgraph({
@@ -66,4 +65,27 @@ it("renders the measurements with missing values for the scale", () => {
         measurements: [{ percentage: { value: "1" }, start: "2019-09-29", end: "2019-09-29" }],
     })
     expect(screen.getAllByText(/Time/).length).toBe(1)
+})
+
+it("renders a placeholder while the measurements are loading", () => {
+    const { container } = renderTrendgraph({ loading: "loading" })
+    expect(container.firstChild.className).toContain("placeholder")
+    expect(screen.queryAllByText(/Time/).length).toBe(0)
+})
+
+it("renders a message if the measurements failed to load", () => {
+    renderTrendgraph({ loading: "failed" })
+    expect(screen.getAllByText(/Loading measurements failed/).length).toBe(1)
+})
+
+it("renders a message if the metric scale is version number", () => {
+    renderTrendgraph({ scale: "version_number" })
+    expect(screen.queryAllByText(/Time/).length).toBe(0)
+    expect(screen.getAllByText(/version number scale/).length).toBe(1)
+})
+
+it("renders a message if the metric has no measurements", () => {
+    renderTrendgraph()
+    expect(screen.queryAllByText(/Time/).length).toBe(0)
+    expect(screen.getAllByText(/trend graph can not be displayed/).length).toBe(1)
 })

--- a/components/frontend/src/subject/SubjectTable.test.js
+++ b/components/frontend/src/subject/SubjectTable.test.js
@@ -43,8 +43,8 @@ const dates = [
     new Date("2020-01-13T00:00:00+00:00"),
 ]
 
-function renderSubjectTable({ dates = [], expandedItems = null } = {}) {
-    let settings = createTestableSettings()
+function renderSubjectTable({ dates = [], expandedItems = null, settings = null } = {}) {
+    settings = settings ?? createTestableSettings()
     if (expandedItems) {
         settings.expandedItems = expandedItems
     }
@@ -207,28 +207,27 @@ it("expands the details via the button", () => {
     expect(expandedItems.result.current.value).toStrictEqual(["1:0"])
 })
 
-it("collapses the details via the button", () => {
+it("collapses the details via the button", async () => {
     history.push("?expanded=1:0")
     const expandedItems = renderHook(() => useExpandedItemsSearchQuery())
     renderSubjectTable({ expandedItems: expandedItems.result.current })
     const expand = screen.getAllByRole("button")[0]
-    fireEvent.click(expand)
+    await act(async () => fireEvent.click(expand))
     expandedItems.rerender()
     expect(expandedItems.result.current.value).toStrictEqual([])
 })
 
-it("expands the details via the url", () => {
-    renderSubjectTable()
-    expect(screen.queryAllByText("Configuration").length).toBe(0)
+it("expands the details via the url", async () => {
     history.push("?expanded=1:0")
     renderSubjectTable()
+    await act(async () => {}) // Wait for hooks to finish
     expect(screen.queryAllByText("Configuration").length).toBe(1)
 })
 
 it("moves a metric", async () => {
     history.push("?expanded=1:2")
     renderSubjectTable()
-    await act(async () => fireEvent.click(await screen.findByLabelText("Move metric to the next row")))
+    await act(async () => fireEvent.click(screen.getByLabelText("Move metric to the next row")))
     expect(fetch_server_api.fetch_server_api).toHaveBeenCalledWith("post", "metric/1/attribute/position", {
         position: "next",
     })

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,10 @@ If your currently installed *Quality-time* version is not v5.14.0, please first 
 
 - Give measurement entity tables sticky headers, like the metric tables already have. Closes [#8879](https://github.com/ICTU/quality-time/issues/8879).
 
+### Changed
+
+- Always show metric trend graph tabs. Display a loader in the tab while loading measurements. If the trend graph cannot be displayed, explain in the tab why not. Closes [#8825](https://github.com/ICTU/quality-time/issues/8825).
+
 ## v5.14.0 - 2024-07-05
 
 ### Deployment notes


### PR DESCRIPTION
- Show warning message when the metric has a version number scale that trend graphs are not supported.
- Show warning message when the metric has no measurements yet.
- Show loader when loading measurements.
- Show warning message when loading failed.

Closes #8825.