### PR TITLE
When measuring branch or line coverage with Jacoco XML as source, the…

### DIFF
--- a/components/collector/tests/source_collectors/jacoco/base.py
+++ b/components/collector/tests/source_collectors/jacoco/base.py
@@ -25,15 +25,34 @@ class JaCoCoCommonTestsMixin:
 class JaCoCoCommonCoverageTestsMixin:
     """Tests common to JaCoCo coverage collectors."""
 
-    JACOCO_XML = "Subclass responsibility"
+    JACOCO_XML = """
+<report>
+    <package>
+        <class>
+            <method>
+                <counter type='LINE' missed='2' covered='4'/>
+                <counter type='BRANCH' missed='2' covered='4'/>
+            </method>
+        </class>
+        <class>
+                    <method>
+                        <counter type='LINE' missed='0' covered='3'/>
+                        <counter type='BRANCH' missed='0' covered='3'/>
+                    </method>
+                </class>
+    </package>
+    <counter type='LINE' missed='2' covered='7'/>
+    <counter type='BRANCH' missed='2' covered='7'/>
+</report>
+"""
 
     async def test_coverage(self):
         """Test that the number of uncovered lines/branches and the total number of lines/branches are returned."""
         response = await self.collect(get_request_text=self.JACOCO_XML)
-        self.assert_measurement(response, value="2", total="6")
+        self.assert_measurement(response, value="2", total="9")
 
     async def test_zipped_report(self):
         """Test that a zipped report can be read."""
         self.set_source_parameter("url", "https://example.org/jacoco.zip")
         response = await self.collect(get_request_content=self.zipped_report(("jacoco.xml", self.JACOCO_XML)))
-        self.assert_measurement(response, value="2", total="6")
+        self.assert_measurement(response, value="2", total="9")

--- a/components/collector/tests/source_collectors/jacoco/test_uncovered_branches.py
+++ b/components/collector/tests/source_collectors/jacoco/test_uncovered_branches.py
@@ -7,7 +7,6 @@ class JaCoCoUncoveredBranchesTest(JaCoCoCommonCoverageTestsMixin, JaCoCoCommonTe
     """Unit tests for the JaCoCo metrics."""
 
     METRIC_TYPE = "uncovered_branches"
-    JACOCO_XML = "<report><counter type='BRANCH' missed='2' covered='4'/></report>"
 
     async def test_uncovered_branches_without_branches(self):
         """Test that a JaCoCo XML without branches results in 100% coverage."""

--- a/components/collector/tests/source_collectors/jacoco/test_uncovered_lines.py
+++ b/components/collector/tests/source_collectors/jacoco/test_uncovered_lines.py
@@ -7,4 +7,3 @@ class JaCoCoUncoveredLinesTest(JaCoCoCommonCoverageTestsMixin, JaCoCoCommonTests
     """Unit tests for the JaCoCo metrics."""
 
     METRIC_TYPE = "uncovered_lines"
-    JACOCO_XML = "<report><counter type='LINE' missed='2' covered='4'/></report>"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -25,6 +25,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 - The comment field of a metric's technical debt tab would be editable even though the user was not logged in or when the user was time traveling. Note that the server would not save any changes made as it also checks for correct permissions. Fixes [#10739](https://github.com/ICTU/quality-time/issues/10739).
 - When changing technical debt with the option "Yes, and also set technical debt target and end date" or "No, and also clear technical debt target and end date", the technical end date value would not be refreshed in the UI. Fixes [#10761](https://github.com/ICTU/quality-time/issues/10761).
 - The status end date of measurement entities would not be refreshed in the UI when changing the status. Fixes [#10762](https://github.com/ICTU/quality-time/issues/10762).
+- When measuring branch or line coverage with Jacoco XML as source, the coverage would be calculated incorrectly. Fixes [#10787](https://github.com/ICTU/quality-time/issues/10787).
 
 ### Changed
 


### PR DESCRIPTION
… coverage would be calculated incorrectly.

Fixes #10787.