### PR TITLE
Don't crash the notifier component when a metric has no scale attribute.

### DIFF
--- a/components/notifier/src/models/metric_notification_data.py
+++ b/components/notifier/src/models/metric_notification_data.py
@@ -30,7 +30,7 @@ class MetricNotificationData:
         self.metric_name = metric["name"] or DATA_MODEL.metrics[metric["type"]].name
         self.metric_unit = metric["unit"] or DATA_MODEL.metrics[metric["type"]].unit.value
         self.subject_name = subject.get("name") or DATA_MODEL.all_subjects[subject["type"]].name
-        self.scale = metric["scale"]
+        self.scale = metric.scale()
         self.status = self.__status(LAST)
         self.new_metric_value = self.__value(LAST)
         self.new_metric_status = self.__user_friendly_status(LAST)

--- a/components/notifier/src/strategies/notification_strategy.py
+++ b/components/notifier/src/strategies/notification_strategy.py
@@ -45,7 +45,7 @@ class NotificationFinder:
         """Determine if a metric got a new status after the given timestamp."""
         if len(measurements) < NR_OF_MEASUREMENTS_NEEDED_TO_DETERMINE_STATUS_CHANGE:
             return False
-        scale = metric["scale"]
+        scale = metric.scale()
         metric_had_other_status = measurements[-2][scale]["status"] != measurements[-1][scale]["status"]
         change_was_recent = datetime.fromisoformat(measurements[-1]["start"]) > most_recent_measurement_seen
         return bool(metric_had_other_status and change_was_recent)

--- a/components/notifier/tests/database/test_measurements.py
+++ b/components/notifier/tests/database/test_measurements.py
@@ -10,7 +10,7 @@ from shared.database.reports import get_reports
 
 from database.measurements import get_recent_measurements
 
-from tests.fixtures import METRIC_ID, create_report
+from tests.fixtures import METRIC_ID, create_report_data
 
 if TYPE_CHECKING:
     from pymongo.database import Database
@@ -30,7 +30,7 @@ class MeasurementsTest(unittest.TestCase):
 
     def test_get_recent_measurements(self):
         """Test that the recent measurements are returned."""
-        self.database["reports"].insert_one(create_report())
+        self.database["reports"].insert_one(create_report_data())
         reports = get_reports(self.database)
 
         metrics = []
@@ -49,7 +49,7 @@ class MeasurementsTest(unittest.TestCase):
 
     def test_get_recent_measurements_limit(self):
         """Test that the recent measurements are returned."""
-        self.database["reports"].insert_one(create_report())
+        self.database["reports"].insert_one(create_report_data())
         reports = get_reports(self.database)
 
         metrics = []

--- a/components/notifier/tests/database/test_reports.py
+++ b/components/notifier/tests/database/test_reports.py
@@ -7,7 +7,7 @@ import mongomock
 
 from database.reports import get_reports_and_measurements
 
-from tests.fixtures import METRIC_ID, create_report
+from tests.fixtures import METRIC_ID, create_report_data
 
 if TYPE_CHECKING:
     from pymongo.database import Database
@@ -27,9 +27,9 @@ class ReportsTest(unittest.TestCase):
 
     def test_get_reports_and_measurements(self):
         """Test that the reports and latest two measurements are returned."""
-        report = create_report()
-        self.database["reports"].insert_one(report)
+        report_data = create_report_data()
+        self.database["reports"].insert_one(report_data)
         self.database["measurements"].insert_many(self.measurements)
         reports, measurements = get_reports_and_measurements(self.database)
-        self.assertEqual(report["report_uuid"], reports[0]["report_uuid"])
+        self.assertEqual(report_data["report_uuid"], reports[0]["report_uuid"])
         self.assertEqual(2, len(measurements))

--- a/components/notifier/tests/destinations/test_teams.py
+++ b/components/notifier/tests/destinations/test_teams.py
@@ -5,9 +5,13 @@ from unittest import TestCase, mock
 
 from pymsteams import cardsection, connectorcard
 
+from shared.model.metric import Metric
+
 from destinations.ms_teams import ICON_URL, create_connector_card, send_notification
 from models.metric_notification_data import MetricNotificationData
 from models.notification import Notification
+
+from tests.fixtures import METRIC_ID, METRIC_ID2
 
 
 class MsTeamsTestCase(TestCase):
@@ -18,17 +22,21 @@ class MsTeamsTestCase(TestCase):
         self.report_url = "https://report1"
         self.report = {"title": "Report 1"}
         self.subject = {"type": "software", "name": "Subject"}
-        metric = {
-            "type": "security_warnings",
-            "name": "Metric",
-            "unit": "sec warnings",
-            "scale": "count",
-        }
+        metric = Metric(
+            {},
+            {
+                "type": "security_warnings",
+                "name": "Metric",
+                "unit": "sec warnings",
+                "scale": "count",
+            },
+            METRIC_ID,
+        )
         measurements = [
             {"count": {"value": 10, "status": "near_target_met"}},
             {"count": {"value": 42, "status": "target_not_met"}},
         ]
