### PR TITLE
Add a result type parameter to the 'jobs within time period' metric.

### DIFF
--- a/components/collector/src/source_collectors/azure_devops/base.py
+++ b/components/collector/src/source_collectors/azure_devops/base.py
@@ -107,8 +107,8 @@ class AzureDevopsPipelines(SourceCollector):
     async def _api_pipelines_url(self, pipeline_id: int | None = None) -> URL:
         """Add the pipelines API, or runs API path if needed."""
         extra_path = "" if not pipeline_id else f"/{pipeline_id}/runs"
-        # currently the pipelines api is not available in any version which is not a -preview version
         api_url = await SourceCollector._api_url(self)  # noqa: SLF001
+        # Use the oldest API version in which the endpoint is available:
         return URL(f"{api_url}/_apis/pipelines{extra_path}?api-version=6.0-preview.1")
 
     async def _active_pipelines(self) -> list[int]:
@@ -148,6 +148,7 @@ class AzureDevopsPipelines(SourceCollector):
                     pipeline=pipeline_name,
                     url=pipeline_run["_links"]["web"]["href"],
                     build_date=str(parse_datetime(pipeline_run["finishedDate"])),
+                    build_result=pipeline_run.get("result", "unknown"),
                     build_status=pipeline_run["state"],
                 ),
             )

--- a/components/collector/src/source_collectors/azure_devops/job_runs_within_time_period.py
+++ b/components/collector/src/source_collectors/azure_devops/job_runs_within_time_period.py
@@ -17,4 +17,5 @@ class AzureDevopsJobRunsWithinTimePeriod(AzureDevopsPipelines):
             return False
         build_age = days_ago(parse_datetime(entity["build_date"]))
         max_build_age = int(cast(str, self._parameter("lookback_days_pipeline_runs")))
-        return build_age <= max_build_age
+        result_types = cast(list[str], self._parameter("result_type"))
+        return build_age <= max_build_age and entity["build_result"] in result_types

