### PR TITLE
Update to Python 3.13.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   unittest_backend:
     docker:
-      - image: cimg/python:3.12.7
+      - image: cimg/python:3.13
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -90,7 +90,7 @@ jobs:
           export COMPOSE_FILE=docker/docker-compose.yml:docker/docker-compose.ci.yml
           docker compose build && docker compose up -d
           docker ps
-          docker run -it -w `pwd` -v `pwd`:`pwd` --network=container:docker-www-1 ghcr.io/astral-sh/uv:python3.12-bookworm tests/application_tests/ci/test.sh
+          docker run -it -w `pwd` -v `pwd`:`pwd` --network=container:docker-www-1 ghcr.io/astral-sh/uv:python3.13-bookworm tests/application_tests/ci/test.sh
           docker ps
           docker compose logs > build/containers.log
       - run:

--- a/.github/workflows/application-tests.yml
+++ b/.github/workflows/application-tests.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           mkdir -p build
           docker compose --file docker/docker-compose.yml --file docker/docker-compose.ci.yml --project-name quality-time up --build --detach --wait
-          docker run -t -w `pwd` -v `pwd`:`pwd` --network=container:quality-time-www-1 ghcr.io/astral-sh/uv:python3.12-bookworm tests/application_tests/ci/test.sh
+          docker run -t -w `pwd` -v `pwd`:`pwd` --network=container:quality-time-www-1 ghcr.io/astral-sh/uv:python3.13-bookworm tests/application_tests/ci/test.sh
       - name: Save container logs
         if: always()
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,20 +9,20 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.13"
   apt_packages:
     - graphviz
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: docs/src/conf.py
+  configuration: docs/src/conf.py
 
 # Additional formats to build
 formats:
-   - pdf
+  - pdf
 
 # Requirements to install
 python:
-   install:
-   - requirements: docs/requirements/requirements-dev.txt
-   - requirements: docs/requirements/requirements-internal-rtd.txt
+  install:
+    - requirements: docs/requirements/requirements-dev.txt
+    - requirements: docs/requirements/requirements-internal-rtd.txt

--- a/components/api_server/Dockerfile
+++ b/components/api_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.7-alpine3.20 AS compile-image
+FROM python:3.13.0-alpine3.20 AS compile-image
 
 WORKDIR /home/server
 
@@ -11,7 +11,7 @@ COPY api_server/requirements/requirements-internal.txt /requirements-internal.tx
 COPY shared_code /home/shared_code/
 RUN pip install --no-cache-dir --use-pep517 -r /requirements-internal.txt
 
-FROM python:3.12.7-alpine3.20
+FROM python:3.13.0-alpine3.20
 
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time API-server"

--- a/components/api_server/pyproject.toml
+++ b/components/api_server/pyproject.toml
@@ -1,10 +1,9 @@
 [project]
 name = "api-server"
 version = "5.19.0-rc.1"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
@@ -36,7 +35,6 @@ optional-dependencies.tools = [
 ]
 
 [tool.ruff]
