### PR TITLE
The comment field of a metric's technical debt tab would be editable …

### DIFF
--- a/components/frontend/src/fields/CommentField.js
+++ b/components/frontend/src/fields/CommentField.js
@@ -16,7 +16,7 @@ export function CommentField({ disabled, id, onChange, value }) {
     )
 }
 CommentField.propTypes = {
-    disabled: bool,
+    disabled: bool.isRequired,
     id: string,
     onChange: func,
     value: string,

--- a/components/frontend/src/fields/MultipleChoiceField.js
+++ b/components/frontend/src/fields/MultipleChoiceField.js
@@ -52,7 +52,7 @@ export function MultipleChoiceField({
     )
 }
 MultipleChoiceField.propTypes = {
-    disabled: bool,
+    disabled: bool.isRequired,
     freeSolo: bool,
     helperText: string,
     label: string,

--- a/components/frontend/src/fields/TextField.js
+++ b/components/frontend/src/fields/TextField.js
@@ -80,7 +80,7 @@ export function TextField({
 }
 TextField.propTypes = {
     children: childrenPropType,
-    disabled: bool,
+    disabled: bool.isRequired,
     endAdornment: oneOfType([element, string]),
     error: bool,
     helperText: oneOfType([element, string]),

--- a/components/frontend/src/metric/MetricDebtParameters.js
+++ b/components/frontend/src/metric/MetricDebtParameters.js
@@ -88,6 +88,8 @@ TechnicalDebtEndDate.propTypes = {
 }
 
 export function MetricDebtParameters({ metric, metric_uuid, reload, report }) {
+    const permissions = useContext(Permissions)
+    const disabled = !accessGranted(permissions, [EDIT_REPORT_PERMISSION])
     return (
         <Grid alignItems="flex-start" container spacing={{ xs: 1, sm: 2, md: 3 }} columns={{ xs: 1, sm: 3, md: 6 }}>
             <Grid size={{ xs: 1, sm: 1, md: 2 }}>
@@ -108,6 +110,7 @@ export function MetricDebtParameters({ metric, metric_uuid, reload, report }) {
             <IssuesRows metric={metric} metric_uuid={metric_uuid} reload={reload} report={report} />
             <Grid size={{ xs: 1, sm: 3, md: 6 }}>
                 <CommentField
+                    disabled={disabled}
                     onChange={(value) => set_metric_attribute(metric_uuid, "comment", value, reload)}
                     value={metric.comment}
                 />

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -22,6 +22,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 - Fix accessibility issues found by the application test. Fixes [#6354](https://github.com/ICTU/quality-time/issues/6354).
 - When adding multiple sources to one metric, the source names would not be comma-separated in the sources column. Fixes [#10735](https://github.com/ICTU/quality-time/issues/10735).
+- The comment field of a metric's technical debt tab would be editable even though the user was not logged in or when the user was time traveling. Note that the server would not save any changes made as it also checks for correct permissions. Fixes [#10739](https://github.com/ICTU/quality-time/issues/10739).
 
 ### Changed
 


### PR DESCRIPTION
…even though the user was not logged in or when the user was time traveling.

Note that the server would not save any changes made as it also checks for correct permissions.

Fixes #10739.