### PR TITLE
When calculating how much time is left until the technical debt end d…

### DIFF
--- a/components/frontend/src/metric/MetricDebtParameters.js
+++ b/components/frontend/src/metric/MetricDebtParameters.js
@@ -68,17 +68,17 @@ function TechnicalDebtEndDate({ metric, metric_uuid, reload }) {
             </p>
         </>
     )
+    let debtEndDateTime = null
+    if (metric.debt_end_date) {
+        debtEndDateTime = new Date(metric.debt_end_date)
+        debtEndDateTime.setHours(23, 59, 59)
+    }
     return (
         <DateInput
             ariaLabelledBy={labelId}
             requiredPermissions={[EDIT_REPORT_PERMISSION]}
             label={
-                <LabelWithDate
-                    date={metric.debt_end_date}
-                    labelId={labelId}
-                    help={help}
-                    label="Technical debt end date"
-                />
+                <LabelWithDate date={debtEndDateTime} labelId={labelId} help={help} label="Technical debt end date" />
             }
             placeholder="YYYY-MM-DD"
             set_value={(value) => set_metric_attribute(metric_uuid, "debt_end_date", value, reload)}

--- a/components/frontend/src/utils.js
+++ b/components/frontend/src/utils.js
@@ -136,6 +136,7 @@ export function getMetricResponseDeadline(metric, report) {
     if (status === "debt_target_met") {
         if (metric.debt_end_date) {
             deadline = new Date(metric.debt_end_date)
+            deadline.setHours(23, 59, 59)
         }
     } else if (status in defaultDesiredResponseTimes && metric.status_start) {
         const desiredResponseTime = getDesiredResponseTime(report, status)

--- a/components/frontend/src/utils.test.js
+++ b/components/frontend/src/utils.test.js
@@ -241,6 +241,7 @@ it("returns the metric response deadline", () => {
 it("returns the metric response deadline based on the tech debt end date", () => {
     const tomorrow = new Date()
     tomorrow.setDate(tomorrow.getDate() + 1)
+    tomorrow.setHours(23, 59, 59)
     expect(
         getMetricResponseDeadline({ status: "debt_target_met", debt_end_date: tomorrow.toISOString() }, {}),
     ).toStrictEqual(tomorrow)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is not v5.17.1, please first 
 
 ### Fixed
 
+- When calculating how much time is left until the technical debt end date, include the technical debt end date itself in the calculation. Fixes [#10063](https://github.com/ICTU/quality-time/issues/10063).
 - Correctly sort subjects in the "Add subject" dropdown menu. Fixes [#10176](https://github.com/ICTU/quality-time/issues/10176).
 
 ### Changed


### PR DESCRIPTION
…ate, include the technical debt end date itself in the calculation.

Fixes #10063.