--- a/components/collector/src/source_collectors/gitlab/base.py
+++ b/components/collector/src/source_collectors/gitlab/base.py
@@ -88,14 +88,14 @@ class GitLabJobsBase(GitLabProjectBase):
         return Entities(
             [
                 Entity(
-                    key=job["id"],
-                    name=job["name"],
-                    url=job["web_url"],
-                    build_status=job["status"],
                     branch=job["ref"],
-                    stage=job["stage"],
                     build_date=str(self._build_datetime(job).date()),
                     build_datetime=self._build_datetime(job),
+                    build_result=job["status"],
+                    key=job["id"],
+                    name=job["name"],
+                    stage=job["stage"],
+                    url=job["web_url"],
                 )
                 for job in await self._jobs(responses)
             ],

--- a/components/collector/src/source_collectors/gitlab/failed_jobs.py
+++ b/components/collector/src/source_collectors/gitlab/failed_jobs.py
@@ -18,4 +18,4 @@ class GitLabFailedJobs(GitLabJobsBase):
     def _include_entity(self, entity: Entity) -> bool:
         """Return whether the job has failed."""
         failure_types = list(self._parameter("failure_type"))
-        return super()._include_entity(entity) and entity["build_status"] in failure_types
+        return super()._include_entity(entity) and entity["build_result"] in failure_types

--- a/components/collector/src/source_collectors/gitlab/job_runs_within_time_period.py
+++ b/components/collector/src/source_collectors/gitlab/job_runs_within_time_period.py
@@ -22,6 +22,7 @@ class GitLabJobRunsWithinTimePeriod(GitLabJobsBase):
 
     def _include_entity(self, entity: Entity) -> bool:
         """Return whether the job was run within the specified time period."""
+        lookback_days = int(cast(str, self._parameter("lookback_days")))
+        result_types = cast(list[str], self._parameter("result_type"))
         build_age = days_ago(entity["build_datetime"])
-        within_time_period = build_age <= int(cast(str, self._parameter("lookback_days")))
-        return within_time_period and super()._include_entity(entity)
+        return build_age <= lookback_days and entity["build_result"] in result_types and super()._include_entity(entity)

--- a/components/collector/src/source_collectors/jenkins/change_failure_rate.py
+++ b/components/collector/src/source_collectors/jenkins/change_failure_rate.py
@@ -23,12 +23,12 @@ class JenkinsChangeFailureRate(JenkinsJobs):
         return Entities(
             [
                 Entity(
+                    build_date=str(datetime_from_timestamp(build["timestamp"])),
+                    build_datetime=datetime_from_timestamp(build["timestamp"]),
+                    build_result=str(build.get("result", "")).capitalize().replace("_", " "),
                     key=f"{job['name']}-{build['timestamp']}",
                     name=job["name"],
                     url=job["url"],
-                    build_status=str(build.get("result", "")).capitalize().replace("_", " "),
-                    build_date=str(datetime_from_timestamp(build["timestamp"])),
-                    build_datetime=datetime_from_timestamp(build["timestamp"]),
                 )
                 for build, job in self._builds_with_jobs((await responses[0].json())["jobs"])
             ],

--- a/components/collector/src/source_collectors/jenkins/failed_jobs.py
+++ b/components/collector/src/source_collectors/jenkins/failed_jobs.py
@@ -10,4 +10,4 @@ class JenkinsFailedJobs(JenkinsJobs):
 
     def _include_entity(self, entity: Entity) -> bool:
         """Extend to count the job if its build status matches the failure types selected by the user."""
-        return super()._include_entity(entity) and entity["build_status"] in self._parameter("failure_type")
+        return super()._include_entity(entity) and entity["build_result"] in self._parameter("failure_type")

--- a/components/collector/src/source_collectors/jenkins/job_runs_within_time_period.py
+++ b/components/collector/src/source_collectors/jenkins/job_runs_within_time_period.py
@@ -5,20 +5,17 @@ from typing import cast
 from collector_utilities.date_time import datetime_from_timestamp, days_ago
 from model import Entities, Entity, SourceMeasurement, SourceResponses
 
-from .base import Build, JenkinsJobs, Job
+from .base import Build, JenkinsJobs
 
 
 class JenkinsJobRunsWithinTimePeriod(JenkinsJobs):
     """Collector class to measure the number of Jenkins jobs run within a specified time period."""
 
-    def _include_build(self, build: Build) -> bool:
-        """Return whether to include this build or not."""
-        build_datetime = datetime_from_timestamp(int(build["timestamp"]))
-        return days_ago(build_datetime) <= int(cast(str, self._parameter("lookback_days")))
-
-    def _builds_within_timeperiod(self, job: Job) -> int:
-        """Return the number of job builds within time period."""
-        return len(super()._builds(job))
+    async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
+        """Count the sum of jobs ran."""
+        included_entities = [entity for entity in await self._parse_entities(responses) if self._include_entity(entity)]
+        job_runs = [int(entity["build_count"]) for entity in included_entities]
+        return SourceMeasurement(value=str(sum(job_runs)), entities=Entities(included_entities))
 
     async def _parse_entities(self, responses: SourceResponses) -> Entities:
         """Override to parse the jobs."""
@@ -28,14 +25,15 @@ class JenkinsJobRunsWithinTimePeriod(JenkinsJobs):
                     key=job["name"],
                     name=job["name"],
                     url=job["url"],
-                    build_count=self._builds_within_timeperiod(job),
+                    build_count=str(len(self._builds(job))),
                 )
                 for job in self._jobs((await responses[0].json())["jobs"])
             ],
         )
 
