### PR TITLE
Add test suite to Robot Framework entities

### DIFF
--- a/components/collector/src/metric_collectors/test_cases.py
+++ b/components/collector/src/metric_collectors/test_cases.py
@@ -59,8 +59,9 @@ class TestCases(MetricCollector):
         "timeout": "errored",
         "warning": "errored",
     }
-    # Regular expression to identify test case ids in test names and descriptions:
+    # Regular expression to identify test case ids in entity attributes:
     TEST_CASE_KEY_RE = re.compile(r"\w+\-\d+")
+    ENTITY_ATTRIBUTES_TO_SEARCH = ("name", "test_name", "description")
     # The supported source types for test cases and test reports:
     TEST_CASE_SOURCE_TYPES: ClassVar[list[str]] = ["jira"]
     TEST_REPORT_SOURCE_TYPES: ClassVar[list[str]] = [
@@ -121,7 +122,7 @@ class TestCases(MetricCollector):
     @classmethod
     def referenced_test_cases(cls, entity: Entity) -> set[str]:
         """Return the keys of test cases referenced in test entity names or descriptions."""
-        text_attributes = " ".join(entity.get(attribute_key, "") for attribute_key in ("name", "description"))
+        text_attributes = " ".join(entity.get(attribute_key, "") for attribute_key in cls.ENTITY_ATTRIBUTES_TO_SEARCH)
         return set(re.findall(cls.TEST_CASE_KEY_RE, text_attributes))
 
     def test_results_to_count(self, source: SourceMeasurement) -> list[TestResult]:

--- a/components/collector/src/source_collectors/robot_framework/tests.py
+++ b/components/collector/src/source_collectors/robot_framework/tests.py
@@ -39,9 +39,14 @@ class RobotFrameworkTests(RobotFrameworkBaseClass):
         stats = first(tree.findall("statistics/total/stat"), lambda stat: (stat.text or "").lower() == "all tests")
         for test_result in all_test_results:
             total_nr_of_tests += int(stats.get(test_result, 0))
-            if test_result in test_results:
-                nr_of_tests += int(stats.get(test_result, 0))
-                for test in tree.findall(f".//test/status[@status='{test_result.upper()}']/.."):
-                    entity = Entity(key=test.get("id", ""), name=test.get("name", ""), test_result=test_result)
+            if test_result not in test_results:
+                continue
+            nr_of_tests += int(stats.get(test_result, 0))
+            for suite in tree.findall(".//suite[test]"):
+                suite_name = suite.get("name", "<Nameless suite>")
+                for test in suite.findall(f"test/status[@status='{test_result.upper()}']/.."):
+                    test_id = test.get("id", "")
+                    test_name = test.get("name", "<Nameless test>")
+                    entity = Entity(key=test_id, test_name=test_name, suite_name=suite_name, test_result=test_result)
                     entities.append(entity)
         return nr_of_tests, total_nr_of_tests, entities

--- a/components/collector/tests/metric_collectors/test_test_cases.py
+++ b/components/collector/tests/metric_collectors/test_test_cases.py
@@ -37,9 +37,13 @@ class TestCasesTest(unittest.IsolatedAsyncioTestCase):
             <testcase name="no_such_key-1"><failure /></testcase>
         </testsuite>
         """
-    ROBOT_FRAMEWORK_XML_V4 = """<?xml version="1.0" encoding="UTF-8"?>
-        <robot generator="Robot 4.0b3.dev1 (Python 3.9.1 on linux)" generated="20210212 17:27:03.027">
-            <suite>
+    ROBOT_FRAMEWORK_XML_V5 = """<?xml version="1.0" encoding="UTF-8"?>
+        <robot
+            generator="Robot 7.1.1 (Python 3.12.7 on linux)"
+            generated="2021-02-12T17:27:03.027383"
+            schemaversion="5"
+        >
+            <suite name="Suite 1">
                 <test id="s1-t1" name="key-1; Test 1">
                     <status status="PASS"></status>
                 </test>
@@ -138,7 +142,7 @@ class TestCasesTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_matching_test_case_robot_framework(self):
         """Test one matching test case."""
-        self.response.text = AsyncMock(return_value=self.ROBOT_FRAMEWORK_XML_V4)
+        self.response.text = AsyncMock(return_value=self.ROBOT_FRAMEWORK_XML_V5)
         jira = {"type": "jira", "parameters": {"url": self.jira_url, "jql": "jql"}}
         robot_framework = {"type": "robot_framework", "parameters": {"url": self.test_report_url}}
         measurement = await self.collect({"jira": jira, "robot_framework": robot_framework})

--- a/components/collector/tests/source_collectors/robot_framework/base.py
+++ b/components/collector/tests/source_collectors/robot_framework/base.py
@@ -7,26 +7,9 @@ class RobotFrameworkTestCase(SourceCollectorTestCase):
     """Base class for testing Robot Framework collectors."""
 
     SOURCE_TYPE = "robot_framework"
-    ROBOT_FRAMEWORK_XML_V3 = """<?xml version="1.0"?>
-        <robot generator="Robot 3.2.2 (Python 3.9.1 on linux)" generated="20210212 17:27:03.027">
-             <suite>
-                <test id="s1-t1" name="Test 1">
-                    <status status="FAIL"></status>
-                </test>
-                <test id="s1-t2" name="Test 2">
-                    <status status="PASS"></status>
-                </test>
-            </suite>
-            <statistics>
-                <total>
-                    <stat pass="1" fail="1">Critical Tests</stat>
-                    <stat pass="1" fail="1">All Tests</stat>
-                </total>
-            </statistics>
-        </robot>"""
     ROBOT_FRAMEWORK_XML_V4 = """<?xml version="1.0" encoding="UTF-8"?>
         <robot generator="Robot 4.0b3.dev1 (Python 3.9.1 on linux)" generated="20210212 17:27:03.027">
-            <suite>
+            <suite name="Suite 1">
                 <test id="s1-t1" name="Test 1">
                     <status status="FAIL"></status>
                 </test>
@@ -42,7 +25,7 @@ class RobotFrameworkTestCase(SourceCollectorTestCase):
         </robot>"""
     ROBOT_FRAMEWORK_XML_V4_WITH_SKIPPED_TESTS = """<?xml version="1.0" encoding="UTF-8"?>
         <robot generator="Robot 4.0b3.dev1 (Python 3.9.1 on linux)" generated="20210212 17:27:03.027">
-            <suite>
+            <suite name="Suite 1">
                 <test id="s1-t1" name="Test 1">
                     <status status="FAIL"></status>
                 </test>
@@ -59,3 +42,27 @@ class RobotFrameworkTestCase(SourceCollectorTestCase):
                 </total>
             </statistics>
         </robot>"""
+    ROBOT_FRAMEWORK_XML_V5 = """<?xml version="1.0" encoding="UTF-8"?>
+        <robot
+            generator="Robot 7.1.1 (Python 3.12.7 on linux)"
+            generated="2021-02-12T17:27:03.027383"
+            rpa="false"
+            schemaversion="5"
+        >
+            <suite>
+                <suite name="Suite 1">
+                    <test id="s1-t1" name="Test 1">
+                        <status status="FAIL"></status>
+                    </test>
+                    <test id="s1-t2" name="Test 2">
+                        <status status="PASS"></status>
+                    </test>
+                </suite>
+            </suite>
+            <statistics>
+                <total>
+                    <stat pass="1" fail="1" skip="0">All Tests</stat>
+                </total>
+            </statistics>
+        </robot>"""
+    ROBOT_FRAMEWORK_XMLS = ROBOT_FRAMEWORK_XML_V4, ROBOT_FRAMEWORK_XML_V5

--- a/components/collector/tests/source_collectors/robot_framework/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/robot_framework/test_source_up_to_dateness.py
@@ -13,7 +13,7 @@ class RobotFrameworkSourceUpToDatenessTest(RobotFrameworkTestCase):
 
     async def test_source_up_to_dateness(self):
         """Test that the source age in days is returned."""
-        for xml in [self.ROBOT_FRAMEWORK_XML_V3, self.ROBOT_FRAMEWORK_XML_V4]:
+        for xml in self.ROBOT_FRAMEWORK_XMLS:
             with self.subTest(xml=xml):
                 response = await self.collect(get_request_text=xml)
                 expected_age = days_ago(datetime_from_parts(2021, 2, 12, 17, 27, 3))

--- a/components/collector/tests/source_collectors/robot_framework/test_source_version.py
+++ b/components/collector/tests/source_collectors/robot_framework/test_source_version.py
@@ -9,12 +9,12 @@ class RobotFrameworkSourceVersion(RobotFrameworkTestCase):
     METRIC_TYPE = "source_version"
     METRIC_ADDITION = "min"
 
-    async def test_source_version3(self):
-        """Test that the Robot Framework version is returned."""
-        response = await self.collect(get_request_text=self.ROBOT_FRAMEWORK_XML_V3)
-        self.assert_measurement(response, value="3.2.2")
-
     async def test_source_version4(self):
         """Test that the Robot Framework version is returned."""
         response = await self.collect(get_request_text=self.ROBOT_FRAMEWORK_XML_V4)
         self.assert_measurement(response, value="4.0b3.dev1")
+
+    async def test_source_version5(self):
+        """Test that the Robot Framework version is returned."""
+        response = await self.collect(get_request_text=self.ROBOT_FRAMEWORK_XML_V5)
+        self.assert_measurement(response, value="7.1.1")

--- a/components/collector/tests/source_collectors/robot_framework/test_tests.py
+++ b/components/collector/tests/source_collectors/robot_framework/test_tests.py
@@ -11,12 +11,12 @@ class RobotFrameworkTestReportTest(RobotFrameworkTestCase):
 
     async def test_tests(self):
         """Test that the number of tests is returned."""
-        for xml in self.ROBOT_FRAMEWORK_XML_V3, self.ROBOT_FRAMEWORK_XML_V4:
+        for xml in self.ROBOT_FRAMEWORK_XMLS:
             with self.subTest(xml=xml):
                 response = await self.collect(get_request_text=xml)
                 expected_entities = [
-                    {"key": "s1-t1", "name": "Test 1", "test_result": "fail"},
-                    {"key": "s1-t2", "name": "Test 2", "test_result": "pass"},
+                    {"key": "s1-t1", "test_name": "Test 1", "test_result": "fail", "suite_name": "Suite 1"},
+                    {"key": "s1-t2", "test_name": "Test 2", "test_result": "pass", "suite_name": "Suite 1"},
                 ]
                 self.assert_measurement(
                     response,
@@ -28,11 +28,13 @@ class RobotFrameworkTestReportTest(RobotFrameworkTestCase):
 
     async def test_failed_tests(self):
         """Test that the number of failed tests is returned."""
-        for xml in self.ROBOT_FRAMEWORK_XML_V3, self.ROBOT_FRAMEWORK_XML_V4:
+        for xml in self.ROBOT_FRAMEWORK_XMLS:
             with self.subTest(xml=xml):
                 self.set_source_parameter("test_result", ["fail"])
-                response = await self.collect(get_request_text=self.ROBOT_FRAMEWORK_XML_V3)
-                expected_entities = [{"key": "s1-t1", "name": "Test 1", "test_result": "fail"}]
+                response = await self.collect(get_request_text=xml)
+                expected_entities = [
+                    {"key": "s1-t1", "test_name": "Test 1", "test_result": "fail", "suite_name": "Suite 1"},
+                ]
                 self.assert_measurement(
                     response,
                     value="1",
@@ -45,7 +47,7 @@ class RobotFrameworkTestReportTest(RobotFrameworkTestCase):
         """Test that the number of skipped tests is returned."""
         self.set_source_parameter("test_result", ["skip"])
         response = await self.collect(get_request_text=self.ROBOT_FRAMEWORK_XML_V4_WITH_SKIPPED_TESTS)
-        expected_entities = [{"key": "s1-t3", "name": "Test 3", "test_result": "skip"}]
+        expected_entities = [{"key": "s1-t3", "test_name": "Test 3", "test_result": "skip", "suite_name": "Suite 1"}]
         self.assert_measurement(
             response,
             value="1",

--- a/components/shared_code/src/shared_data_model/sources/robot_framework.py
+++ b/components/shared_code/src/shared_data_model/sources/robot_framework.py
@@ -27,7 +27,8 @@ ROBOT_FRAMEWORK = Source(
         "tests": Entity(
             name="test",
             attributes=[
-                EntityAttribute(name="Test name", key="name"),
+                EntityAttribute(name="Suite name"),
+                EntityAttribute(name="Test name"),
                 EntityAttribute(name="Test result", color={"fail": Color.NEGATIVE, "pass": Color.POSITIVE}),
             ],
         ),


### PR DESCRIPTION
Add test suite to the Robot Framework entities.

When using Robot Framework test reports as source for the tests metric, also show the test suite in the measurement entities.

Prepares for  #10078.