### PR TITLE
Prevent warning in console when running frontend unit tests.

### DIFF
--- a/components/frontend/src/report/ReportsOverview.test.js
+++ b/components/frontend/src/report/ReportsOverview.test.js
@@ -47,14 +47,14 @@ it("shows an error message if there are no reports at the specified date", async
 })
 
 it("shows the reports overview", async () => {
-    const reports = [{ subjects: {} }]
+    const reports = [{ report_uuid: "report_uuid", subjects: {} }]
     const reportsOverview = { title: "Overview", permissions: {} }
     renderReportsOverview({ reports: reports, reportsOverview: reportsOverview })
     expect(screen.getAllByText(/Overview/).length).toBe(2)
 })
 
 it("shows the comment", async () => {
-    const reports = [{ subjects: {} }]
+    const reports = [{ report_uuid: "report_uuid", subjects: {} }]
     const reportsOverview = { title: "Overview", comment: "Commentary", permissions: {} }
     renderReportsOverview({ reports: reports, reportsOverview: reportsOverview })
     expect(screen.getAllByText(/Commentary/).length).toBe(1)


### PR DESCRIPTION
Prevent console error "Warning: Failed prop type: ReactGridLayout: layout[0].i must be a string! Received: null (object)".