-    async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
-        """Count the sum of jobs ran."""
-        included_entities = [entity for entity in await self._parse_entities(responses) if self._include_entity(entity)]
-        job_runs = [job["build_count"] for job in included_entities]
-        return SourceMeasurement(value=str(sum(job_runs)), entities=Entities(included_entities))
+    def _include_build(self, build: Build) -> bool:
+        """Return whether to include this build or not."""
+        result_types = [result_type.lower() for result_type in self._parameter("result_type")]
+        lookback_days = int(cast(str, self._parameter("lookback_days")))
+        build_datetime = datetime_from_timestamp(int(build["timestamp"]))
+        return days_ago(build_datetime) <= lookback_days and build["result"].lower() in result_types

--- a/components/collector/tests/metric_collectors/test_change_failure_rate.py
+++ b/components/collector/tests/metric_collectors/test_change_failure_rate.py
@@ -98,7 +98,7 @@ class ChangeFailureRateTest(unittest.IsolatedAsyncioTestCase):
             "branch": "main",
             "build_date": self.DEPLOY_DT.astimezone(tzutc()).date().isoformat(),
             "build_datetime": self.DEPLOY_DT,
-            "build_status": "failed",
+            "build_result": "failed",
             "failed": True,
             "key": "1",
             "name": job,

--- a/components/collector/tests/source_collectors/azure_devops/base.py
+++ b/components/collector/tests/source_collectors/azure_devops/base.py
@@ -130,6 +130,7 @@ class AzureDevopsPipelinesTestCase(AzureDevopsTestCase):
                 "key": f"{self.test_pipeline['id']}-20191015_1",  # safe_entity_key
                 "url": f"{self.url}/_build/results?buildId=1",
                 "build_date": "2019-10-15 12:24:10.190586+00:00",
+                "build_result": "succeeded",
                 "build_status": "completed",
             },
             {
@@ -138,6 +139,7 @@ class AzureDevopsPipelinesTestCase(AzureDevopsTestCase):
                 "key": f"{self.test_pipeline['id']}-20191015_2",  # safe_entity_key
                 "url": f"{self.url}/_build/results?buildId=2",
                 "build_date": "2019-10-15 12:34:10.190586+00:00",
+                "build_result": "succeeded",
                 "build_status": "completed",
             },
         ]

--- a/components/collector/tests/source_collectors/azure_devops/test_job_runs_within_time_period.py
+++ b/components/collector/tests/source_collectors/azure_devops/test_job_runs_within_time_period.py
@@ -33,6 +33,19 @@ class AzureDevopsJobRunsWithinTimePeriodTest(AzureDevopsPipelinesTestCase):
 
         self.assert_measurement(response, value="0", entities=[])
 
+    async def test_pipeline_runs_jobs_exclude_by_result_type(self):
+        """Test that the pipeline runs are filtered by result type."""
+        self.set_source_parameter("lookback_days_pipeline_runs", "424242")
+        self.set_source_parameter("result_type", ["succeeded"])
+
+        response = await self.collect(
+            get_request_json_return_value=self.pipeline_runs,
+            get_request_json_side_effect=[self.pipelines, self.pipeline_runs],
+        )
+
+        expected_entities = [entity for entity in self.expected_entities if entity.get("build_result") == "succeeded"]
+        self.assert_measurement(response, value=str(len(expected_entities)), entities=expected_entities)
+
     async def test_pipeline_runs_jobs_empty_include(self):
         """Test that counting pipeline runs filtered by a not-matching name include, works."""
         self.set_source_parameter("lookback_days_pipeline_runs", "424242")
@@ -92,6 +105,7 @@ class AzureDevopsJobRunsWithinTimePeriodTest(AzureDevopsPipelinesTestCase):
                 "key": f"{self.test_pipeline['id']}-{build_date_str}_1",  # safe_entity_key
                 "url": f"{self.url}/_build/results?buildId=6",
                 "build_date": str(now_dt),
+                "build_result": "succeeded",
                 "build_status": "completed",
             },
         ]