-target-version = "py312"
 line-length = 120
 src = [
     "src",

--- a/components/collector/Dockerfile
+++ b/components/collector/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.7-alpine3.20 AS compile-image
+FROM python:3.13.0-alpine3.20 AS compile-image
 
 WORKDIR /home/collector
 
@@ -11,7 +11,7 @@ COPY shared_code /home/shared_code/
 COPY collector/requirements/requirements-internal.txt /requirements-internal.txt
 RUN pip install --no-cache-dir --use-pep517 -r /requirements-internal.txt
 
-FROM python:3.12.7-alpine3.20
+FROM python:3.13.0-alpine3.20
 
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time collector"

--- a/components/collector/pyproject.toml
+++ b/components/collector/pyproject.toml
@@ -1,10 +1,9 @@
 [project]
 name = "collector"
 version = "5.19.0-rc.1"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
@@ -36,7 +35,6 @@ optional-dependencies.tools = [
 ]
 
 [tool.ruff]
-target-version = "py312"
 line-length = 120
 src = [
     "src",

--- a/components/notifier/Dockerfile
+++ b/components/notifier/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.7-alpine3.20 AS compile-image
+FROM python:3.13.0-alpine3.20 AS compile-image
 
 WORKDIR /home/notifier
 
@@ -11,7 +11,7 @@ COPY shared_code /home/shared_code/
 COPY notifier/requirements/requirements-internal.txt /requirements-internal.txt
 RUN pip install --no-cache-dir --use-pep517 -r /requirements-internal.txt
 
-FROM python:3.12.7-alpine3.20
+FROM python:3.13.0-alpine3.20
 
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time notifier"

--- a/components/notifier/pyproject.toml
+++ b/components/notifier/pyproject.toml
@@ -1,10 +1,9 @@
 [project]
 name = "notifier"
 version = "5.19.0-rc.1"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
@@ -29,7 +28,6 @@ optional-dependencies.tools = [
 ]
 
 [tool.ruff]
-target-version = "py312"
 line-length = 120
 src = [
     "src",

--- a/components/shared_code/pyproject.toml
+++ b/components/shared_code/pyproject.toml
@@ -1,10 +1,9 @@
 [project]
 name = "shared-code"
 version = "5.19.0-rc.1"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
@@ -38,7 +37,6 @@ where = [
 ]
 
 [tool.ruff]
-target-version = "py312"
 line-length = 120
 src = [
     "src",

--- a/components/testdata/Dockerfile
+++ b/components/testdata/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.7-alpine3.20
+FROM python:3.13.0-alpine3.20
 
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time testdata"

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,10 +1,9 @@
 [project]
 name = "docs"
 version = "5.19.0-rc.1"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
@@ -33,7 +32,6 @@ optional-dependencies.tools = [
 ]
 
 [tool.ruff]
-target-version = "py312"
 line-length = 120
 src = [
     "src",

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -25,7 +25,7 @@ create_reference_md.main()
 # -- Project information -----------------------------------------------------
 
 project = "Quality-time"
-copyright = "2021-2023, ICTU"  # noqa: A001
+copyright = "2021-2024, ICTU"  # noqa: A001
 author = "ICTU"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -12,7 +12,7 @@ If you want to get *Quality-time* up and running quickly, for example for a demo
 
 #### Install prerequisites
 
-Prerequisites are Docker and Git for both scenario's. For scenario 2 you also need Python 3.12, [uv](https://github.com/astral-sh/uv), and a recent version of Node.js (we currently use Node.js v22).
+Prerequisites are Docker and Git for both scenario's. For scenario 2 you also need Python 3.13, [uv](https://github.com/astral-sh/uv), and a recent version of Node.js (we currently use Node.js v22).
 
 Clone this repository:
 
@@ -441,7 +441,7 @@ The application tests in theory test all components through the frontend, but un
 
 ```console
 docker-compose up -d
-docker run -it -w `pwd` -v `pwd`:`pwd` --network=container:qualitytime_www_1 ghcr.io/astral-sh/uv:python3.12-bookworm tests/application_tests/ci/test.sh
+docker run -it -w `pwd` -v `pwd`:`pwd` --network=container:qualitytime_www_1 ghcr.io/astral-sh/uv:python3.13-bookworm tests/application_tests/ci/test.sh
 ```
 
 ## Documentation and changelog

--- a/release/pyproject.toml
+++ b/release/pyproject.toml
@@ -1,10 +1,9 @@
 [project]
 name = "release"
 version = "5.19.0-rc.1"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
@@ -22,7 +21,6 @@ optional-dependencies.tools = [
 ]
 
 [tool.ruff]
-target-version = "py312"
 line-length = 120
 src = [
     "src",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.projectVersion=5.19.0-rc.1
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 # This property is optional if sonar.modules is set.
 sonar.sources=components/collector,components/notifier,components/api_server,components/shared_code,components/frontend
-sonar.python.version=3.12
+sonar.python.version=3.13
 
 # Exclude third party software and generated code from analysis
 sonar.exclusions=**/coverage/**/*,**/build/**/*,**/node_modules/**/*

--- a/tests/application_tests/pyproject.toml
+++ b/tests/application_tests/pyproject.toml
@@ -1,10 +1,9 @@
 [project]
 name = "application-tests"
 version = "5.19.0-rc.1"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
@@ -26,7 +25,6 @@ optional-dependencies.tools = [
 ]
 
 [tool.ruff]
-target-version = "py312"
 line-length = 120
 src = [
     "src",

--- a/tests/feature_tests/pyproject.toml
+++ b/tests/feature_tests/pyproject.toml
@@ -1,10 +1,9 @@
 [project]
 name = "feature-tests"
 version = "5.19.0-rc.1"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
@@ -31,7 +30,6 @@ optional-dependencies.tools = [
 ]
 
 [tool.ruff]
-target-version = "py312"
 line-length = 120
 src = [
     "src",


### PR DESCRIPTION
Issues preventing update:

- [x] ~~No wheel available for lxml. Upstream issue: https://bugs.launchpad.net/lxml/+bug/2068828~~
- [x] ~~Building wheels for greenlet fails. Upstream PR: https://github.com/python-greenlet/greenlet/pull/396~~
- [x] ~~No wheel available for aiohttp. Upstream issue: https://github.com/aio-libs/aiohttp/issues/8194~~
- [x] ~~API-server unittest fails with `AttributeError: '_MainThread' object has no attribute '_tstate_lock'`. Gevent issue: https://github.com/gevent/gevent/issues/2054~~
- [x] ~~No `cimg/python` 3.13 image available: https://hub.docker.com/r/cimg/python/tags?page_size=&ordering=&name=3.13~~
- [x] ~~No `ghcr.io/astral-sh/uv:python3.13-bookworm` image available. Should be available shortly as the PR has been merged: https://github.com/astral-sh/uv/pull/8105~~
- [x] ~~ReadTheDocs does not support 3.13 yet: https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python, ticket: https://github.com/readthedocs/readthedocs.org/issues/11671~~