### PR TITLE
Support OWASP Dependency-Check v12.0.0.

### DIFF
--- a/components/collector/src/source_collectors/owasp_dependency_check/base.py
+++ b/components/collector/src/source_collectors/owasp_dependency_check/base.py
@@ -11,5 +11,5 @@ class OWASPDependencyCheckBase(XMLFileSourceCollector, ABC):
 
     allowed_root_tags: ClassVar[list[str]] = [
         f"{{https://jeremylong.github.io/DependencyCheck/dependency-check.{version}.xsd}}analysis"
-        for version in ("2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "3.0", "3.1", "4.0")
+        for version in ("2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "3.0", "3.1", "4.0", "4.1")
     ]

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -21,6 +21,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 ### Added
 
 - When measuring missing metrics, make the subject type and the metric type of the missing metrics link to the reference documentation. Closes [#10528](https://github.com/ICTU/quality-time/issues/10528).
+- Support version 4.1 of the OWASP Dependency-Check DTD (OWASP Dependency-Check version 12.0.0). Closes [#10645](https://github.com/ICTU/quality-time/issues/10645).
 
 ### Changed
 


### PR DESCRIPTION
Support version 4.1 of the OWASP Dependency-Check DTD (OWASP Dependency-Check version 12.0.0).

Closes #10645.