### PR TITLE
Don't stop retrieving data from Dependency-Track after the first page.

### DIFF
--- a/components/collector/src/collector_utilities/functions.py
+++ b/components/collector/src/collector_utilities/functions.py
@@ -62,6 +62,16 @@ def hashless(url: URL) -> URL:
     return URL(urllib.parse.urlunsplit((scheme, netloc, path, query, fragment)))
 
 
+def add_query(url: URL, query: str) -> URL:
+    """Add the query to the URL.
+
+    For example, adding "a=b&c=d" to "https://example.org" returns "https://example.org?a=b&c=d".
+    """
+    if not query:
+        return url
+    return URL(f"{url}{'&' if '?' in url else '?'}{query}")
+
+
 def sha1_hash(string: str) -> str:
     """Return a sha1 hash of the string."""
     sha1 = hashlib.sha1(string.encode("utf-8"), usedforsecurity=False)  # noqa: DUO130,RUF100

--- a/components/collector/src/source_collectors/dependency_track/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/dependency_track/source_up_to_dateness.py
@@ -1,11 +1,12 @@
 """Dependency-Track source up-to-dateness collector."""
 
+from collections.abc import Sequence
 from datetime import datetime
 
 from base_collectors import TimePassedCollector
 from collector_utilities.date_time import datetime_from_timestamp
 from collector_utilities.exceptions import CollectorError
-from collector_utilities.type import URL, Response
+from collector_utilities.type import URL
 from model import Entities, Entity, SourceResponses
 
 from .base import DependencyTrackBase, DependencyTrackProject