-        self.metric_notification_data = MetricNotificationData(metric, "metric_uuid", measurements, self.subject)
+        self.metric_notification_data = MetricNotificationData(metric, METRIC_ID, measurements, self.subject)
         self.notification = Notification(self.report, self.report_url, [self.metric_notification_data], {})
 
 
@@ -73,18 +81,21 @@ class BuildNotificationMessageTests(MsTeamsTestCase):
 
     def test_changed_status_text(self):
         """Test that the text is correct."""
-        scale = "count"
-        metric2 = {
-            "type": "security_warnings",
-            "name": None,
-            "unit": None,
-            "scale": scale,
-        }
+        metric2 = Metric(
+            {},
+            {
+                "type": "security_warnings",
+                "name": None,
+                "unit": None,
+                "scale": "count",
+            },
+            METRIC_ID2,
+        )
         measurements2 = [
             {"count": {"value": 5, "status": "target_met"}},
             {"count": {"value": 10, "status": "target_not_met"}},
         ]
-        metric_notification_data2 = MetricNotificationData(metric2, "metric_uuid2", measurements2, self.subject)
+        metric_notification_data2 = MetricNotificationData(metric2, METRIC_ID2, measurements2, self.subject)
         notification = Notification(
             self.report, self.report_url, [self.metric_notification_data, metric_notification_data2], {}
         )
@@ -97,7 +108,7 @@ class BuildNotificationMessageTests(MsTeamsTestCase):
                 "target_not_met",
                 "target not met (red), was near target met (yellow)",
                 "42 sec warnings, was 10 sec warnings",
-                "metric_uuid",
+                METRIC_ID,
             )
         )
         expected_card.addSection(
@@ -106,25 +117,29 @@ class BuildNotificationMessageTests(MsTeamsTestCase):
                 "target_not_met",
                 "target not met (red), was target met (green)",
                 "10 security warnings, was 5 security warnings",
-                "metric_uuid2",
+                METRIC_ID2,
             )
         )
         self.assertEqual(expected_card.payload, create_connector_card("destination", notification).payload)
 
     def test_unknown_text(self):
         """Test that the text is correct."""
-        metric1 = {
-            "type": "metric_type",
-            "name": "Metric",
-            "unit": "units",
-            "scale": "count",
-        }
+        metric = Metric(
+            {},
+            {
+                "type": "metric_type",
+                "name": "Metric",
+                "unit": "units",
+                "scale": "count",
+            },
+            METRIC_ID,
+        )
         measurements = [
             {"count": {"value": 0, "status": "near_target_met"}},
             {"count": {"value": None, "status": "unknown"}},
         ]
-        metric_notification_data1 = MetricNotificationData(metric1, "metric_uuid", measurements, self.subject)
-        notification = Notification(self.report, self.report_url, [metric_notification_data1], {})
+        metric_notification_data = MetricNotificationData(metric, METRIC_ID, measurements, self.subject)
+        notification = Notification(self.report, self.report_url, [metric_notification_data], {})
         expected_card = connectorcard("destination")
         expected_card.title("Quality-time notifications for Report 1")
         expected_card.summary("Report 1 has 1 metric that changed status")
@@ -134,7 +149,7 @@ class BuildNotificationMessageTests(MsTeamsTestCase):
                 "unknown",
                 "unknown (white), was near target met (yellow)",
                 "unknown, was 0 units",
-                "metric_uuid",
+                METRIC_ID,
             )
         )
         self.assertEqual(expected_card.payload, create_connector_card("destination", notification).payload)

--- a/components/notifier/tests/fixtures.py
+++ b/components/notifier/tests/fixtures.py
@@ -2,17 +2,20 @@
 
 from typing import cast
 
-from shared.utils.type import MetricId, NotificationDestinationId, SubjectId
+from shared.utils.type import MetricId, NotificationDestinationId, ReportId, SubjectId
 
 METRIC_ID = cast(MetricId, "metric_uuid")
+METRIC_ID2 = cast(MetricId, "metric_uuid2")
 NOTIFICATION_DESTINATION_ID = cast(NotificationDestinationId, "destination1")
+REPORT_ID = cast(ReportId, "report_uuid")
+REPORT_ID2 = cast(ReportId, "report_uuid2")
 SUBJECT_ID = cast(SubjectId, "subject_uuid")
 
 
