### PR TITLE
When measuring test cases, warn the user if none of the configured so…

### DIFF
--- a/components/collector/src/metric_collectors/test_cases.py
+++ b/components/collector/src/metric_collectors/test_cases.py
@@ -79,6 +79,10 @@ class TestCases(MetricCollector):
             return None
         test_cases = self.test_cases(measurement.sources)
         test_case_keys = set(test_cases.keys())
+        if not test_case_keys:
+            for source in measurement.sources:
+                source.parse_error = "No test case keys found in this source"
+            return measurement
         # Derive the test result of the test cases from the test results of the tests
         for entity in self.test_report_entities(measurement.sources):
             for test_case_key in self.referenced_test_cases(entity) & test_case_keys:

--- a/components/collector/tests/metric_collectors/test_test_cases.py
+++ b/components/collector/tests/metric_collectors/test_test_cases.py
@@ -108,6 +108,13 @@ class TestCasesTest(unittest.IsolatedAsyncioTestCase):
         """Test missing sources."""
         self.assertIsNone(await self.collect({}))
 
+    async def test_no_test_cases(self):
+        """Test missing test cases."""
+        self.response.text = AsyncMock(return_value=self.JUNIT_XML)
+        junit = {"type": "junit", "parameters": {"url": self.test_report_url}}
+        measurement = await self.collect({"junit": junit})
+        self.assertEqual("No test case keys found in this source", measurement.sources[0].parse_error)
+
     async def test_no_test_report(self):
         """Test missing test report."""
         measurement = await self.collect({"jira": {"type": "jira", "parameters": {"url": self.jira_url, "jql": "jql"}}})

--- a/components/collector/tests/source_collectors/junit/test_tests.py
+++ b/components/collector/tests/source_collectors/junit/test_tests.py
@@ -63,3 +63,22 @@ class JUnitTestsTest(JUnitCollectorTestCase):
         </testsuite></testsuites>"""
         response = await self.collect(get_request_text=junit_xml_repeated_test_case_name)
         self.assert_measurement(response, value="4", total="4")
+
+    async def test_one_top_level_nested_test_suite(self):
+        """Test that a JUnit XML file with one top level nested test suite works."""
+        xml = """
+        <testsuite name="ts1" timestamp="2009-12-19T17:58:59" failures="0" errors="1" skipped="0" tests="1">
+            <testsuite name="ts1-1" timestamp="2009-12-19T17:58:59" failures="0" errors="1" skipped="0" tests="1">
+                <testcase name="tc1" classname="cn"><error/></testcase>
+            </testsuite>
+        </testsuite>
+        """
+        response = await self.collect(get_request_text=xml)
+        self.assert_measurement(
+            response,
+            value="1",
+            total="1",
+            entities=[
+                {"key": "cn:tc1", "old_key": "tc1", "name": "tc1", "class_name": "cn", "test_result": "errored"},
+            ],
+        )

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 - Don't throw an exception when a Trivy JSON file contains vulnerabilities without fixed version information. Fixes [#10606](https://github.com/ICTU/quality-time/issues/10606).
 - When measuring the number of job runs within a time period with Jenkins as source, don't throw an exception when a Jenkins pipeline build has no result yet. Fixes [#10610](https://github.com/ICTU/quality-time/issues/10610).
+- When measuring test cases, warn the user if none of the configured sources contains test cases. Fixes [#10615](https://github.com/ICTU/quality-time/issues/10615).
 - Correctly count test suites in JUnit XML files with one root testsuite element. Fixes [#10616](https://github.com/ICTU/quality-time/issues/10616).
 
 ### Added


### PR DESCRIPTION
…urces contains test cases.

Fixes #10615.