### PR TITLE
Developer documentation was still refering to `venv/bin/activate` whe…

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -21,6 +21,7 @@ If your currently installed *Quality-time* version is not v5.17.0, please first 
 - Correctly sort metrics in the "Add metric" dropdown menu. Fixes [#9857](https://github.com/ICTU/quality-time/issues/9857).
 - The warning message shown for unsupported measurement details was incorrect for metrics with a version scale. Fixes [#9973](https://github.com/ICTU/quality-time/issues/9973).
 - The metric summary cards with pie chart wouldn't erase the center label when rerendering, causing the label to be visible multiple times. Fixes [#10098](https://github.com/ICTU/quality-time/issues/10098).
+- Developer documentation was still refering to `venv/bin/activate` where this should be `.venv/bin/activate`. Fixes [#10172](https://github.com/ICTU/quality-time/issues/10172).
 
 ## v5.17.0 - 2024-10-17
 

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -70,7 +70,7 @@ Open another terminal and run the API-server:
 ```console
 cd components/api_server
 uv venv
-. venv/bin/activate  # on Windows: venv\Scripts\activate
+. .venv/bin/activate  # on Windows: venv\Scripts\activate
 ci/pip-install.sh
 python src/quality_time_server.py
 ```
@@ -80,7 +80,7 @@ The API of the API-server is served at [http://localhost:5001](http://localhost:
 ```{note}
 If you're new to Python virtual environments, note that:
 - Creating a virtual environment (`uv venv`) has to be done once. Only when the Python version changes, you want to recreate the virtual environment.
-- Activating the virtual environment (`. venv/bin/activate`) has to be done every time you open a new shell and want to use the Python installed in the virtual environment.
+- Activating the virtual environment (`. .venv/bin/activate`) has to be done every time you open a new shell and want to use the Python installed in the virtual environment.
 - Installing the requirements (`ci/pip-install.sh`) has to be repeated when the dependencies, specified in the requirements files, change.
 ```
 
@@ -96,7 +96,7 @@ Open another terminal and run the collector:
 ```console
 cd components/collector
 uv venv
-. venv/bin/activate  # on Windows: venv\Scripts\activate
+. .venv/bin/activate  # on Windows: venv\Scripts\activate
 ci/pip-install.sh
 python src/quality_time_collector.py
 ```
@@ -132,7 +132,7 @@ Optionally, open yet another terminal and run the notifier:
 ```console
 cd components/notifier
 uv venv
-. venv/bin/activate  # on Windows: venv\Scripts\activate
+. .venv/bin/activate  # on Windows: venv\Scripts\activate
 ci/pip-install.sh
 python src/quality_time_notifier.py
 ```
@@ -151,7 +151,7 @@ To create a virtual environment for the shared component and install the depende
 ```console
 cd components/shared_code
 uv venv
-. venv/bin/activate  # on Windows: venv\Scripts\activate
+. .venv/bin/activate  # on Windows: venv\Scripts\activate
 ci/pip-install.sh
 ```
 
@@ -453,7 +453,7 @@ To generate the documentation locally:
 ```console
 cd docs
 uv venv
-. venv/bin/activate  # on Windows: venv\Scripts\activate
+. .venv/bin/activate  # on Windows: venv\Scripts\activate
 ci/pip-install.sh
 make html
 open build/html/index.html
@@ -476,7 +476,7 @@ Make sure the release folder is the current directory, and you have the dependen
 ```console
 cd release
 uv venv
-. venv/bin/activate
+. .venv/bin/activate
 ci/pip-install.sh
 ```
 


### PR DESCRIPTION
…re this should be `.venv/bin/activate`.

Fixes #10172.