### PR TITLE
Add version info to Dependency-Track security warnings.

### DIFF
--- a/components/collector/src/base_collectors/source_collector.py
+++ b/components/collector/src/base_collectors/source_collector.py
@@ -259,7 +259,7 @@ class SecurityWarningsSourceCollector(SourceCollector):
         severity = str(entity[self.ENTITY_SEVERITY_ATTRIBUTE])
         if self.MAKE_ENTITY_SEVERITY_VALUE_LOWER_CASE:
             severity = severity.lower()
-        return severity in self._parameter(self.SEVERITY_PARAMETER)
+        return severity in self._parameter(self.SEVERITY_PARAMETER) and super()._include_entity(entity)
 
 
 class TimeCollector(SourceCollector):

--- a/components/collector/tests/source_collectors/dependency_track/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_security_warnings.py
@@ -27,7 +27,11 @@ class DependencyTrackSecurityWarningsTest(SourceCollectorTestCase):
         return [
             DependencyTrackFinding(
                 component=DependencyTrackComponent(
-                    name="component name", project="project uuid", uuid="component-uuid"
+                    latestVersion="2",
+                    name="component name",
+                    project="project uuid",
+                    uuid="component-uuid",
+                    version="1",
                 ),
                 matrix="matrix",
                 vulnerability=DependencyTrackVulnerability(
@@ -47,9 +51,12 @@ class DependencyTrackSecurityWarningsTest(SourceCollectorTestCase):
                 "description": "vulnerability description",
                 "identifier": "CVE-123",
                 "key": "matrix",
+                "latest": "2",
+                "latest_version_status": "update possible",
                 "project": "project name",
                 "project_landing_url": "/projects/project uuid",
                 "severity": "Unassigned",
+                "version": "1",
             },
         ]
 

--- a/components/shared_code/src/shared_data_model/sources/dependency_track.py
+++ b/components/shared_code/src/shared_data_model/sources/dependency_track.py
@@ -19,6 +19,19 @@ DEPENDENCY_TRACK_DESCRIPTIlON = (
     "Dependency-Track is a component analysis platform that allows organizations to identify and "
     "reduce risk in the software supply chain."
 )
+VERSION_ATTRIBUTES = [
+    EntityAttribute(name="Current version", key="version"),
+    EntityAttribute(name="Latest version", key="latest"),
+    EntityAttribute(
+        name="Latest version status",
+        key="latest_version_status",
+        color={
+            "unknown": Color.ACTIVE,
+            "up-to-date": Color.POSITIVE,
+            "update possible": Color.WARNING,
+        },
+    ),
+]
 
 DEPENDENCY_TRACK = Source(
     name="Dependency-Track",
@@ -62,7 +75,7 @@ DEPENDENCY_TRACK = Source(
             placeholder="all statuses",
             help="Limit which latest version statuses to show.",
             values=["up-to-date", "update possible", "unknown"],
-            metrics=["dependencies"],
+            metrics=["dependencies", "security_warnings"],
         ),
         "severities": Severities(values=["Unassigned", "Info", "Low", "Medium", "High", "Critical"]),
     },
@@ -73,17 +86,7 @@ DEPENDENCY_TRACK = Source(
             attributes=[
                 EntityAttribute(name="Project", url="project_landing_url"),
                 EntityAttribute(name="Component", url="component_landing_url"),
-                EntityAttribute(name="Current version", key="version"),
-                EntityAttribute(name="Latest version", key="latest"),
-                EntityAttribute(
-                    name="Latest version status",
-                    key="latest_version_status",
-                    color={
-                        "unknown": Color.ACTIVE,
-                        "up-to-date": Color.POSITIVE,
-                        "update possible": Color.WARNING,
-                    },
-                ),
+                *VERSION_ATTRIBUTES,
             ],
         ),
         "security_warnings": Entity(
@@ -94,6 +97,7 @@ DEPENDENCY_TRACK = Source(
                 EntityAttribute(name="Identifier"),
                 EntityAttribute(name="Description"),
                 EntityAttribute(name="Severity", color={"Critical": Color.NEGATIVE, "High": Color.WARNING}),
+                *VERSION_ATTRIBUTES,
             ],
         ),
         "source_up_to_dateness": Entity(

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,10 @@ If your currently installed *Quality-time* version is not v5.16.2, please first 
 
 - The subject column in the measurement details of the 'missing metrics' metric would be empty for subjects that not have their default name overridden. Fixes [#9854](https://github.com/ICTU/quality-time/issues/9854).
 
+### Added
+
+- When measuring 'security warnings' with Dependency-Track as source, also show the current version, latest version, and update status of the components in the measurement details. Also add a parameter to allow for filtering by update status. Closes [#8685](https://github.com/ICTU/quality-time/issues/8685).
+
 ## v5.16.2 - 2024-10-03
 
 ### Deployment notes


### PR DESCRIPTION
When measuring 'security warnings' with Dependency-Track as source, also show the current version, latest version, and update status of the components in the measurement details. Also add a parameter to allow for filtering by update status.

Closes #8685.