### PR TITLE
Fix developer documentation wrt docker-compose.

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,6 +14,10 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 ## [Unreleased]
 
+### Fixed
+
+- Docker compose has been integrated into Docker as a subcommand for a while, but the developer documentation did not reflect that. Change `docker-compose` to `docker compose` in the documentation. Fixes [#10684](https://github.com/ICTU/quality-time/issues/10684).
+
 ### Changed
 
 - Completed the replacement of Semantic UI React with Material UI as frontend component library. Closes [#9796](https://github.com/ICTU/quality-time/issues/9796).

--- a/docs/src/deployment.md
+++ b/docs/src/deployment.md
@@ -14,7 +14,7 @@ Before skipping versions or downgrading, see the [version policy](versioning.md)
 
 ## Docker-composition
 
-This document assumes docker-compose is used to deploy the containers. The [docker folder](https://github.com/ICTU/quality-time/tree/master/docker) of the *Quality-time* repository contains different compose files for running *Quality-time* in development and continuous integration mode. You can use these compose files as basis for your own deployment configuration.
+This document assumes Docker is used to deploy the containers. The [docker folder](https://github.com/ICTU/quality-time/tree/master/docker) of the *Quality-time* repository contains different compose files for running *Quality-time* in development and continuous integration mode. You can use these compose files as basis for your own deployment configuration.
 
 ```{note}
 Per the [version policy](versioning.md), if the Docker-composition needs changes, this will be indicated by a new major release of *Quality-time*.

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -444,7 +444,7 @@ tests/feature_tests/ci/test.sh tests/feature_tests/features/metric.feature
 The application tests in theory test all components through the frontend, but unfortunately the number of tests is too small to meet that goal. To run the application tests, start all components and then start the tests:
 
 ```console
-docker-compose up -d
+docker compose up -d
 docker run -it -w `pwd` -v `pwd`:`pwd` --network=container:qualitytime_www_1 ghcr.io/astral-sh/uv:python3.13-bookworm tests/application_tests/ci/test.sh
 ```
 

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -98,6 +98,7 @@ Implemented features include:
 - Side-by-side comparison of measurements at different points in time.
 - Integration with issue tracker (Jira only at the moment) to manage actions and technical debt.
 - Dark and light UI mode.
+- Runs on Docker and Kubernetes.
 
 ```{seealso}
 For more plans, see the [issue tracker](https://github.com/ICTU/quality-time/issues).
@@ -105,7 +106,7 @@ For more plans, see the [issue tracker](https://github.com/ICTU/quality-time/iss
 
 # Trying it out
 
-*Quality-time* requires Docker and Docker-compose.
+*Quality-time* requires Docker or Kubernetes, but the easiest way to try it out locally is to use Docker.
 
 Clone this repository:
 
@@ -116,13 +117,13 @@ git clone https://github.com/ICTU/quality-time.git
 Build the containers:
 
 ```console
-docker-compose build
+docker compose build
 ```
 
 Start the containers:
 
 ```console
-docker-compose up
+docker compose up
 ```
 
 *Quality-time* is served at [http://localhost](http://localhost). Use username `jadoe` and password `secret` to log in.


### PR DESCRIPTION
Docker compose has been integrated into Docker as a subcommand for a while, but the developer documentation did not reflect that. Change `docker-compose` to `docker compose` in the documentation.

Fixes #10684.