### PR TITLE
When measuring the number of job runs within a time period with Jenki…

### DIFF
--- a/components/collector/src/source_collectors/jenkins/job_runs_within_time_period.py
+++ b/components/collector/src/source_collectors/jenkins/job_runs_within_time_period.py
@@ -36,4 +36,4 @@ class JenkinsJobRunsWithinTimePeriod(JenkinsJobs):
         result_types = [result_type.lower() for result_type in self._parameter("result_type")]
         lookback_days = int(cast(str, self._parameter("lookback_days")))
         build_datetime = datetime_from_timestamp(int(build["timestamp"]))
-        return days_ago(build_datetime) <= lookback_days and build["result"].lower() in result_types
+        return days_ago(build_datetime) <= lookback_days and build.get("result", "").lower() in result_types

--- a/components/collector/tests/source_collectors/jenkins/base.py
+++ b/components/collector/tests/source_collectors/jenkins/base.py
@@ -15,6 +15,7 @@ class JenkinsTestCase(SourceCollectorTestCase):
         self.builds = [
             {"result": "FAILURE", "timestamp": 1552686540953},
             {"result": "SUCCESS", "timestamp": 1552686531953},
+            {"timestamp": 1552686531953},
         ]
         self.job_url = "https://job"
         self.job2_url = "https://job2"

--- a/components/frontend/src/header_footer/buttons/DownloadAsPDFButton.test.js
+++ b/components/frontend/src/header_footer/buttons/DownloadAsPDFButton.test.js
@@ -32,11 +32,11 @@ async function clickDownload(nrClicks = 1) {
 }
 
 function expectButtonIsLoading() {
-    expect(screen.getAllByLabelText(/Download/)[0].className).toContain("MuiCircularProgress-indeterminate")
+    expect(screen.getByRole("button").className).toContain("MuiLoadingButton-loading")
 }
 
 function expectButtonIsNotLoading() {
-    expect(screen.getByLabelText(/Download/).className).not.toContain("MuiCircularProgress-indeterminate")
+    expect(screen.getByRole("button").className).not.toContain("MuiLoadingButton-loading")
 }
 
 function mockGetReportPDFWithTimeout() {

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 ### Fixed
 
 - Don't throw an exception when a Trivy JSON file contains vulnerabilities without fixed version information. Fixes [#10606](https://github.com/ICTU/quality-time/issues/10606).
+- When measuring the number of job runs within a time period with Jenkins as source, don't throw an exception when a Jenkins pipeline build has no result yet. Fixes [#10610](https://github.com/ICTU/quality-time/issues/10610).
 
 ### Added
 


### PR DESCRIPTION
…ns as source, don't throw an exception when a Jenkins pipeline build has no result yet.

Fixes #10610.