### PR TITLE
Fix refresh of measurement entity status end date.

### DIFF
--- a/components/api_server/src/routes/measurement.py
+++ b/components/api_server/src/routes/measurement.py
@@ -45,11 +45,12 @@ def set_entity_attribute(
     description = f"{user.name()} changed the {attribute} of '{entity_description}' from '{old_value}' to '{new_value}'"
     entity_user_data = source.setdefault("entity_user_data", {}).setdefault(entity_key, {})
     entity_user_data[attribute] = new_value
-    if attribute == "status" and (end_date := report.deadline(new_value)):
+    if attribute == "status":
+        new_end_date = report.deadline(new_value)
         old_end_date = entity_user_data.get("status_end_date")
-        if end_date != old_end_date:
-            entity_user_data["status_end_date"] = end_date
-            description += f" and changed the status end date from '{old_end_date}' to '{end_date}'"
+        if new_end_date != old_end_date:
+            entity_user_data["status_end_date"] = new_end_date
+            description += f" and changed the status end date from '{old_end_date}' to '{new_end_date}'"
     new_measurement["delta"] = {
         "uuids": [report.uuid, metric.subject_uuid, metric_uuid, source_uuid],
         "description": description + ".",

--- a/components/frontend/src/source/SourceEntityDetails.jsx
+++ b/components/frontend/src/source/SourceEntityDetails.jsx
@@ -103,6 +103,7 @@ export function SourceEntityDetails({
                 <DatePicker
                     defaultValue={status_end_date ? dayjs(status_end_date) : null}
                     disabled={disabled}
+                    key={status_end_date}
                     label={`${capitalize(name)} status end date`}
                     onChange={(value) =>
                         set_source_entity_attribute(

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -24,6 +24,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 - When adding multiple sources to one metric, the source names would not be comma-separated in the sources column. Fixes [#10735](https://github.com/ICTU/quality-time/issues/10735).
 - The comment field of a metric's technical debt tab would be editable even though the user was not logged in or when the user was time traveling. Note that the server would not save any changes made as it also checks for correct permissions. Fixes [#10739](https://github.com/ICTU/quality-time/issues/10739).
 - When changing technical debt with the option "Yes, and also set technical debt target and end date" or "No, and also clear technical debt target and end date", the technical end date value would not be refreshed in the UI. Fixes [#10761](https://github.com/ICTU/quality-time/issues/10761).
+- The status end date of measurement entities would not be refreshed in the UI when changing the status. Fixes [#10762](https://github.com/ICTU/quality-time/issues/10762).
 
 ### Changed
 


### PR DESCRIPTION
The status end date of measurement entities would not be refreshed in the UI when changing the status.

Fixes #10762.