### PR TITLE
Fix source URL of "job runs within time period"

### DIFF
--- a/components/collector/src/source_collectors/gitlab/base.py
+++ b/components/collector/src/source_collectors/gitlab/base.py
@@ -65,6 +65,10 @@ class GitLabJobsBase(GitLabProjectBase):
         """Override to return the jobs API."""
         return await self._gitlab_api_url("jobs")
 
+    async def _landing_url(self, responses: SourceResponses) -> URL:
+        """Extend to add the jobs landing page."""
+        return URL(f"{await super()._landing_url(responses)}/{self._parameter('project')}/-/jobs")
+
     async def _next_urls(self, responses: SourceResponses) -> list[URL]:
         """Return the next (pagination) links from the responses as long as we're within lookback days."""
         # Note: the GitLab documentation (https://docs.gitlab.com/ee/api/jobs.html#list-project-jobs) says:

--- a/components/collector/src/source_collectors/gitlab/merge_requests.py
+++ b/components/collector/src/source_collectors/gitlab/merge_requests.py
@@ -73,7 +73,7 @@ class GitLabMergeRequests(GitLabBase):
     APPROVED_FIELD = "approved"  # Name of the merge request approved field in the GitLab GraphQL API
 
     async def _landing_url(self, responses: SourceResponses) -> URL:
-        """Extend to add the project branches."""
+        """Extend to add the project merge requests landing page."""
         return URL(f"{await super()._landing_url(responses)}/{self._parameter('project')}/-/merge_requests")
 
     async def _get_source_responses(self, *urls: URL) -> SourceResponses:

--- a/components/collector/tests/source_collectors/gitlab/base.py
+++ b/components/collector/tests/source_collectors/gitlab/base.py
@@ -59,6 +59,12 @@ class GitLabTestCase(SourceCollectorTestCase):
         ]
 
 
+class GitLabJobsTestCase(GitLabTestCase):
+    """Base class for GitLab job collector unit tests."""
+
+    LANDING_URL = "https://gitlab/namespace/project/-/jobs"
+
+
 class CommonGitLabJobsTestsMixin:
     """Unit tests that should succeed for both the unused jobs metric as well as the failed jobs metric."""
 

--- a/components/collector/tests/source_collectors/gitlab/test_failed_jobs.py
+++ b/components/collector/tests/source_collectors/gitlab/test_failed_jobs.py
@@ -1,9 +1,9 @@
 """Unit tests for the GitLab jobs collectors."""
 
-from .base import CommonGitLabJobsTestsMixin, GitLabTestCase
+from .base import CommonGitLabJobsTestsMixin, GitLabJobsTestCase
 
 
-class GitLabFailedJobsTest(CommonGitLabJobsTestsMixin, GitLabTestCase):
+class GitLabFailedJobsTest(CommonGitLabJobsTestsMixin, GitLabJobsTestCase):
     """Unit tests for the GitLab failed jobs metric."""
 
     METRIC_TYPE = "failed_jobs"
@@ -11,20 +11,20 @@ class GitLabFailedJobsTest(CommonGitLabJobsTestsMixin, GitLabTestCase):
     async def test_nr_of_failed_jobs(self):
         """Test that the number of failed jobs is returned."""
         response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
-        self.assert_measurement(response, value="2", entities=self.expected_entities)
+        self.assert_measurement(response, value="2", entities=self.expected_entities, landing_url=self.LANDING_URL)
 
     async def test_nr_of_failed_jobs_without_failed_jobs(self):
         """Test that the number of failed jobs is returned."""
         for job in self.gitlab_jobs_json:
             job["status"] = "success"
         response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
-        self.assert_measurement(response, value="0", entities=[])
+        self.assert_measurement(response, value="0", entities=[], landing_url=self.LANDING_URL)
 
     async def test_no_jobs_in_lookback_period(self):
         """Test that the number of failed jobs is returned."""
         self.set_source_parameter("lookback_days", "3")
         response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
-        self.assert_measurement(response, value="0", entities=[])
+        self.assert_measurement(response, value="0", entities=[], landing_url=self.LANDING_URL)
 
     async def test_ignore_previous_runs_of_jobs(self):
         """Test that previous runs of the same job are ignored."""
@@ -51,7 +51,7 @@ class GitLabFailedJobsTest(CommonGitLabJobsTestsMixin, GitLabTestCase):
             ],
         )
         response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