-def create_report(deleted: bool = False) -> dict:
-    """Return a fake report."""
+def create_report_data(deleted: bool = False) -> dict:
+    """Return data for a fake report."""
     report = {
-        "report_uuid": "report1",
+        "report_uuid": REPORT_ID,
         "title": "Title",
         "subjects": {
             SUBJECT_ID: {

--- a/components/notifier/tests/models/test_metric_notification_data.py
+++ b/components/notifier/tests/models/test_metric_notification_data.py
@@ -2,7 +2,11 @@
 
 import unittest
 
+from shared.model.metric import Metric
+
 from models.metric_notification_data import MetricNotificationData
+
+from tests.fixtures import METRIC_ID
 
 
 class MetricNotificationDataModelTestCase(unittest.TestCase):
@@ -10,12 +14,16 @@ class MetricNotificationDataModelTestCase(unittest.TestCase):
 
     def setUp(self):
         """Set variables for the other testcases."""
-        self.metric = {
-            "type": "metric_type",
-            "name": "default metric 1",
-            "unit": "units",
-            "scale": "count",
-        }
+        self.metric = Metric(
+            {},
+            {
+                "type": "metric_type",
+                "name": "default metric 1",
+                "unit": "units",
+                "scale": "count",
+            },
+            METRIC_ID,
+        )
         self.measurements = [
             {"count": {"value": 10, "status": "target_met"}},
             {"count": {"value": 20, "status": "target_not_met"}},
@@ -24,19 +32,19 @@ class MetricNotificationDataModelTestCase(unittest.TestCase):
 
     def test_new_status(self):
         """Test that the new status is set correctly."""
-        notification_data = MetricNotificationData(self.metric, "metric_uuid", self.measurements, self.subject)
+        notification_data = MetricNotificationData(self.metric, METRIC_ID, self.measurements, self.subject)
         self.assertEqual("target_not_met", notification_data.status)
         self.assertEqual("target not met (red)", notification_data.new_metric_status)
 
     def test_unknown_status(self):
         """Test that a recent measurement without status works."""
         self.measurements[-1]["count"]["status"] = None
-        notification_data = MetricNotificationData(self.metric, "metric_uuid", self.measurements, self.subject)
+        notification_data = MetricNotificationData(self.metric, METRIC_ID, self.measurements, self.subject)
         self.assertEqual("unknown", notification_data.status)
         self.assertEqual("unknown (white)", notification_data.new_metric_status)
 
     def test_unknown_status_without_recent_measurements(self):
         """Test that a metric without recent measurements works."""
-        notification_data = MetricNotificationData(self.metric, "metric_uuid", [], self.subject)
+        notification_data = MetricNotificationData(self.metric, METRIC_ID, [], self.subject)
         self.assertEqual("unknown", notification_data.status)
         self.assertEqual("unknown (white)", notification_data.new_metric_status)

--- a/components/notifier/tests/test_fixtures.py
+++ b/components/notifier/tests/test_fixtures.py
@@ -1,21 +1,21 @@
-"""Fixture for reports."""
+"""Unit tests for the report data fixture."""
 
 import unittest
 
-from .fixtures import create_report
+from .fixtures import METRIC_ID, REPORT_ID, SUBJECT_ID, create_report_data
 
 
 class FixtureTest(unittest.TestCase):
     """Tests for fixtures."""
 
-    def test_create_report(self):
-        """Tests create report."""
-        report1 = create_report()
-        self.assertEqual(report1["report_uuid"], "report1")
-        self.assertEqual(report1["title"], "Title")
-        self.assertEqual(report1["subjects"]["subject_uuid"]["metrics"]["metric_uuid"]["name"], "Metric")
+    def test_create_report_data(self):
+        """Test create report."""
+        report_data = create_report_data()
+        self.assertEqual(report_data["report_uuid"], REPORT_ID)
+        self.assertEqual(report_data["title"], "Title")
+        self.assertEqual(report_data["subjects"][SUBJECT_ID]["metrics"][METRIC_ID]["name"], "Metric")
 
-    def test_create_report_deleted(self):
-        """Tests with deleted."""
-        report_deleted = create_report(deleted=True)
-        self.assertTrue(report_deleted["deleted"])
+    def test_create_report_data_deleted(self):
+        """Test create report data for a deleted report."""
+        report_data = create_report_data(deleted=True)
+        self.assertTrue(report_data["deleted"])

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,6 +19,7 @@ If your currently installed *Quality-time* version is not v5.17.1, please first 
 - When calculating how much time is left until the technical debt end date, include the technical debt end date itself in the calculation. Fixes [#10063](https://github.com/ICTU/quality-time/issues/10063).
 - Fix cut off borders of popups in the dashboard. Fixes [#10175](https://github.com/ICTU/quality-time/issues/10175).
 - Correctly sort subjects in the "Add subject" dropdown menu. Fixes [#10176](https://github.com/ICTU/quality-time/issues/10176).
+- Don't crash the notifier component when a metric has no scale attribute. Fixes [#10228](https://github.com/ICTU/quality-time/issues/10228).
 
 ### Changed
 


### PR DESCRIPTION
Fixes #10228.