### PR TITLE
Prevent resource warnings from pymongo.

### DIFF
--- a/components/api_server/src/quality_time_server.py
+++ b/components/api_server/src/quality_time_server.py
@@ -9,6 +9,8 @@ import os
 
 import bottle
 
+from shared.initialization.database import mongo_client
+
 from initialization.database import init_database
 from initialization.bottle import init_bottle
 
@@ -18,10 +20,11 @@ def serve() -> None:  # pragma: no feature-test-cover
     log_level = str(os.getenv("API_SERVER_LOG_LEVEL", "WARNING"))
     logger = logging.getLogger()
     logger.setLevel(log_level)
-    database = init_database()
-    init_bottle(database)
-    server_port = int(os.getenv("API_SERVER_PORT", "5001"))
-    bottle.run(server="gevent", host="0.0.0.0", port=server_port, reloader=True, log=logger)  # nosec, # noqa: S104
+    with mongo_client() as client:
+        database = init_database(client)
+        init_bottle(database)
+        server_port = int(os.getenv("API_SERVER_PORT", "5001"))
+        bottle.run(server="gevent", host="0.0.0.0", port=server_port, reloader=True, log=logger)  # nosec, # noqa: S104
 
 
 if __name__ == "__main__":  # pragma: no feature-test-cover, pragma: no cover

--- a/components/api_server/tests/initialization/test_database.py
+++ b/components/api_server/tests/initialization/test_database.py
@@ -24,7 +24,7 @@ class DatabaseInitTest(DataModelTestCase):
         self.database.sessions.find_one.return_value = {"user": "jodoe"}
         self.database.measurements.count_documents.return_value = 0
         self.database.measurements.index_information.return_value = {}
-        self.mongo_client().quality_time_db = self.database
+        self.mongo_client.get_database.return_value = self.database
 
     def init_database(self, data_model_json: str, assert_glob_called: bool = True) -> None:
         """Initialize the database."""
@@ -35,9 +35,8 @@ class DatabaseInitTest(DataModelTestCase):
                 "open",
                 mock_open(read_data=data_model_json),
             ),
-            patch("pymongo.MongoClient", self.mongo_client),
         ):
-            init_database()
+            init_database(self.mongo_client)
         if assert_glob_called:
             glob_mock.assert_called()
         else:

--- a/components/collector/src/quality_time_collector.py
+++ b/components/collector/src/quality_time_collector.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from typing import NoReturn
 
-from shared.initialization.database import database_connection
+from shared.initialization.database import get_database, mongo_client
 
 # Make sure subclasses are registered
 import metric_collectors  # noqa: F401
@@ -15,7 +15,8 @@ from base_collectors import Collector, config
 async def collect() -> NoReturn:
     """Collect the measurements indefinitely."""
     logging.getLogger().setLevel(config.LOG_LEVEL)
-    await Collector(database_connection()).start()
+    with mongo_client() as client:
+        await Collector(get_database(client)).start()
 
 
 if __name__ == "__main__":

--- a/components/collector/tests/base_collectors/test_collector.py
+++ b/components/collector/tests/base_collectors/test_collector.py
@@ -178,7 +178,7 @@ class CollectorTest(unittest.IsolatedAsyncioTestCase):
     async def test_collect(self):
         """Test the collect method."""
         with (
-            patch("quality_time_collector.database_connection", return_value=self.database),
+            patch("quality_time_collector.get_database", return_value=self.database),
             self.assertRaises(RuntimeError),
         ):
             await quality_time_collector.collect()

--- a/components/notifier/src/quality_time_notifier.py
+++ b/components/notifier/src/quality_time_notifier.py
@@ -5,7 +5,7 @@ import logging
 import os
 from typing import NoReturn
 
-from shared.initialization.database import database_connection
+from shared.initialization.database import get_database, mongo_client
 
 from notifier.notifier import notify
 
@@ -14,7 +14,8 @@ def start_notifications() -> NoReturn:
     """Notify indefinitely."""
     logging.getLogger().setLevel(str(os.getenv("NOTIFIER_LOG_LEVEL", "WARNING")))
     sleep_duration = int(os.getenv("NOTIFIER_SLEEP_DURATION", "60"))
-    asyncio.run(notify(database_connection(), sleep_duration))
+    with mongo_client() as client:
+        asyncio.run(notify(get_database(client), sleep_duration))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/components/shared_code/tests/shared/initialization/test_database.py
+++ b/components/shared_code/tests/shared/initialization/test_database.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 import mongomock
 
-from shared.initialization.database import database_connection
+from shared.initialization.database import get_database, mongo_client
 
 from tests.shared.base import DataModelTestCase
 
@@ -13,7 +13,8 @@ class DatabaseInitTest(DataModelTestCase):
     """Unit tests for database initialization."""
 
     @patch("shared.initialization.database.pymongo", return_value=mongomock)
-    def test_client(self, client: Mock) -> None:
+    def test_get_database(self, pymongo_client: Mock) -> None:
         """Test that the client is called."""
-        database_connection()
-        client.MongoClient.assert_called_once()
+        with mongo_client() as client:
+            get_database(client)
+        pymongo_client.MongoClient.assert_called_once()


### PR DESCRIPTION
To prevent resource warnings from pymongo when running tests, ensure the Mongo client connection is closed by wrapping it in a context manager.