### PR TITLE
Fix empty subject column in missing metric details.

### DIFF
--- a/components/collector/src/source_collectors/quality_time/missing_metrics.py
+++ b/components/collector/src/source_collectors/quality_time/missing_metrics.py
@@ -83,7 +83,7 @@ class QualityTimeMissingMetrics(QualityTimeCollector):
                 key=f"{report_uuid}:{subject_uuid}:{metric_type}",
                 report=report["title"],
                 report_url=report_url,
-                subject=subject.get("name", subject_type_name),
+                subject=subject.get("name") or subject_type_name,
                 subject_url=f"{report_url}#{subject_uuid}",
                 subject_uuid=f"{subject_uuid}",
                 subject_type=subject_type_name,

--- a/components/collector/tests/source_collectors/quality_time/test_missing_metrics.py
+++ b/components/collector/tests/source_collectors/quality_time/test_missing_metrics.py
@@ -18,6 +18,9 @@ class QualityTimeMissingMetricsTest(QualityTimeTestCase):
         """Set up test data."""
         super().setUp()
         self.data_model = json.loads(DATA_MODEL_JSON)
+
+    def add_report_fixture(self, subject_name: str = "Subject 2"):
+        """Add a report to the reports fixture."""
         self.reports["reports"].append(
             {
                 "title": "R3",
@@ -25,7 +28,7 @@ class QualityTimeMissingMetricsTest(QualityTimeTestCase):
                 "subjects": {
                     "s2": {
                         "type": "software_source_code",
-                        "name": "Subject2",
+                        "name": subject_name,
                         "metrics": {
                             "m21": {
                                 "tags": ["security"],
@@ -55,7 +58,12 @@ class QualityTimeMissingMetricsTest(QualityTimeTestCase):
                 nr_supported_metrics += len(QualityTimeMissingMetrics.supported_metric_types(self.data_model, subject))
         return nr_supported_metrics
 
-    def entities(self, subjects_to_ignore: list[str] | None = None) -> list[dict[str, str]]:
+    def entities(
+        self,
+        subjects_to_ignore: list[str] | None = None,
+        expected_subject_names: dict[str, str] | None = None,
+        expected_subject_types: dict[str, str] | None = None,
+    ) -> list[dict[str, str]]:
         """Create the expected entities."""
         subjects_to_ignore = subjects_to_ignore or []
         entities = []
@@ -65,33 +73,39 @@ class QualityTimeMissingMetricsTest(QualityTimeTestCase):
                     continue
                 subject_metric_types = [metric["type"] for metric in subject["metrics"].values()]
                 supported_metric_types = QualityTimeMissingMetrics.supported_metric_types(self.data_model, subject)
+                expected_subject_name = (expected_subject_names or {}).get(subject_uuid, subject["name"])
+                expected_subject_type = (expected_subject_types or {}).get(subject_uuid, "Software")
                 entities.extend(
                     [
-                        self.create_entity(report, subject_uuid, subject, supported_metric_type)
+                        self.create_entity(
+                            report, subject_uuid, expected_subject_type, expected_subject_name, supported_metric_type
+                        )
                         for supported_metric_type in supported_metric_types
                         if supported_metric_type not in subject_metric_types
                     ]
                 )
         return entities
 
-    def create_entity(self, report, subject_uuid: str, subject, metric_type: str) -> dict[str, str]:
-        """Create a missing metric entity."""
-        data_model_subject = QualityTimeMissingMetrics.subject_type(self.data_model["subjects"], subject["type"])
+    def create_entity(
+        self, report, subject_uuid: str, expected_subject_type: str, expected_subject_name: str, metric_type: str
+    ) -> dict[str, str]:
+        """Create an expected missing metric entity."""
         return {
             "key": f"{report['report_uuid']}:{subject_uuid}:{metric_type}",
             "report": report["title"],
             "report_url": f"https://quality_time/{report['report_uuid']}",
-            "subject": subject["name"],
+            "subject": expected_subject_name,
             "subject_url": f"https://quality_time/{report['report_uuid']}#{subject_uuid}",
             "subject_uuid": f"{subject_uuid}",
-            "subject_type": data_model_subject["name"] if data_model_subject else "missing",
+            "subject_type": expected_subject_type,
             "metric_type": self.data_model["metrics"][metric_type]["name"],
         }
 
     async def test_nr_of_metrics(self):
         """Test that the number of missing metrics is returned."""
+        self.add_report_fixture()
         response = await self.collect(get_request_json_side_effect=[self.data_model, self.reports])
-        entities = self.entities()
+        entities = self.entities(expected_subject_types={"s2": "Software source code"})
         self.assert_measurement(
             response,
             entities=entities,
@@ -101,16 +115,18 @@ class QualityTimeMissingMetricsTest(QualityTimeTestCase):
 
     async def test_nr_of_missing_metrics_without_correct_report(self):
         """Test that an error is thrown for reports that don't exist."""
+        self.add_report_fixture()
         self.set_source_parameter("reports", ["r42"])
         response = await self.collect(get_request_json_side_effect=[self.data_model, self.reports])
         self.assert_measurement(response, parse_error="No reports found with title or id")
 
     async def test_subjects_to_ignore_by_name(self):
         """Test that the number of non-ignored missing metrics is returned when filtered by name."""
+        self.add_report_fixture()
         subjects_to_ignore = ["Subject2"]
         self.set_source_parameter("subjects_to_ignore", subjects_to_ignore)
         response = await self.collect(get_request_json_side_effect=[self.data_model, self.reports])
-        entities = self.entities(subjects_to_ignore)
+        entities = self.entities(subjects_to_ignore, expected_subject_types={"s2": "Software source code"})
         self.assert_measurement(
             response,
             entities=entities,
@@ -120,10 +136,25 @@ class QualityTimeMissingMetricsTest(QualityTimeTestCase):
 
     async def test_subjects_to_ignore_by_uuid(self):
         """Test that the number of non-ignored missing metrics is returned when filtered by uuid."""
+        self.add_report_fixture()
         subjects_to_ignore = ["s2"]
         self.set_source_parameter("subjects_to_ignore", subjects_to_ignore)
         response = await self.collect(get_request_json_side_effect=[self.data_model, self.reports])
-        entities = self.entities(subjects_to_ignore)
+        entities = self.entities(subjects_to_ignore, expected_subject_types={"s2": "Software source code"})
+        self.assert_measurement(
+            response,
+            entities=entities,
+            total=str(self.nr_supported_metric_types()),
+            value=str(len(entities)),
+        )
+
+    async def test_subject_without_overridden_subject_name(self):
+        """Test that the default subject name is used for subjects that don't have an overridden name."""
+        self.add_report_fixture(subject_name="")
+        response = await self.collect(get_request_json_side_effect=[self.data_model, self.reports])
+        entities = self.entities(
+            expected_subject_names={"s2": "Software source code"}, expected_subject_types={"s2": "Software source code"}
+        )
         self.assert_measurement(
             response,
             entities=entities,

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Deployment notes
+
+If your currently installed *Quality-time* version is not v5.16.2, please first check the upgrade path in the [versioning policy](versioning.md).
+
+### Fixed
+
+- The subject column in the measurement details of the 'missing metrics' metric would be empty for subjects that not have their default name overridden. Fixes [#9854](https://github.com/ICTU/quality-time/issues/9854).
+
 ## v5.16.2 - 2024-10-03
 
 ### Deployment notes


### PR DESCRIPTION
The subject column in the measurement details of the 'missing metrics' metric would be empty for subjects that not have their default name overridden.

Fixes #9854.