--- a/components/collector/tests/source_collectors/gitlab/base.py
+++ b/components/collector/tests/source_collectors/gitlab/base.py
@@ -23,7 +23,7 @@ class GitLabTestCase(SourceCollectorTestCase):
         self.gitlab_jobs_json = [
             {
                 "id": "1",
-                "status": "failed",
+                "status": "skipped",
                 "name": "job1",
                 "stage": "stage",
                 "created_at": "2019-03-31T19:40:39.927Z",
@@ -50,7 +50,7 @@ class GitLabTestCase(SourceCollectorTestCase):
                 "url": "https://gitlab/job1",
                 "build_date": "2019-03-31",
                 "build_datetime": datetime(2019, 3, 31, 19, 40, 39, 927000, tzinfo=tzutc()),
-                "build_status": "failed",
+                "build_result": "skipped",
             },
             {
                 "key": "2",
@@ -60,7 +60,7 @@ class GitLabTestCase(SourceCollectorTestCase):
                 "url": "https://gitlab/job2",
                 "build_date": "2019-03-31",
                 "build_datetime": datetime(2019, 3, 31, 19, 40, 39, 927000, tzinfo=tzutc()),
-                "build_status": "failed",
+                "build_result": "failed",
             },
         ]
 

--- a/components/collector/tests/source_collectors/gitlab/test_job_runs_within_time_period.py
+++ b/components/collector/tests/source_collectors/gitlab/test_job_runs_within_time_period.py
@@ -17,6 +17,14 @@ class GitLabJobRunsWithinTimePeriodTest(GitLabJobsTestCase):
     _job4_url = "https://gitlab/job4"
     _job5_url = "https://gitlab/job5"
 
+    async def test_result_type_filter(self):
+        """Test that the jobs can be filtered by result type."""
+        self.set_source_parameter("lookback_days", "100000")
+        self.set_source_parameter("result_type", ["skipped"])
+        response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
+        entities = [entity for entity in self.expected_entities if entity["build_result"] == "skipped"]
+        self.assert_measurement(response, value=str(len(entities)), entities=entities, landing_url=self.LANDING_URL)
+
     async def test_job_lookback_days(self):
         """Test that the job lookback_days are verified."""
         just_now = datetime.now(tz=tzutc())
@@ -48,14 +56,14 @@ class GitLabJobRunsWithinTimePeriodTest(GitLabJobsTestCase):
         response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
         expected_entities = [
             {
-                "key": "3",
-                "name": "job3",
-                "url": self._job3_url,
-                "build_status": "failed",
                 "branch": "main",
-                "stage": "stage",
                 "build_date": str(just_now.date()),
                 "build_datetime": just_now,
+                "build_result": "failed",
+                "key": "3",
+                "name": "job3",
+                "stage": "stage",
+                "url": self._job3_url,
             },
         ]
         self.assert_measurement(response, value="1", entities=expected_entities, landing_url=self.LANDING_URL)
@@ -79,10 +87,10 @@ class GitLabJobRunsWithinTimePeriodTest(GitLabJobsTestCase):
                 {
                     "id": "4",
                     "status": "failed",
-                    "name": "job3",
+                    "name": "job4",
                     "stage": "stage",
                     "created_at": yesterday.isoformat(),
-                    "web_url": self._job3_url,
+                    "web_url": self._job4_url,
                     "ref": "main",
                 },
             ],
@@ -91,24 +99,24 @@ class GitLabJobRunsWithinTimePeriodTest(GitLabJobsTestCase):
         response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
         expected_entities = [
             {
-                "key": "3",
-                "name": "job3",
-                "url": self._job3_url,
-                "build_status": "failed",
-                "branch": "main",
-                "stage": "stage",
                 "build_date": str(just_now.date()),
                 "build_datetime": just_now,
+                "branch": "main",
+                "build_result": "failed",
+                "key": "3",
+                "name": "job3",
+                "stage": "stage",
+                "url": self._job3_url,
             },
             {
-                "key": "4",
-                "name": "job3",
-                "url": self._job3_url,
-                "build_status": "failed",
                 "branch": "main",
-                "stage": "stage",
                 "build_date": str(yesterday.date()),
                 "build_datetime": just_now - timedelta(days=1),
+                "build_result": "failed",
+                "key": "4",
+                "name": "job4",
+                "stage": "stage",
+                "url": self._job4_url,
             },
         ]
         self.assert_measurement(response, value="2", entities=expected_entities, landing_url=self.LANDING_URL)
