### PR TITLE
Deprecate Trello

### DIFF
--- a/components/shared_code/src/shared_data_model/sources/trello.py
+++ b/components/shared_code/src/shared_data_model/sources/trello.py
@@ -51,6 +51,8 @@ TRELLO_APP_KEY_URL = HttpUrl(f"{TRELLO_URL}/app-key")
 TRELLO = Source(
     name="Trello",
     description="Trello is a collaboration tool that organizes projects into boards.",
+    deprecated=True,
+    deprecation_url=HttpUrl("https://github.com/ICTU/quality-time/issues/10613"),
     url=HttpUrl(TRELLO_URL),
     parameters={
         "url": URL(

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -22,6 +22,10 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 - When measuring missing metrics, make the subject type and the metric type of the missing metrics link to the reference documentation. Closes [#10528](https://github.com/ICTU/quality-time/issues/10528).
 
+### Changed
+
+- Support for Trello as source for metrics is deprecated and marked for removal in the future. Closes [#10613](https://github.com/ICTU/quality-time/issues/10613).
+
 ## v5.21.0 - 2024-12-12
 
 ### Fixed


### PR DESCRIPTION
Support for Trello as source for metrics is deprecated and marked for removal in the future.

Closes #10613.