### PR TITLE
Cut off long text fields.

### DIFF
--- a/components/frontend/src/source/SourceEntity.js
+++ b/components/frontend/src/source/SourceEntity.js
@@ -5,6 +5,7 @@ import { useState } from "react"
 import { Table } from "semantic-ui-react"
 
 import { entityAttributesPropType, entityPropType, entityStatusPropType, reportPropType } from "../sharedPropTypes"
+import { limitTextLength } from "../utils"
 import { TableRowWithDetails } from "../widgets/TableRowWithDetails"
 import { TimeAgoWithDate } from "../widgets/TimeAgoWithDate"
 import { IGNORABLE_SOURCE_ENTITY_STATUSES, SOURCE_ENTITY_STATUS_NAME } from "./source_entity_status"
@@ -77,7 +78,7 @@ export function SourceEntity({
         >
             <Table.Cell style={style}>{SOURCE_ENTITY_STATUS_NAME[status]}</Table.Cell>
             <Table.Cell style={style}>{status === "unconfirmed" ? "" : status_end_date}</Table.Cell>
-            <Table.Cell style={style}>{rationale}</Table.Cell>
+            <Table.Cell style={style}>{limitTextLength(rationale)}</Table.Cell>
             <Table.Cell style={style}>
                 {entity.first_seen ? <TimeAgoWithDate dateFirst date={entity.first_seen} /> : ""}
             </Table.Cell>

--- a/components/frontend/src/source/SourceEntity.test.js
+++ b/components/frontend/src/source/SourceEntity.test.js
@@ -49,6 +49,11 @@ it("renders the status rationale", () => {
     expect(screen.getAllByText(/Why\?/).length).toBe(1)
 })
 
+it("limits the length of a long status rationale", () => {
+    renderSourceEntity({ status: "fixed", rationale: "long rationale ".repeat(20) })
+    expect(screen.getAllByText(/\.\.\./).length).toBe(1)
+})
+
 it("renders the first seen datetime", () => {
     renderSourceEntity({ first_seen: "2023-07-17" })
     expect(screen.getAllByText(/ago/).length).toBe(1)

--- a/components/frontend/src/source/SourceEntityAttribute.js
+++ b/components/frontend/src/source/SourceEntityAttribute.js
@@ -1,14 +1,11 @@
 import { StatusIcon } from "../measurement/StatusIcon"
 import { entityAttributePropType, entityPropType } from "../sharedPropTypes"
-import { formatMetricValue } from "../utils"
+import { formatMetricValue, limitTextLength } from "../utils"
 import { HyperLink } from "../widgets/HyperLink"
 import { TimeAgoWithDate } from "../widgets/TimeAgoWithDate"
 
 export function SourceEntityAttribute({ entity, entityAttribute }) {
-    let cellContents = entity[entityAttribute.key] ?? ""
-    if (typeof cellContents === "string" && cellContents.length >= 250) {
-        cellContents = cellContents.slice(0, 247) + "..."
-    }
+    let cellContents = limitTextLength(entity[entityAttribute.key] ?? "")
     // See the data model (components/shared_code/src/shared_data_model/meta/entity.py) for possible entity attribute
     // types. Note that if entity attribute types are removed old types need to be supported to allow for time travel.
     const type = entityAttribute.type ?? ""

--- a/components/frontend/src/subject/SubjectTableRow.js
+++ b/components/frontend/src/subject/SubjectTableRow.js
@@ -36,6 +36,7 @@ import {
     getMetricScale,
     getMetricTags,
     getMetricUnit,
+    limitTextLength,
 } from "../utils"
 import { TableRowWithDetails } from "../widgets/TableRowWithDetails"
 import { Tag } from "../widgets/Tag"
@@ -338,7 +339,10 @@ export function SubjectTableRow({
             )}
             {settings.hiddenColumns.excludes("comment") && (
                 <Table.Cell style={style}>
-                    <div style={{ wordBreak: "break-word" }} dangerouslySetInnerHTML={{ __html: metric.comment }} />
+                    <div
+                        style={{ wordBreak: "break-word" }}
+                        dangerouslySetInnerHTML={{ __html: limitTextLength(metric.comment) }}
+                    />
                 </Table.Cell>
             )}
             {settings.hiddenColumns.excludes("issues") && (

--- a/components/frontend/src/subject/SubjectTableRow.test.js
+++ b/components/frontend/src/subject/SubjectTableRow.test.js
@@ -11,6 +11,7 @@ beforeEach(() => {
 })
 
 function renderSubjectTableRow({
+    comment = "",
     direction = "<",
     ascending = false,
     scale = "count",
@@ -51,6 +52,7 @@ function renderSubjectTableRow({
                         dates={dates}
                         measurements={[]}
                         metric={{
+                            comment: comment,
                             direction: direction,
                             evaluate_targets: evaluate_targets,
                             recent_measurements: [],
@@ -118,4 +120,9 @@ it("shows the delta column for the version scale", () => {
     expect(screen.getAllByLabelText("Metric type worsened from 1.0 to 1.2").length).toBe(1)
     expect(screen.getAllByText("-").length).toBe(1)
     expect(screen.getAllByLabelText("Metric type improved from 1.2 to 0.8").length).toBe(1)
+})
+
+it("cuts off long comments in the comment column", () => {
+    renderSubjectTableRow({ comment: "long comment ".repeat(20) })
+    expect(screen.queryAllByText(/\.\.\./).length).toBe(1)
 })

--- a/components/frontend/src/utils.js
+++ b/components/frontend/src/utils.js
@@ -337,6 +337,15 @@ export function pluralize(word, count) {
     return word + (count === 1 ? "" : "s")
 }
 
+export function limitTextLength(text, maxLength = 250) {
+    if (typeof text === "string" && text.length > maxLength) {
+        const ellipsis = "..."
+        const newLength = Math.max(0, maxLength - ellipsis.length)
+        return text.slice(0, newLength) + ellipsis
+    }
+    return text
+}
+
 export function niceNumber(number) {
     let rounded_numbers = [10, 12, 15, 20, 30, 50, 75]
     do {

--- a/components/frontend/src/utils.test.js
+++ b/components/frontend/src/utils.test.js
@@ -16,6 +16,7 @@ import {
     isMeasurementOutdated,
     isMeasurementRequested,
     isMeasurementStale,
+    limitTextLength,
     niceNumber,
     nrMetricsInReport,
     nrMetricsInReports,
@@ -538,4 +539,19 @@ it("returns whether a metric's measurement is outdated", () => {
     expect(isMeasurementOutdated({ latest_measurement: {} })).toBe(false)
     // A metric with an outdated measurement is outdated:
     expect(isMeasurementOutdated({ latest_measurement: { outdated: true } })).toBe(true)
+})
+
+it("limits the text length", () => {
+    // Short texts are not changed:
+    expect(limitTextLength("short text")).toStrictEqual("short text")
+    // Long texts are shortened:
+    expect(limitTextLength("a very very long text", 10)).toStrictEqual("a very ...")
+    // Very short texts result in an ellipsis only:
+    expect(limitTextLength("short text", 4)).toStrictEqual("s...")
+    expect(limitTextLength("short text", 3)).toStrictEqual("...")
+    expect(limitTextLength("short text", 2)).toStrictEqual("...")
+    expect(limitTextLength("short text", 1)).toStrictEqual("...")
+    expect(limitTextLength("short text", 0)).toStrictEqual("...")
+    // Arguments that are not text are returned unchanged:
+    expect(limitTextLength(<>{"short text"}</>)).toStrictEqual(<>{"short text"}</>)
 })

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is not v5.16.2, please first 
 
 ### Fixed
 
+- Prevent metric comment columns and measurement entity status rationale columns from getting too wide and cut off values that are longer than 250 characters. Fixes [#8281](https://github.com/ICTU/quality-time/issues/8281).
 - The subject column in the measurement details of the 'missing metrics' metric would be empty for subjects that not have their default name overridden. Fixes [#9854](https://github.com/ICTU/quality-time/issues/9854).
 
 ### Added


### PR DESCRIPTION
In metric tables, prevent the comment column from getting too wide and cut off comments that are longer than 250 characters. In the measurement entity details, prevent the rationale column from getting too wide and cut off rationales that are longer than 250 characters.

Fixes #8281.