### PR TITLE
Fix documentation links.

### DIFF
--- a/components/frontend/src/utils.jsx
+++ b/components/frontend/src/utils.jsx
@@ -421,7 +421,7 @@ export function dropdownOptions(options) {
 
 export function referenceDocumentationURL(name) {
     // Return a URL to the documentation for the metric/subject/source name
-    const slug = `${name?.toLowerCase().replaceAll(" ", "-").replaceAll(/[()/]/g, "")}`
+    const slug = `${name?.toLowerCase().replaceAll(/[\s_]/g, "-").replaceAll(/[()/]/g, "")}`
     return `${DOCUMENTATION_URL}/reference.html#${slug}`
 }
 

--- a/components/frontend/src/utils.test.jsx
+++ b/components/frontend/src/utils.test.jsx
@@ -1,6 +1,7 @@
 import { EDIT_ENTITY_PERMISSION, EDIT_REPORT_PERMISSION } from "./context/Permissions"
 import { defaultDesiredResponseTimes } from "./defaults"
 import {
+    DOCUMENTATION_URL,
     addCounts,
     capitalize,
     getMetricResponseDeadline,
@@ -19,6 +20,7 @@ import {
     niceNumber,
     nrMetricsInReport,
     nrMetricsInReports,
+    referenceDocumentationURL,
     scaledNumber,
     sortWithLocaleCompare,
     sum,
@@ -513,4 +515,18 @@ it("returns whether a metric's measurement is outdated", () => {
     expect(isMeasurementOutdated({ latest_measurement: {} })).toBe(false)
     // A metric with an outdated measurement is outdated:
     expect(isMeasurementOutdated({ latest_measurement: { outdated: true } })).toBe(true)
+})
+
+it("returns the reference documentation URL", () => {
+    const url = `${DOCUMENTATION_URL}/reference.html`
+    // Simple name
+    expect(referenceDocumentationURL("name")).toBe(`${url}#name`)
+    // Name with spaces
+    expect(referenceDocumentationURL("name with space")).toBe(`${url}#name-with-space`)
+    // Name with underscores
+    expect(referenceDocumentationURL("name_with_underscore")).toBe(`${url}#name-with-underscore`)
+    // Name with brackets
+    expect(referenceDocumentationURL("(bracketed)")).toBe(`${url}#bracketed`)
+    // Name with forward slash
+    expect(referenceDocumentationURL("forward/slash")).toBe(`${url}#forwardslash`)
 })

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 ### Fixed
 
+- Links to documentation on Read the Docs for subjects, metrics, or sources with hyphens in their name wouldn't scroll to the right location. Fixes [#10843](https://github.com/ICTU/quality-time/issues/10843).
 - The software documentation was outdated (among other things the API-server health check endpoint). Fixes [#10858](https://github.com/ICTU/quality-time/issues/10858).
 
 ## v5.25.0 - 2025-02-14


### PR DESCRIPTION
Links to documentation on Read the Docs for subjects, metrics, or sources with hyphens in their name wouldn't scroll to the right location.

Fixes #10843.