### PR TITLE
Filter by Dependency-Track component name.

### DIFF
--- a/components/collector/src/source_collectors/dependency_track/base.py
+++ b/components/collector/src/source_collectors/dependency_track/base.py
@@ -105,5 +105,12 @@ class DependencyTrackLatestVersionStatusBase(DependencyTrackBase):
 
     def _include_entity(self, entity: Entity) -> bool:
         """Return whether to include the entity in the measurement."""
+        component_name = entity["component"]
+        components_to_include = self._parameter("components_to_include")
+        if components_to_include and not match_string_or_regular_expression(component_name, components_to_include):
+            return False
+        components_to_ignore = self._parameter("components_to_ignore")
+        if components_to_ignore and match_string_or_regular_expression(component_name, components_to_ignore):
+            return False
         has_latest_version_status = entity["latest_version_status"] in self._parameter("latest_version_status")
         return super()._include_entity(entity) and has_latest_version_status

--- a/components/collector/tests/source_collectors/dependency_track/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_security_warnings.py
@@ -101,6 +101,30 @@ class DependencyTrackSecurityWarningsTest(DependencyTrackTestCase):
         response = await self.collect(get_request_json_side_effect=[self.projects(), self.findings()])
         self.assert_measurement(response, value="1", entities=self.entities())
 
+    async def test_include_by_component_name(self):
+        """Test filtering by component name."""
+        self.set_source_parameter("components_to_include", ["other component"])
+        response = await self.collect(get_request_json_side_effect=[self.projects(), self.findings()])
+        self.assert_measurement(response, value="0", entities=[])
+
+    async def test_include_by_component_name_regular_expression(self):
+        """Test filtering by component name regular expression."""
+        self.set_source_parameter("components_to_include", ["component.*"])
+        response = await self.collect(get_request_json_side_effect=[self.projects(), self.findings()])
+        self.assert_measurement(response, value="1", entities=self.entities())
+
+    async def test_exclude_by_component_name(self):
+        """Test filtering by component name."""
+        self.set_source_parameter("components_to_ignore", ["component name"])
+        response = await self.collect(get_request_json_side_effect=[self.projects(), self.findings()])
+        self.assert_measurement(response, value="0", entities=[])
+
+    async def test_exclude_by_component_name_regular_expression(self):
+        """Test filtering by component name regular expression."""
+        self.set_source_parameter("components_to_ignore", ["other.*"])
+        response = await self.collect(get_request_json_side_effect=[self.projects(), self.findings()])
+        self.assert_measurement(response, value="1", entities=self.entities())
+
     async def test_api_key(self):
         """Test that the API key is passed as header."""
         self.set_source_parameter("private_token", "API key")

--- a/components/shared_code/src/shared_data_model/sources/dependency_track.py
+++ b/components/shared_code/src/shared_data_model/sources/dependency_track.py
@@ -69,6 +69,18 @@ DEPENDENCY_TRACK = Source(
             short_name="project versions",
             metrics=["dependencies", "security_warnings", "source_up_to_dateness"],
         ),
+        "components_to_include": MultipleChoiceWithAdditionParameter(
+            name="Components to include (regular expressions or component names)",
+            placeholder="all components",
+            short_name="components to include",
+            metrics=["dependencies", "security_warnings"],
+        ),
+        "components_to_ignore": MultipleChoiceWithAdditionParameter(
+            name="Components to ignore (regular expressions or component names)",
+            placeholder="none",
+            short_name="components to ignore",
+            metrics=["dependencies", "security_warnings"],
+        ),
         "latest_version_status": MultipleChoiceParameter(
             name="Latest version statuses",
             short_name="statuses",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 ### Added
 
+- Allow for filtering by component when measuring dependencies and security warnings with Dependency-Track as source. Closes [#9577](https://github.com/ICTU/quality-time/issues/9577).
 - Allow for measuring the time since the last analysis date of a Bill-of-Materials (BOM) in Dependency-Track using the new 'project event type' parameter of the 'source up-to-dateness' metric. Closes [#9764](https://github.com/ICTU/quality-time/issues/9764).
 - Add a result type parameter to the 'jobs within time period' metric to allow for filtering jobs by result type (success, failed, skipped, etc.). Closes [#9926](https://github.com/ICTU/quality-time/issues/9926).
 - Allow for using Visual Studio test reports (.trx) as source for the metrics 'tests', 'test cases', and 'source up-to-dateness'. Closes [#10009](https://github.com/ICTU/quality-time/issues/10009).


### PR DESCRIPTION
Allow for filtering by component name when measuring dependencies and security warnings with Dependency-Track as source.

Closes #9577.