@@ -18,12 +19,14 @@ class DependencyTrackSourceUpToDateness(DependencyTrackBase, TimePassedCollector
         """Extend to add the projects endpoint to the API URL."""
         return URL(await super()._api_url() + "/project")
 
-    async def _parse_source_response_date_time(self, response: Response) -> datetime:
-        """Override to parse the timestamp from the response."""
+    async def _parse_source_response_date_times(self, responses: SourceResponses) -> Sequence[datetime]:
+        """Override to parse the timestamp from the responses."""
         if datetimes := [
-            self._last_bom_import_datetime(project) async for project in self._get_projects_from_response(response)
+            self._last_bom_import_datetime(project)
+            for response in responses
+            async for project in self._get_projects_from_response(response)
         ]:
-            return self.minimum(datetimes)
+            return datetimes
         error_message = "No projects found"
         raise CollectorError(error_message)
 

--- a/components/collector/src/source_collectors/gitlab/base.py
+++ b/components/collector/src/source_collectors/gitlab/base.py
@@ -10,7 +10,7 @@ from shared.utils.date_time import now
 from base_collectors import SourceCollector
 from collector_utilities.date_time import parse_datetime
 from collector_utilities.exceptions import CollectorError
-from collector_utilities.functions import match_string_or_regular_expression
+from collector_utilities.functions import add_query, match_string_or_regular_expression
 from collector_utilities.type import URL, Job
 from model import Entities, Entity, SourceResponses
 
@@ -52,10 +52,8 @@ class GitLabProjectBase(GitLabBase, ABC):
         """Return a GitLab API url for a project, if present in the parameters."""
         url = await super()._api_url()
         project = self._parameter("project", quote=True)
-        api_url = f"{url}/api/v4/projects/{project}" + (f"/{api}" if api else "")
-        sep = "&" if "?" in api_url else "?"
-        api_url += f"{sep}per_page=100"
-        return URL(api_url)
+        api_url = URL(f"{url}/api/v4/projects/{project}" + (f"/{api}" if api else ""))
+        return add_query(api_url, "per_page=100")
 
 
 class GitLabJobsBase(GitLabProjectBase):

--- a/components/collector/src/source_collectors/trello/base.py
+++ b/components/collector/src/source_collectors/trello/base.py
@@ -5,6 +5,7 @@ from abc import ABC
 from shared.utils.functions import first
 
 from base_collectors import SourceCollector
+from collector_utilities.functions import add_query
 from collector_utilities.type import URL
 from model import SourceResponses
 
@@ -31,8 +32,8 @@ class TrelloBase(SourceCollector, ABC):
         return str(first(boards, lambda board: self._parameter("board") in board.values())["id"])
 
     async def __url_with_auth(self, api_part: str) -> URL:
-        """Return the authentication URL parameters."""
-        sep = "&" if "?" in api_part else "?"
+        """Return the URL for the API endpoint, with authentication parameters."""
+        api_url = URL(f"{await self._api_url()}/{api_part}")
         api_key = self._parameter("api_key")
         token = self._parameter("token")
-        return URL(f"{await self._api_url()}/{api_part}{sep}key={api_key}&token={token}")
+        return add_query(api_url, f"key={api_key}&token={token}")

--- a/components/collector/tests/collector_utilities/test_functions.py
+++ b/components/collector/tests/collector_utilities/test_functions.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 
 from collector_utilities.date_time import days_ago
 from collector_utilities.functions import (
+    add_query,
     decimal_round_half_up,
     hashless,
     is_regexp,
@@ -101,6 +102,27 @@ class StripHashTest(unittest.TestCase):
         """Test that an url with a host name that matches the hash regular expression is returned unchanged."""
         expected_url = url = URL("https://test.app58064cb8d36474bd79f9.example.org:1234/main.js")
         self.assertEqual(expected_url, hashless(url))
+
+
+class AddQueryTest(unittest.TestCase):
+    """Unit tests for the add_query funcion."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.url = URL("https://example.org")
+
+    def test_add_query_to_url_without_query(self):
+        """Test adding a query to a URL without queries."""
+        self.assertEqual(self.url, add_query(self.url, ""))
+        self.assertEqual(URL("https://example.org?a=b"), add_query(self.url, "a=b"))
+        self.assertEqual(URL("https://example.org?a=b&c=d"), add_query(self.url, "a=b&c=d"))
+
+    def test_add_query_to_url_with_query(self):
+        """Test adding a query to a URL with queries."""
+        url = add_query(self.url, "a=b")
+        self.assertEqual(url, add_query(url, ""))
+        self.assertEqual(URL("https://example.org?a=b&c=d"), add_query(url, "c=d"))
+        self.assertEqual(URL("https://example.org?a=b&c=d&e=f"), add_query(url, "c=d&e=f"))
 
 
 class IsRegularExpressionTest(unittest.TestCase):

--- a/components/collector/tests/source_collectors/dependency_track/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_source_up_to_dateness.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 from dateutil.tz import tzlocal
 
-from source_collectors.dependency_track.base import DependencyTrackProject
+from source_collectors.dependency_track.base import DependencyTrackBase, DependencyTrackProject
 
 from tests.source_collectors.source_collector_test_case import SourceCollectorTestCase
 
@@ -75,3 +75,11 @@ class DependencyTrackSourceUpToDatenessVersionTest(SourceCollectorTestCase):
         self.set_source_parameter("project_versions", ["1.3", "1.4"])
         response = await self.collect(get_request_json_return_value=self.projects())
         self.assert_measurement(response, parse_error="No projects found")
+
+    async def test_source_up_to_dateness_with_pagination(self):
+        """Test that the source up-to-dateness can be measured when pagination is needed."""
+        default_size = DependencyTrackBase.PAGE_SIZE
+        DependencyTrackBase.PAGE_SIZE = 1
+        response = await self.collect(get_request_json_return_value=self.projects())
+        self.assert_measurement(response, value="7", landing_url=self.LANDING_URL, entities=self.entities())
+        DependencyTrackBase.PAGE_SIZE = default_size

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -20,6 +20,7 @@ If your currently installed *Quality-time* version is not v5.15.0, please first 
 - When filtering metrics by clicking on the "Action required" card or the "Issues" card, update the donut charts in the other cards. Fixes [#9245](https://github.com/ICTU/quality-time/issues/9245).
 - Don't fail on parsing npm outdated output with multiple dependents per dependency. Fixes [#9566](https://github.com/ICTU/quality-time/issues/9566).
 - Don't fail when measuring the number of 'missing metrics' in a subject with a composite subject type. Fixes [#9574](https://github.com/ICTU/quality-time/issues/9574).
+- Don't stop retrieving data from Dependency-Track after the first page. Fixes [#9751](https://github.com/ICTU/quality-time/issues/9751).
 
 ### Added
 


### PR DESCRIPTION
Fixes #9751.