### PR TITLE
Fix collector GitLab unit tests time zone.

### DIFF
--- a/components/collector/tests/source_collectors/gitlab/base.py
+++ b/components/collector/tests/source_collectors/gitlab/base.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from dateutil.tz import tzlocal
+from dateutil.tz import tzutc
 
 from tests.source_collectors.source_collector_test_case import SourceCollectorTestCase
 
@@ -49,7 +49,7 @@ class GitLabTestCase(SourceCollectorTestCase):
                 "branch": "main",
                 "url": "https://gitlab/job1",
                 "build_date": "2019-03-31",
-                "build_datetime": datetime(2019, 3, 31, 19, 40, 39, 927000, tzinfo=tzlocal()),
+                "build_datetime": datetime(2019, 3, 31, 19, 40, 39, 927000, tzinfo=tzutc()),
                 "build_status": "failed",
             },
             {
@@ -59,7 +59,7 @@ class GitLabTestCase(SourceCollectorTestCase):
                 "branch": "develop",
                 "url": "https://gitlab/job2",
                 "build_date": "2019-03-31",
-                "build_datetime": datetime(2019, 3, 31, 19, 40, 39, 927000, tzinfo=tzlocal()),
+                "build_datetime": datetime(2019, 3, 31, 19, 40, 39, 927000, tzinfo=tzutc()),
                 "build_status": "failed",
             },
         ]


### PR DESCRIPTION
Without this fix, 7 GitLab collector unit tests fail like this one when running the unit tests locally:

```console
======================================================================
FAIL: test_nr_of_unused_jobs (tests.source_collectors.gitlab.test_unused_jobs.GitLabUnusedJobsTest.test_nr_of_unused_jobs)
Test that the number of unused jobs is returned.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/fniessink/Library/Application Support/uv/python/cpython-3.12.5-macos-aarch64-none/lib/python3.12/unittest/async_case.py", line 90, in _callTestMethod
    if self._callMaybeAsync(method) is not None:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/fniessink/Library/Application Support/uv/python/cpython-3.12.5-macos-aarch64-none/lib/python3.12/unittest/async_case.py", line 112, in _callMaybeAsync
    return self._asyncioRunner.run(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/fniessink/Library/Application Support/uv/python/cpython-3.12.5-macos-aarch64-none/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/fniessink/Library/Application Support/uv/python/cpython-3.12.5-macos-aarch64-none/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/fniessink/Developer/quality-time/components/collector/tests/source_collectors/gitlab/test_unused_jobs.py", line 14, in test_nr_of_unused_jobs
    self.assert_measurement(response, value="2", entities=self.expected_entities, landing_url=self.LANDING_URL)
  File "/Users/fniessink/Developer/quality-time/components/collector/tests/source_collectors/source_collector_test_case.py", line 124, in assert_measurement
    self.__assert_measurement_source_attribute(attribute_key, attribute_value, measurement, source_index)
  File "/Users/fniessink/Developer/quality-time/components/collector/tests/source_collectors/source_collector_test_case.py", line 138, in __assert_measurement_source_attribute
    self.assertDictEqual(expected_entity, actual_entity)
AssertionError: {'key': '1', 'name': 'job1', 'stage': 'stage', 'branch'[221 chars]amp'} != {'key': '1', 'first_seen': 'ignore first seen timestamp[219 chars]c())}
  {'branch': 'main',
   'build_date': '2019-03-31',
-  'build_datetime': datetime.datetime(2019, 3, 31, 19, 40, 39, 927000, tzinfo=tzlocal()),
?                                                                                ^^ --

+  'build_datetime': datetime.datetime(2019, 3, 31, 19, 40, 39, 927000, tzinfo=tzutc()),
?                                                                                ^^

   'build_status': 'failed',
   'first_seen': 'ignore first seen timestamp',
   'key': '1',
   'name': 'job1',
   'stage': 'stage',
   'url': 'https://gitlab/job1'}
```