### PR TITLE
Don't interpret version numbers as regular expressions.

### DIFF
--- a/components/collector/src/collector_utilities/functions.py
+++ b/components/collector/src/collector_utilities/functions.py
@@ -70,7 +70,24 @@ def sha1_hash(string: str) -> str:
 
 def is_regexp(string: str) -> bool:
     """Return whether the string looks like a regular expression."""
-    return bool(set("$^?.+*[]") & set(string))
+    return False if matches_semantic_version(string) else bool(set("$^?.+*[]") & set(string))
+
+
+def matches_semantic_version(string) -> bool:
+    """Return whether the string is a semantic version number.
+
+    Regular expression taken from
+    https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string.
+    """
+    return (
+        re.match(
+            r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+            r"(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+            r"(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
+            string,
+        )
+        is not None
+    )
 
 
 def match_string_or_regular_expression(string: str, strings_and_or_regular_expressions: Collection[str]) -> bool:

--- a/components/collector/tests/collector_utilities/test_functions.py
+++ b/components/collector/tests/collector_utilities/test_functions.py
@@ -114,6 +114,13 @@ class IsRegularExpressionTest(unittest.TestCase):
         self.assertTrue(is_regexp("bar?foo"))
         self.assertTrue(is_regexp("[a-z]+foo"))
 
+    def test_semantic_version_are_no_regexp(self):
+        """Test that semantic version numbers are not considered a regular expression."""
+        self.assertFalse(is_regexp("1.2.3"))
+        self.assertFalse(is_regexp("1.2.3-rc.0"))
+        self.assertTrue(is_regexp("v10.2"))
+        self.assertTrue(is_regexp("foo 10.2"))
+
 
 class IterableToBatchesTest(unittest.TestCase):
     """Unit tests for the iterable_to_batches function."""

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 If your currently installed *Quality-time* version is not v5.15.0, please first check the upgrade path in the [versioning policy](versioning.md).
 
+### Fixed
+
+- Don't interpret version number parameters as regular expressions. Fixes [#8739](https://github.com/ICTU/quality-time/issues/8739).
+
 ### Added
 
 - Allow for configuring Jenkins as source for the metric 'CI-pipeline duration' (GitLab CI was already supported, Azure DevOps will follow later). Partially implements [#6423](https://github.com/ICTU/quality-time/issues/6423).


### PR DESCRIPTION
Don't interpret version numbers as regular expressions in source parameters for versions that allow regular expressions.

Fixes #8739.