### PR TITLE
Fix percentage in issues created from Quality-time.

### DIFF
--- a/components/api_server/src/routes/metric.py
+++ b/components/api_server/src/routes/metric.py
@@ -212,10 +212,11 @@ def create_issue_text(metric: Metric, measured_value: Value) -> tuple[str, str]:
     metric_url = dict(bottle.request.json)["metric_url"]
     source_names = ", ".join([source.name or DATA_MODEL.sources[str(source.type)].name for source in metric.sources])
     source_urls = [url for url in [source.get("parameters", {}).get("url") for source in metric.sources] if url]
-    issue_summary = f"Fix {measured_value} {metric.unit} from {source_names}"
+    percentage = "%" if metric.scale() == "percentage" else ""
+    issue_summary = f"Fix {measured_value}{percentage} {metric.unit} from {source_names}"
     source_url_str = f"\nPlease go to {', '.join(source_urls)} for more details." if source_urls else ""
     issue_description = (
         f"The metric [{metric.name}|{metric_url}] in Quality-time reports "
-        f"{measured_value} {metric.unit} from {source_names}.{source_url_str}\n"
+        f"{measured_value}{percentage} {metric.unit} from {source_names}.{source_url_str}\n"
     )
     return issue_summary, issue_description

--- a/components/api_server/tests/routes/test_metric.py
+++ b/components/api_server/tests/routes/test_metric.py
@@ -593,6 +593,23 @@ class MetricIssueTest(DataModelTestCase):
         self.assert_issue_inserted()
 
     @patch("bottle.request", Mock(json={"metric_url": METRIC_URL}))
+    def test_add_metric_issue_with_percentage_scale(self, requests_post):
+        """Test that an issue with the percentage scale can be added to the issue tracker."""
+        self.measurement["percentage"] = {"status": "target_not_met", "value": "21"}
+        self.expected_json["fields"]["summary"] = "Fix 21% violations from Source"
+        self.expected_json["fields"]["description"] = (
+            "The metric [name|https://quality_time/metric42] in Quality-time reports 21% violations "
+            "from Source.\nPlease go to https://zap for more details.\n"
+        )
+        self.report.metrics_dict[METRIC_ID]["scale"] = "percentage"
+        response = Mock()
+        response.json.return_value = {"key": "FOO-42"}
+        requests_post.return_value = response
+        self.assertEqual({"ok": True, "issue_url": self.ISSUE_URL}, add_metric_issue(METRIC_ID, self.database))
+        self.assert_issue_posted(requests_post)
+        self.assert_issue_inserted()
+
+    @patch("bottle.request", Mock(json={"metric_url": METRIC_URL}))
     @patch("model.issue_tracker.requests.get")
     def test_add_metric_issue_with_labels(self, requests_get, requests_post):
         """Test that an issue can be added to the issue tracker."""

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -21,6 +21,7 @@ If your currently installed *Quality-time* version is not v5.13.0, please first 
 - The icon of the trend graph tab would not be shown. Fixes [#8822](https://github.com/ICTU/quality-time/issues/8822).
 - Closing the Chromium browser in the renderer component after creating a PDF would not stop all browser child processes. Fixed by starting Chromium only once and reusing, instead of starting a new browser for each render. Fixes [#8979](https://github.com/ICTU/quality-time/issues/8979).
 - Open links in the footer in a new browser tab or window. Fixes [#9136](https://github.com/ICTU/quality-time/issues/9136).
+- If a metric has the percentage scale, include the percentage sign (%) in the summary and description of issues created from *Quality-time*. Fixes [#9137](https://github.com/ICTU/quality-time/issues/9137).
 
 ### Added
 


### PR DESCRIPTION
If a metric has the percentage scale, include the percentage sign (%) in the summary and description of issues created from Quality-time.

Fixes #9137.