-        self.assert_measurement(response, value="1", entities=self.expected_entities[-1:])
+        self.assert_measurement(response, value="1", entities=self.expected_entities[-1:], landing_url=self.LANDING_URL)
 
     async def test_private_token(self):
         """Test that the private token is used."""
@@ -64,4 +64,5 @@ class GitLabFailedJobsTest(CommonGitLabJobsTestsMixin, GitLabTestCase):
                 "https://gitlab/api/v4/projects/namespace%2Fproject/jobs?per_page=100&"
                 "scope[]=canceled&scope[]=failed&scope[]=skipped"
             ),
+            landing_url=self.LANDING_URL,
         )

--- a/components/collector/tests/source_collectors/gitlab/test_job_runs_within_time_period.py
+++ b/components/collector/tests/source_collectors/gitlab/test_job_runs_within_time_period.py
@@ -2,10 +2,10 @@
 
 from datetime import UTC, datetime, timedelta
 
-from .base import GitLabTestCase
+from .base import GitLabJobsTestCase
 
 
-class GitLabJobRunsWithinTimePeriodTest(GitLabTestCase):
+class GitLabJobRunsWithinTimePeriodTest(GitLabJobsTestCase):
     """Unit tests for the GitLab job runs within time period collector."""
 
     LOOKBACK_DAYS = "3"
@@ -55,7 +55,7 @@ class GitLabJobRunsWithinTimePeriodTest(GitLabTestCase):
                 "build_date": str(now_dt.date()),
             },
         ]
-        self.assert_measurement(response, value="1", entities=expected_entities)
+        self.assert_measurement(response, value="1", entities=expected_entities, landing_url=self.LANDING_URL)
 
     async def test_jobs_not_deduplicated(self):
         """Test that the job runs are not deduplicated."""
@@ -107,4 +107,4 @@ class GitLabJobRunsWithinTimePeriodTest(GitLabTestCase):
                 "build_date": str((now_dt - timedelta(days=1)).date()),
             },
         ]
-        self.assert_measurement(response, value="2", entities=expected_entities)
+        self.assert_measurement(response, value="2", entities=expected_entities, landing_url=self.LANDING_URL)

--- a/components/collector/tests/source_collectors/gitlab/test_unused_jobs.py
+++ b/components/collector/tests/source_collectors/gitlab/test_unused_jobs.py
@@ -1,9 +1,9 @@
 """Unit tests for the GitLab jobs collectors."""
 
-from .base import CommonGitLabJobsTestsMixin, GitLabTestCase
+from .base import CommonGitLabJobsTestsMixin, GitLabJobsTestCase
 
 
-class GitLabUnusedJobsTest(CommonGitLabJobsTestsMixin, GitLabTestCase):
+class GitLabUnusedJobsTest(CommonGitLabJobsTestsMixin, GitLabJobsTestCase):
     """Unit tests for the GitLab unused jobs metric."""
 
     METRIC_TYPE = "unused_jobs"
@@ -11,7 +11,7 @@ class GitLabUnusedJobsTest(CommonGitLabJobsTestsMixin, GitLabTestCase):
     async def test_nr_of_unused_jobs(self):
         """Test that the number of unused jobs is returned."""
         response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
-        self.assert_measurement(response, value="2", entities=self.expected_entities)
+        self.assert_measurement(response, value="2", entities=self.expected_entities, landing_url=self.LANDING_URL)
 
     async def test_private_token(self):
         """Test that the private token is used."""
@@ -21,4 +21,5 @@ class GitLabUnusedJobsTest(CommonGitLabJobsTestsMixin, GitLabTestCase):
             response,
             value="2",
             api_url="https://gitlab/api/v4/projects/namespace%2Fproject/jobs?per_page=100",
+            landing_url=self.LANDING_URL,
         )

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 If your currently installed *Quality-time* version is not v5.14.0, please first check the upgrade path in the [versioning policy](versioning.md).
 
+### Fixed
+
+- When using GitLab as source for the "job runs within time period metric", the source URL would point to the main GitLab landing page instead of the job overview of the configured project. Fixes [#9213](https://github.com/ICTU/quality-time/issues/9213).
+
 ### Added
 
 - Add icons to tabs with measurement entities. Closes [#8823](https://github.com/ICTU/quality-time/issues/8823).


### PR DESCRIPTION
When using GitLab as source for the "job runs within time period metric", the source URL would point to the main GitLab landing page instead of the job overview of the configured project.

Fixes #9213.