### PR TITLE
Always show measurement entity tabs.

### DIFF
--- a/components/frontend/src/metric/MetricDetails.js
+++ b/components/frontend/src/metric/MetricDetails.js
@@ -171,32 +171,24 @@ export function MetricDetails({
             { iconName: "linegraph" },
         ),
     )
-    if (measurements.length > 0) {
-        lastMeasurement.sources.forEach((source) => {
-            const reportSource = metric.sources[source.source_uuid]
-            if (!reportSource) {
-                return
-            } // source was deleted, continue
-            const nrEntities = source.entities?.length ?? 0
-            if (nrEntities === 0) {
-                return
-            } // no entities to show, continue
-            const sourceName = getSourceName(reportSource, dataModel)
-            panes.push(
-                tabPane(
-                    sourceName,
-                    <SourceEntities
-                        report={report}
-                        metric={metric}
-                        metric_uuid={metric_uuid}
-                        source={source}
-                        reload={measurementsReload}
-                    />,
-                    { image: <Logo logo={reportSource.type} alt={sourceName} /> },
-                ),
-            )
-        })
-    }
+    Object.entries(metric.sources).forEach(([source_uuid, source]) => {
+        const sourceName = getSourceName(source, dataModel)
+        panes.push(
+            tabPane(
+                sourceName,
+                <SourceEntities
+                    loading={measurementsStatus}
+                    measurements={measurements}
+                    metric={metric}
+                    metric_uuid={metric_uuid}
+                    reload={measurementsReload}
+                    report={report}
+                    source_uuid={source_uuid}
+                />,
+                { image: <Logo logo={source.type} alt={sourceName} /> },
+            ),
+        )
+    })
 
     return (
         <>

--- a/components/frontend/src/metric/MetricDetails.test.js
+++ b/components/frontend/src/metric/MetricDetails.test.js
@@ -71,7 +71,7 @@ async function renderMetricDetails(stopFilteringAndSorting, connection_error, fa
                         end: "2020-02-29T11:25:52.252Z",
                         sources: [
                             {},
-                            { source_uuid: "source_uuid" },
+                            { source_uuid: "source_uuid2" },
                             {
                                 source_uuid: "source_uuid",
                                 entities: [{ key: "1" }],

--- a/components/frontend/src/metric/TrendGraph.js
+++ b/components/frontend/src/metric/TrendGraph.js
@@ -1,13 +1,13 @@
-import { oneOf } from "prop-types"
 import { useContext } from "react"
-import { Placeholder, PlaceholderImage } from "semantic-ui-react"
+import { Message } from "semantic-ui-react"
 import { VictoryAxis, VictoryChart, VictoryLabel, VictoryLine, VictoryTheme } from "victory"
 
 import { DarkMode } from "../context/DarkMode"
 import { DataModel } from "../context/DataModel"
-import { measurementsPropType, metricPropType } from "../sharedPropTypes"
+import { loadingPropType, measurementsPropType, metricPropType } from "../sharedPropTypes"
 import { capitalize, formatMetricScaleAndUnit, getMetricName, getMetricScale, niceNumber, scaledNumber } from "../utils"
-import { WarningMessage } from "../widgets/WarningMessage"
+import { LoadingPlaceHolder } from "../widgets/Placeholder"
+import { FailedToLoadMeasurementsWarningMessage, WarningMessage } from "../widgets/WarningMessage"
 
 function measurementAttributeAsNumber(metric, measurement, field, dataModel) {
     const scale = getMetricScale(metric, dataModel)
@@ -22,26 +22,17 @@ export function TrendGraph({ metric, measurements, loading }) {
     const estimatedTotalChartHeight = chartHeight + 200 // Estimate of the height including title and axis
     if (getMetricScale(metric, dataModel) === "version_number") {
         return (
-            <WarningMessage
+            <Message
                 content="Trend graphs are not supported for metrics with a version number scale."
                 header="Trend graph not supported for version numbers"
             />
         )
     }
     if (loading === "failed") {
-        return (
-            <WarningMessage
-                content="Loading the measurements from the API-server failed."
-                header="Loading measurements failed"
-            />
-        )
+        return <FailedToLoadMeasurementsWarningMessage />
     }
     if (loading === "loading") {
-        return (
-            <Placeholder fluid inverted={darkMode} style={{ height: estimatedTotalChartHeight }}>
-                <PlaceholderImage />
-            </Placeholder>
-        )
+        return <LoadingPlaceHolder height={estimatedTotalChartHeight} />
     }
     if (measurements.length === 0) {
         return (
@@ -117,7 +108,7 @@ export function TrendGraph({ metric, measurements, loading }) {
     )
 }
 TrendGraph.propTypes = {
-    loading: oneOf(["failed", "loaded", "loading"]),
+    loading: loadingPropType,
     metric: metricPropType,
     measurements: measurementsPropType,
 }

--- a/components/frontend/src/sharedPropTypes.js
+++ b/components/frontend/src/sharedPropTypes.js
@@ -70,6 +70,8 @@ export const sortDirectionURLSearchQueryPropType = shape({
     value: sortDirectionPropType,
 })
 
+export const loadingPropType = oneOf(["failed", "loaded", "loading"])
+
 export const hiddenCardsPropType = oneOf(["action_required", "reports", "subjects", "tags", "issues", "legend"])
 
 export const metricsToHidePropType = oneOf(["all", "none", "no_action_required", "no_issues"])

--- a/components/frontend/src/widgets/Placeholder.js
+++ b/components/frontend/src/widgets/Placeholder.js
@@ -1,0 +1,18 @@
+import { number } from "prop-types"
+import { useContext } from "react"
+import { Placeholder, PlaceholderImage } from "semantic-ui-react"
+
+import { DarkMode } from "../context/DarkMode"
+
+export function LoadingPlaceHolder({ height }) {
+    const darkMode = useContext(DarkMode)
+    const defaultHeight = 400
+    return (
+        <Placeholder fluid inverted={darkMode} style={{ height: height ?? defaultHeight }}>
+            <PlaceholderImage />
+        </Placeholder>
+    )
+}
+LoadingPlaceHolder.propTypes = {
+    height: number,
+}

--- a/components/frontend/src/widgets/WarningMessage.js
+++ b/components/frontend/src/widgets/WarningMessage.js
@@ -10,3 +10,12 @@ export function WarningMessage(props) {
 WarningMessage.propTypes = {
     showIf: bool,
 }
+
+export function FailedToLoadMeasurementsWarningMessage() {
+    return (
+        <WarningMessage
+            content="Loading the measurements from the API-server failed."
+            header="Loading measurements failed"
+        />
+    )
+}

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -26,6 +26,7 @@ If your currently installed *Quality-time* version is not v5.14.0, please first 
 ### Changed
 
 - Always show metric trend graph tabs. Display a loader in the tab while loading measurements. If the trend graph cannot be displayed, explain in the tab why not. Closes [#8825](https://github.com/ICTU/quality-time/issues/8825).
+- Always show measurement entity tabs. Display a loader in the tab while loading measurements. If the measurement entities cannot be displayed, explain in the tab why not. Closes [#8826](https://github.com/ICTU/quality-time/issues/8826).
 
 ## v5.14.0 - 2024-07-05
 


### PR DESCRIPTION
Display a loader in the tab while loading measurements. If the measurement entities cannot be displayed, explain in the tab why not.

Closes #8826.