### PR TITLE
Correctly parse empty Axe-core JSON report.

### DIFF
--- a/components/collector/src/source_collectors/axe_core/violations.py
+++ b/components/collector/src/source_collectors/axe_core/violations.py
@@ -57,9 +57,10 @@ class AxeCoreViolations(JSONFileSourceCollector, AxeViolationsCollector):
 
     def _parse_json(self, json: JSON, filename: str) -> Entities:
         """Override to parse the violations."""
+        result_types = self._parameter("result_types")
         entity_attributes = []
         for test_result in self.__parse_test_results(json):
-            violations = {result_type: test_result.get(result_type) for result_type in self._parameter("result_types")}
+            violations = {result_type: test_result.get(result_type, []) for result_type in result_types}
             url = test_result.get("url", "")
             entity_attributes.extend(self.__parse_violations(violations, url))
         return Entities(Entity(key=self.__create_key(attributes), **attributes) for attributes in entity_attributes)

--- a/components/collector/tests/source_collectors/axe_core/test_violations.py
+++ b/components/collector/tests/source_collectors/axe_core/test_violations.py
@@ -94,8 +94,14 @@ class AxeCoreViolationsTest(AxeCoreTestCase):
         self.assert_measurement(response, value="2", entities=self.expected_entities)
 
     async def test_no_issues(self):
-        """Test zero issues."""
+        """Test zero issues, with an empty violations list."""
         self.json["violations"] = []
+        response = await self.collect(get_request_json_return_value=self.json)
+        self.assert_measurement(response, value="0", entities=[])
+
+    async def test_no_violations_key(self):
+        """Test zero issues, without a violations list."""
+        del self.json["violations"]
         response = await self.collect(get_request_json_return_value=self.json)
         self.assert_measurement(response, value="0", entities=[])
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 ### Fixed
 
 - When measuring test cases with Visual Studio TRX as source, search all test category items for test case ids, instead of cutting the search short after the first match. Fixes [#10460](https://github.com/ICTU/quality-time/issues/10460).
+- Correctly parse empty Axe-core JSON report. Fixes [#10487](https://github.com/ICTU/quality-time/issues/10487).
 
 ## v5.20.0 - 2024-12-05
 


### PR DESCRIPTION
Fixes #10487.