### PR TITLE
Change the order of the metric tabs.

### DIFF
--- a/components/frontend/src/metric/MetricDetails.js
+++ b/components/frontend/src/metric/MetricDetails.js
@@ -147,11 +147,6 @@ export function MetricDetails({
             />,
         ),
         tabPane(
-            "Technical debt",
-            <MetricDebtParameters metric={metric} metric_uuid={metric_uuid} report={report} reload={reload} />,
-            { iconName: "money" },
-        ),
-        tabPane(
             "Sources",
             <Sources
                 reports={reports}
@@ -163,6 +158,11 @@ export function MetricDetails({
                 reload={reload}
             />,
             { iconName: "server", error: Boolean(anyError) },
+        ),
+        tabPane(
+            "Technical debt",
+            <MetricDebtParameters metric={metric} metric_uuid={metric_uuid} report={report} reload={reload} />,
+            { iconName: "money" },
         ),
         changelogTabPane(<ChangeLog timestamp={report.timestamp} metric_uuid={metric_uuid} />),
         tabPane(

--- a/components/frontend/src/subject/SubjectTable.test.js
+++ b/components/frontend/src/subject/SubjectTable.test.js
@@ -234,7 +234,7 @@ it("moves a metric", async () => {
 })
 
 it("adds a source", async () => {
-    history.push("?expanded=1:2")
+    history.push("?expanded=1:1")
     renderSubjectTable()
     const addButton = await screen.findByText("Add source")
     await act(async () => fireEvent.click(addButton))

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -25,6 +25,7 @@ If your currently installed *Quality-time* version is not v5.14.0, please first 
 
 ### Changed
 
+- Change the order of the metric tabs to follow the natural usage order, first configure metric and sources, then manage the measurements. Closes [#8824](https://github.com/ICTU/quality-time/issues/8824).
 - Always show metric trend graph tabs. Display a loader in the tab while loading measurements. If the trend graph cannot be displayed, explain in the tab why not. Closes [#8825](https://github.com/ICTU/quality-time/issues/8825).
 - Always show measurement entity tabs. Display a loader in the tab while loading measurements. If the measurement entities cannot be displayed, explain in the tab why not. Closes [#8826](https://github.com/ICTU/quality-time/issues/8826).
 


### PR DESCRIPTION
Change the order of the metric tabs to follow the natural usage order, first configure metric and sources, then manage the measurements.

Closes #8824.