### PR TITLE
Next to ignoring branches, tags, and jobs, also allow for including b…

### DIFF
--- a/components/collector/src/source_collectors/gitlab/base.py
+++ b/components/collector/src/source_collectors/gitlab/base.py
@@ -118,11 +118,12 @@ class GitLabJobsBase(GitLabProjectBase):
 
     def _include_entity(self, entity: Entity) -> bool:
         """Return whether to count the job."""
+        jobs_to_include = self._parameter("jobs_to_include")
+        refs_to_include = self._parameter("refs_to_include")
         return (
-            not match_string_or_regular_expression(
-                entity["name"],
-                self._parameter("jobs_to_ignore"),
-            )
+            (match_string_or_regular_expression(entity["name"], jobs_to_include) if jobs_to_include else True)
+            and (match_string_or_regular_expression(entity["branch"], refs_to_include) if refs_to_include else True)
+            and not match_string_or_regular_expression(entity["name"], self._parameter("jobs_to_ignore"))
             and not match_string_or_regular_expression(entity["branch"], self._parameter("refs_to_ignore"))
             and entity["build_datetime"] >= self._lookback_datetime()
         )

--- a/components/collector/tests/source_collectors/gitlab/base.py
+++ b/components/collector/tests/source_collectors/gitlab/base.py
@@ -80,8 +80,20 @@ class CommonGitLabJobsTestsMixin:
         response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
         self.assert_measurement(response, value="1", entities=self.expected_entities[:-1])
 
+    async def test_include_job_by_name(self):
+        """Test that jobs can be included by name."""
+        self.set_source_parameter("jobs_to_include", ["job1"])
+        response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
+        self.assert_measurement(response, value="1", entities=self.expected_entities[:-1])
+
     async def test_ignore_job_by_ref(self):
         """Test that jobs can be ignored by ref."""
         self.set_source_parameter("refs_to_ignore", ["develop"])
+        response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
+        self.assert_measurement(response, value="1", entities=self.expected_entities[:-1])
+
+    async def test_include_job_by_ref(self):
+        """Test that jobs can be included by ref."""
+        self.set_source_parameter("refs_to_include", ["main"])
         response = await self.collect(get_request_json_return_value=self.gitlab_jobs_json)
         self.assert_measurement(response, value="1", entities=self.expected_entities[:-1])

--- a/components/shared_code/src/shared_data_model/sources/gitlab.py
+++ b/components/shared_code/src/shared_data_model/sources/gitlab.py
@@ -141,6 +141,13 @@ profile/personal_access_tokens.html) with the scope `read_repository` in the pri
             help_url=GITLAB_BRANCH_HELP_URL,
             metrics=["change_failure_rate", "failed_jobs", "job_runs_within_time_period", "unused_jobs"],
         ),
+        "refs_to_include": MultipleChoiceWithAdditionParameter(
+            name="Branches and tags to include (regular expressions, branch names or tag names)",
+            short_name="branches and tags to include",
+            help_url=GITLAB_BRANCH_HELP_URL,
+            placeholder="all branches and tags",
+            metrics=["change_failure_rate", "failed_jobs", "job_runs_within_time_period", "unused_jobs"],
+        ),
         "inactive_days": Days(
             name="Number of days since last commit after which to consider branches inactive",
             short_name="number of days since last commit",
@@ -159,6 +166,13 @@ profile/personal_access_tokens.html) with the scope `read_repository` in the pri
             name="Jobs to ignore (regular expressions or job names)",
             short_name="jobs to ignore",
             help="Jobs to ignore can be specified by job name or by regular expression.",
+            metrics=["change_failure_rate", "failed_jobs", "job_runs_within_time_period", "unused_jobs"],
+        ),
+        "jobs_to_include": MultipleChoiceWithAdditionParameter(
+            name="Jobs to include (regular expressions or job names)",
+            short_name="jobs to include",
+            help="Jobs to include can be specified by job name or by regular expression.",
+            placeholder="all jobs",
             metrics=["change_failure_rate", "failed_jobs", "job_runs_within_time_period", "unused_jobs"],
         ),
         "lookback_days": Days(

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,6 +14,10 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 ## [Unreleased]
 
+### Added
+
+- Next to ignoring branches, tags, and jobs, also allow for including branches, tags, and jobs when measuring 'failed CI-jobs', 'unused CI-jobs', 'change failure rate', and 'jobs runs within time period' with GitLab as source. Closes [#4520](https://github.com/ICTU/quality-time/issues/4520).
+
 ### Fixed
 
 - Use ARGON2 hashes to verify user LDAP passwords instead of SSHA1. Fixes [#6233](https://github.com/ICTU/quality-time/issues/6233).


### PR DESCRIPTION
…ranches, tags, and jobs when measuring failed CI-jobs with GitLab as source.

Closes #4520.