### PR TITLE
Fix measurement detail warning message.

### DIFF
--- a/components/frontend/src/source/SourceEntities.js
+++ b/components/frontend/src/source/SourceEntities.js
@@ -269,7 +269,7 @@ export function SourceEntities({ loading, measurements, metric, metric_uuid, rel
     const metricEntities = dataModel.sources[sourceType]?.entities?.[metric.type]
 
     if (!metricEntities) {
-        const unit = dataModel.metrics[metric.type].unit
+        const unit = dataModel.metrics[metric.type].unit || "entities"
         const sourceTypeName = dataModel.sources[sourceType].name
         return (
             <Message

--- a/components/frontend/src/source/SourceEntities.test.js
+++ b/components/frontend/src/source/SourceEntities.test.js
@@ -28,12 +28,13 @@ const dataModel = {
                 },
             },
         },
-        source_type_without_entities: {},
+        source_type_without_entities: { name: "Source type without entities" },
     },
     metrics: {
         metric_type: {
             unit: "items",
         },
+        metric_type_without_unit: {},
     },
 }
 
@@ -123,6 +124,26 @@ it("renders a message if the metric does not support measurement entities", () =
         metric: { type: "metric_type", sources: { source_uuid: { type: "source_type_without_entities" } } },
     })
     expect(screen.getAllByText(/Measurement details not supported/).length).toBe(1)
+    expect(
+        screen.getAllByText(
+            /Showing individual items is not supported when using Source type without entities as source./,
+        ).length,
+    ).toBe(1)
+})
+
+it("renders a message if the metric does not support measurement entities andhas no unit", () => {
+    renderSourceEntities({
+        metric: {
+            type: "metric_type_without_unit",
+            sources: { source_uuid: { type: "source_type_without_entities" } },
+        },
+    })
+    expect(screen.getAllByText(/Measurement details not supported/).length).toBe(1)
+    expect(
+        screen.getAllByText(
+            /Showing individual entities is not supported when using Source type without entities as source./,
+        ).length,
+    ).toBe(1)
 })
 
 it("renders a message if the metric does not have measurement entities", () => {

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is not v5.17.0, please first 
 
 ### Fixed
 
+- The warning message shown for unsupported measurement details was incorrect for metrics with a version scale. Fixes [#9973](https://github.com/ICTU/quality-time/issues/9973).
 - The metric summary cards with pie chart wouldn't erase the center label when rerendering, causing the label to be visible multiple times. Fixes [#10098](https://github.com/ICTU/quality-time/issues/10098).
 
 ## v5.17.0 - 2024-10-17


### PR DESCRIPTION
The warning message shown for unsupported measurement details was incorrect for metrics with a version scale.

Fixes #9973.