### PR TITLE
When measuring test cases with Visual Studio TRX as source, search al…

### DIFF
--- a/components/collector/src/metric_collectors/test_cases.py
+++ b/components/collector/src/metric_collectors/test_cases.py
@@ -59,8 +59,9 @@ class TestCases(MetricCollector):
         "timeout": "errored",
         "warning": "errored",
     }
-    # Regular expression to identify test case ids in entity attributes:
-    TEST_CASE_KEY_RE = re.compile(r"\w+\-\d+")
+    # Regular expression to identify test case ids in entity attributes. Matches identifiers of the form BAR-123,
+    # while ensuring they are not part of longer identifiers such as FOO-BAR-123 or BAR-123-456:
+    TEST_CASE_KEY_RE = re.compile(r"(?<![-\w])\b[A-Za-z]+\-\d+\b(?![-\w])")
     ENTITY_ATTRIBUTES_TO_SEARCH = ("name", "test_name", "description")
     # The supported source types for test cases and test reports:
     TEST_CASE_SOURCE_TYPES: ClassVar[list[str]] = ["jira"]

--- a/components/collector/src/source_collectors/visual_studio_trx/tests.py
+++ b/components/collector/src/source_collectors/visual_studio_trx/tests.py
@@ -39,9 +39,10 @@ class VisualStudioTRXTests(XMLFileSourceCollector):
     def __entity(test: Element, result: str, namespaces: Namespaces) -> Entity:
         """Transform a test case into a test entity."""
         name = test.attrib["name"]
-        for category in test.findall(".//ns:TestCategoryItem", namespaces):
-            if match := re.search(TestCases.TEST_CASE_KEY_RE, category.attrib["TestCategory"]):
-                name += f" ({match[0]})"
-                break
+        category_items = test.findall(".//ns:TestCategoryItem", namespaces)
+        categories = [item.attrib["TestCategory"] for item in category_items]
+        matches = [match[0] for category in categories if (match := re.search(TestCases.TEST_CASE_KEY_RE, category))]
+        if matches:
+            name += f" ({', '.join(sorted(matches))})"
         key = test.attrib["id"]
         return Entity(key=key, name=name, test_result=result)

--- a/components/collector/tests/source_collectors/visual_studio_trx/base.py
+++ b/components/collector/tests/source_collectors/visual_studio_trx/base.py
@@ -41,9 +41,15 @@ class VisualStudioTRXCollectorTestCase(SourceCollectorTestCase):
         <TestDefinitions>
             <UnitTest name="BestaandeZaakOpenen" id="446a0829-8d87-1082-ab45-b2ab9f846325">
                 <TestCategory>
-                    <TestCategoryItem TestCategory="FeatureTag" />
-                    <TestCategoryItem TestCategory="ScenarioTag1" />
-                    <TestCategoryItem TestCategory="JIRA-224" />
+                    <TestCategoryItem TestCategory="This is not an identifier" />
+                    <TestCategoryItem TestCategory="This is not an-identifier-1" />
+                    <TestCategoryItem TestCategory="This is not an identifier-1-2" />
+                    <TestCategoryItem TestCategory="This is -not-3 an identifier" />
+                    <TestCategoryItem TestCategory="This is not-4- an identifier" />
+                    <TestCategoryItem TestCategory="This is 5-not an identifier" />
+                    <TestCategoryItem TestCategory="This is not an identifier 6" />
+                    <TestCategoryItem TestCategory="This is an identifier: JIRA-224" />
+                    <TestCategoryItem TestCategory="JIRA-225 is also an identifier" />
                 </TestCategory>
                 <Execution id="daf369f6-7c54-482d-a12c-68357679bd78" />
                 <TestMethod

--- a/components/collector/tests/source_collectors/visual_studio_trx/test_tests.py
+++ b/components/collector/tests/source_collectors/visual_studio_trx/test_tests.py
@@ -14,7 +14,7 @@ class VisualStudioTRXTestReportTest(VisualStudioTRXCollectorTestCase):
         self.expected_entities = [
             {
                 "key": "446a0829-8d87-1082-ab45-b2ab9f846325",
-                "name": "BestaandeZaakOpenen (JIRA-224)",
+                "name": "BestaandeZaakOpenen (JIRA-224, JIRA-225)",
                 "test_result": "Passed",
             },
             {

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,12 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- When measuring test cases with Visual Studio TRX as source, search all test category items for test case ids, instead of cutting the search short after the first match. Fixes [#10460](https://github.com/ICTU/quality-time/issues/10460).
+
 ## v5.20.0 - 2024-12-05
 
 ### Added


### PR DESCRIPTION
…l test category items for test case ids, instead cutting the search short after the first match.

Fixes #10460.