### PR TITLE
Fix missing measurement entity status rationale.

### DIFF
--- a/components/frontend/src/source/SourceEntity.js
+++ b/components/frontend/src/source/SourceEntity.js
@@ -77,7 +77,7 @@ export function SourceEntity({
         >
             <Table.Cell style={style}>{source_entity_status_name[status]}</Table.Cell>
             <Table.Cell style={style}>{status === "unconfirmed" ? "" : status_end_date}</Table.Cell>
-            <Table.Cell style={style}>{status === "unconfirmed" ? "" : rationale}</Table.Cell>
+            <Table.Cell style={style}>{rationale}</Table.Cell>
             <Table.Cell style={style}>
                 {entity.first_seen ? <TimeAgoWithDate dateFirst date={entity.first_seen} /> : ""}
             </Table.Cell>

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -20,6 +20,7 @@ If your currently installed *Quality-time* version is not v5.13.0, please first 
 - In the dropdown of the "Add metric" button, keep the two checkboxes next to each other regardless of the width of the menu. Fixes [#8745](https://github.com/ICTU/quality-time/issues/8745).
 - The icon of the trend graph tab would not be shown. Fixes [#8822](https://github.com/ICTU/quality-time/issues/8822).
 - Closing the Chromium browser in the renderer component after creating a PDF would not stop all browser child processes. Fixed by starting Chromium only once and reusing, instead of starting a new browser for each render. Fixes [#8979](https://github.com/ICTU/quality-time/issues/8979).
+- Don't hide the measurement entity status rationale when the status of the measurement entity is "Unconfirmed". Fixes [#9134](https://github.com/ICTU/quality-time/issues/9134).
 - Open links in the footer in a new browser tab or window. Fixes [#9136](https://github.com/ICTU/quality-time/issues/9136).
 - If a metric has the percentage scale, include the percentage sign (%) in the summary and description of issues created from *Quality-time*. Fixes [#9137](https://github.com/ICTU/quality-time/issues/9137).
 


### PR DESCRIPTION
Don't hide the measurement entity status rationale when the status of the measurement entity is "Unconfirmed".

Fixes #9134.