@@ -154,24 +162,24 @@ class GitLabJobRunsWithinTimePeriodTest(GitLabJobsTestCase):
         response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
         expected_entities = [
             {
-                "key": "3",
-                "name": "job3",
-                "url": self._job3_url,
-                "build_status": "failed",
                 "branch": "main",
-                "stage": "stage",
                 "build_date": str(just_now.date()),
                 "build_datetime": just_now,
+                "build_result": "failed",
+                "key": "3",
+                "name": "job3",
+                "stage": "stage",
+                "url": self._job3_url,
             },
             {
-                "key": "4",
-                "name": "job4",
-                "url": self._job4_url,
-                "build_status": "failed",
                 "branch": "main",
-                "stage": "stage",
                 "build_date": str(just_before_cutoff.date()),
                 "build_datetime": just_before_cutoff,
+                "build_result": "failed",
+                "key": "4",
+                "name": "job4",
+                "stage": "stage",
+                "url": self._job4_url,
             },
         ]
         self.assert_measurement(response, value="2", entities=expected_entities, landing_url=self.LANDING_URL)

--- a/components/collector/tests/source_collectors/jenkins/base.py
+++ b/components/collector/tests/source_collectors/jenkins/base.py
@@ -12,6 +12,9 @@ class JenkinsTestCase(SourceCollectorTestCase):
         """Extend to set up a Jenkins with a build."""
         super().setUp()
         self.set_source_parameter("failure_type", ["Failure"])
-        self.builds = [{"result": "FAILURE", "timestamp": 1552686540953}]
+        self.builds = [
+            {"result": "FAILURE", "timestamp": 1552686540953},
+            {"result": "SUCCESS", "timestamp": 1552686531953},
+        ]
         self.job_url = "https://job"
         self.job2_url = "https://job2"

--- a/components/collector/tests/source_collectors/jenkins/test_failed_jobs.py
+++ b/components/collector/tests/source_collectors/jenkins/test_failed_jobs.py
@@ -38,7 +38,7 @@ class JenkinsFailedJobsTest(JenkinsTestCase):
             {
                 "build_date": "2019-03-15",
                 "build_datetime": datetime_from_timestamp(self.builds[0]["timestamp"]),
-                "build_status": "Failure",
+                "build_result": "Failure",
                 "key": "job",
                 "name": "job",
                 "url": self.job_url,
@@ -54,7 +54,7 @@ class JenkinsFailedJobsTest(JenkinsTestCase):
             {
                 "build_date": "2019-03-15",
                 "build_datetime": datetime_from_timestamp(self.builds[0]["timestamp"]),
-                "build_status": "Failure",
+                "build_result": "Failure",
                 "key": "job",
                 "name": "job",
                 "url": self.job_url,
@@ -70,7 +70,7 @@ class JenkinsFailedJobsTest(JenkinsTestCase):
             {
                 "build_date": "2019-03-15",
                 "build_datetime": datetime_from_timestamp(self.builds[0]["timestamp"]),
-                "build_status": "Failure",
+                "build_result": "Failure",
                 "key": "job2",
                 "name": "job2",
                 "url": self.job2_url,
@@ -86,7 +86,7 @@ class JenkinsFailedJobsTest(JenkinsTestCase):
             {
                 "build_date": "2019-03-15",
                 "build_datetime": datetime_from_timestamp(self.builds[0]["timestamp"]),
-                "build_status": "Failure",
+                "build_result": "Failure",
                 "key": "job",
                 "name": "job",
                 "url": self.job_url,
@@ -102,7 +102,7 @@ class JenkinsFailedJobsTest(JenkinsTestCase):
             {
                 "build_date": "2019-03-15",
                 "build_datetime": datetime_from_timestamp(self.builds[0]["timestamp"]),
-                "build_status": "Failure",
+                "build_result": "Failure",
                 "key": "job",
                 "name": "job",
                 "url": self.job_url,
@@ -122,7 +122,7 @@ class JenkinsFailedJobsTest(JenkinsTestCase):
             {
                 "build_date": "2019-03-15",
                 "build_datetime": datetime_from_timestamp(self.builds[0]["timestamp"]),
-                "build_status": "Failure",
+                "build_result": "Failure",
                 "key": "job3",
                 "name": "job3",
                 "url": "https://job3",

--- a/components/collector/tests/source_collectors/jenkins/test_job_runs_within_time_period.py
+++ b/components/collector/tests/source_collectors/jenkins/test_job_runs_within_time_period.py
@@ -12,6 +12,27 @@ class JenkinsJobRunsWithinTimePeriodTest(JenkinsTestCase):
 
     METRIC_TYPE = "job_runs_within_time_period"
 
+    async def test_all_builds(self):
+        """Test that all builds are counted if no filtering is done."""
+        self.set_source_parameter("lookback_days", "100000")
+        jenkins_json = {
+            "jobs": [{"name": "job", "url": self.job_url, "buildable": True, "color": "blue", "builds": self.builds}],
+        }
+        response = await self.collect(get_request_json_return_value=jenkins_json)
+        expected_entities = [{"build_count": "2", "key": "job", "name": "job", "url": self.job_url}]
+        self.assert_measurement(response, value="2", entities=expected_entities)
+
+    async def test_filter_by_result_type(self):
+        """Test that the builds can be filtered by result type."""
+        self.set_source_parameter("lookback_days", "100000")
+        self.set_source_parameter("result_type", ["Failure"])
+        jenkins_json = {
+            "jobs": [{"name": "job", "url": self.job_url, "buildable": True, "color": "blue", "builds": self.builds}],
+        }
+        response = await self.collect(get_request_json_return_value=jenkins_json)
+        expected_entities = [{"build_count": "1", "key": "job", "name": "job", "url": self.job_url}]
+        self.assert_measurement(response, value="1", entities=expected_entities)
+
     async def test_job_lookback_days(self):
         """Test that the build lookback_days are verified."""
         self.set_source_parameter("lookback_days", "3")
@@ -31,5 +52,5 @@ class JenkinsJobRunsWithinTimePeriodTest(JenkinsTestCase):
         }
         response = await self.collect(get_request_json_return_value=jenkins_json)
 
-        expected_entities = [{"build_count": 1, "key": "job", "name": "job", "url": self.job_url}]
+        expected_entities = [{"build_count": "1", "key": "job", "name": "job", "url": self.job_url}]
         self.assert_measurement(response, value="1", entities=expected_entities)

--- a/components/collector/tests/source_collectors/jenkins/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/jenkins/test_source_up_to_dateness.py
@@ -22,7 +22,7 @@ class JenkinsSourceUpToDatenessTest(JenkinsTestCase):
             {
                 "build_date": "2019-03-15",
                 "build_datetime": expected_dt,
-                "build_status": "Failure",
+                "build_result": "Failure",
                 "key": "job",
                 "name": "job",
                 "url": self.job_url,
@@ -38,7 +38,7 @@ class JenkinsSourceUpToDatenessTest(JenkinsTestCase):
             {
                 "build_date": "",
                 "build_datetime": None,
-                "build_status": "Not built",
+                "build_result": "Not built",
                 "key": "job",
                 "name": "job",
                 "url": self.job_url,
@@ -48,9 +48,8 @@ class JenkinsSourceUpToDatenessTest(JenkinsTestCase):
 
     async def test_ignore_failed_builds(self):
         """Test that failed builds can be ignored."""
-        success_dt = 1553686540953
+        success_dt = 1552686531953
         self.set_source_parameter("result_type", ["Success"])
-        self.builds.append({"result": "SUCCESS", "timestamp": success_dt})
         jenkins_json = {
             "jobs": [{"name": "job", "url": self.job_url, "buildable": True, "color": "red", "builds": self.builds}],
         }
@@ -58,9 +57,9 @@ class JenkinsSourceUpToDatenessTest(JenkinsTestCase):
         expected_dt = datetime_from_timestamp(success_dt)
         expected_entities = [
             {
-                "build_date": "2019-03-27",
+                "build_date": "2019-03-15",
                 "build_datetime": expected_dt,
-                "build_status": "Success",
+                "build_result": "Success",
                 "key": "job",
                 "name": "job",
                 "url": self.job_url,

--- a/components/shared_code/src/shared_data_model/parameters.py
+++ b/components/shared_code/src/shared_data_model/parameters.py
@@ -196,6 +196,16 @@ class FailureType(MultipleChoiceParameter):
     metrics: list[str] = ["failed_jobs"]
 
 
+class ResultType(MultipleChoiceParameter):
+    """Build result type parameter."""
+
+    name: str = "Build result types"
+    short_name: str = "result types"
+    help: str = "Limit which build result types to include."
+    placeholder: str = "all result types"
+    metrics: list[str] = ["job_runs_within_time_period"]
+
+
 def access_parameters(
     metrics: list[str],
     include: dict[str, bool] | None = None,

--- a/components/shared_code/src/shared_data_model/sources/azure_devops.py
+++ b/components/shared_code/src/shared_data_model/sources/azure_devops.py
@@ -14,6 +14,7 @@ from shared_data_model.parameters import (
     MultipleChoiceParameter,
     MultipleChoiceWithAdditionParameter,
     PrivateToken,
+    ResultType,
     StringParameter,
     TargetBranchesToInclude,
     TestResult,
@@ -46,11 +47,15 @@ PIPELINE_ATTRIBUTES = [
     EntityAttribute(
         name="Status of most recent build",
         key="build_status",
+    ),
+    # Result types conform https://learn.microsoft.com/en-us/rest/api/azure/devops/pipelines/runs/list?view=azure-devops-rest-6.0#runresult
+    EntityAttribute(
+        name="Result of most recent build",
+        key="build_result",
         color={
             "succeeded": Color.POSITIVE,
             "failed": Color.NEGATIVE,
             "canceled": Color.ACTIVE,
-            "partiallySucceeded": Color.WARNING,
         },
     ),
     EntityAttribute(name="Date of most recent build", key="build_date", type=EntityAttributeType.DATE),
@@ -193,6 +198,8 @@ AZURE_DEVOPS = Source(
             values=["canceled", "failed", "no result", "partially succeeded"],
             api_values={"no result": "none", "partially succeeded": "partiallySucceeded"},
         ),
+        # Result types conform https://learn.microsoft.com/en-us/rest/api/azure/devops/pipelines/runs/list?view=azure-devops-rest-6.0#runresult
+        "result_type": ResultType(values=["canceled", "failed", "succeeded", "unknown"]),
         "merge_request_state": MergeRequestState(
             values=["abandoned", "active", "completed", "not set"],
             api_values={"not set": "notSet"},

--- a/components/shared_code/src/shared_data_model/sources/gitlab.py
+++ b/components/shared_code/src/shared_data_model/sources/gitlab.py
@@ -15,6 +15,7 @@ from shared_data_model.parameters import (
     MultipleChoiceParameter,
     MultipleChoiceWithAdditionParameter,
     PrivateToken,
+    ResultType,
     StringParameter,
     TargetBranchesToInclude,
     Upvotes,
@@ -39,9 +40,14 @@ JOB_ENTITY = Entity(
         EntityAttribute(name="Job stage", key="stage"),
         EntityAttribute(name="Branch or tag", key="branch"),
         EntityAttribute(
-            name="Status of most recent build",
-            key="build_status",
-            color={"canceled": Color.ACTIVE, "failed": Color.NEGATIVE, "success": Color.POSITIVE},
+            name="Result of most recent build",
+            key="build_result",
+            color={
+                "canceled": Color.ACTIVE,
+                "failed": Color.NEGATIVE,
+                "skipped": Color.WARNING,
+                "success": Color.POSITIVE,
+            },
         ),
         EntityAttribute(name="Date of most recent build", key="build_date", type=EntityAttributeType.DATE),
     ],
@@ -146,6 +152,7 @@ profile/personal_access_tokens.html) with the scope `read_repository` in the pri
             metrics=["unused_jobs"],
         ),
         "failure_type": FailureType(values=["canceled", "failed", "skipped"]),
+        "result_type": ResultType(values=["canceled", "failed", "skipped", "success"]),
         "jobs_to_ignore": MultipleChoiceWithAdditionParameter(
             name="Jobs to ignore (regular expressions or job names)",
             short_name="jobs to ignore",

--- a/components/shared_code/src/shared_data_model/sources/jenkins.py
+++ b/components/shared_code/src/shared_data_model/sources/jenkins.py
@@ -9,8 +9,8 @@ from shared_data_model.parameters import (
     Branches,
     Days,
     FailureType,
-    MultipleChoiceParameter,
     MultipleChoiceWithAdditionParameter,
+    ResultType,
     StringParameter,
     TestResult,
     access_parameters,
@@ -54,8 +54,8 @@ JOB_ENTITY = Entity(
     attributes=[
         EntityAttribute(name=_JOB_ENTITY_NAME_NAME, key="name", url="url"),
         EntityAttribute(
-            name="Status of most recent build",
-            key="build_status",
+            name="Result of most recent build",
+            key="build_result",
             color={
                 "Success": Color.POSITIVE,
                 "Failure": Color.NEGATIVE,
@@ -136,13 +136,9 @@ the "Username" field and the private token in the "**Password**" field.
             mandatory=True,
             metrics=["pipeline_duration"],
         ),
-        "result_type": MultipleChoiceParameter(
-            name="Build result types",
-            short_name="result types",
-            help="Limit which build result types to include.",
-            placeholder="all result types",
+        "result_type": ResultType(
             values=["Aborted", "Failure", "Not built", "Success", "Unstable"],
-            metrics=["pipeline_duration", "source_up_to_dateness"],
+            metrics=["job_runs_within_time_period", "pipeline_duration", "source_up_to_dateness"],
         ),
         "failure_type": FailureType(values=["Aborted", "Failure", "Not built", "Unstable"]),
         **jenkins_access_parameters(
@@ -161,7 +157,7 @@ the "Username" field and the private token in the "**Password**" field.
             name="deployment",
             attributes=[
                 EntityAttribute(name=_JOB_ENTITY_NAME_NAME, key="name", url="url"),
-                EntityAttribute(name="Status of most recent build", key="build_status"),
+                EntityAttribute(name="Result of most recent build", key="build_result"),
                 EntityAttribute(name="Date of most recent build", key="build_date", type=EntityAttributeType.DATE),
             ],
         ),

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 ### Added
 
 - Allow for measuring the time since the last analysis date of a Bill-of-Materials (BOM) in Dependency-Track using the new 'project event type' parameter of the 'source up-to-dateness' metric. Closes [#9764](https://github.com/ICTU/quality-time/issues/9764).
+- Add a result type parameter to the 'jobs within time period' metric to allow for filtering jobs by result type (success, failed, skipped, etc.). Closes [#9926](https://github.com/ICTU/quality-time/issues/9926).
 - Allow for using Visual Studio test reports (.trx) as source for the metrics 'tests', 'test cases', and 'source up-to-dateness'. Closes [#10009](https://github.com/ICTU/quality-time/issues/10009).
 
 ## v5.18.0 - 2024-11-06


### PR DESCRIPTION
Add a result type parameter to the 'jobs within time period' metric for the sources:
- Azure DevOps
- GitLab 
- Jenkins 

Closes #9926.