### PR TITLE
Don't install fonts in renderer image.

### DIFF
--- a/components/renderer/Dockerfile
+++ b/components/renderer/Dockerfile
@@ -3,19 +3,7 @@ FROM node:23.8.0-alpine3.21
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time PDF render service"
 
-RUN apk add --no-cache \
-    msttcorefonts-installer=3.8.1-r1 \
-    fontconfig=2.15.0-r1 \
-    font-droid=20200215-r3 \
-    font-noto=24.7.1-r0 \
-    freetype=2.13.3-r0 \
-    ttf-dejavu=2.37-r5 \
-    ttf-freefont=20120503-r4 \
-    ttf-liberation=2.1.5-r2 \
-    chromium=132.0.6834.83-r0 && \
-    rm -rf /var/cache/apk/* /tmp/* && \
-    update-ms-fonts && \
-    fc-cache -f
+RUN apk add --no-cache chromium=132.0.6834.83-r0
 
 WORKDIR /home/renderer
 COPY package*.json /home/renderer/

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -26,6 +26,10 @@ If your currently installed *Quality-time* version is not the latest version, pl
 - Keep the footer at the bottom of the page even if the report is very short. Fixes [#10877](https://github.com/ICTU/quality-time/issues/10877).
 - Automatically expand long comments when exporting to PDF. Fixes [#10892](https://github.com/ICTU/quality-time/issues/10892).
 
+### Removed
+
+- To reduce the size of the renderer image, don't install fonts and let Chromium use its default fonts for PDF exports. Closes [#10835](https://github.com/ICTU/quality-time/issues/10835).
+
 ## v5.25.0 - 2025-02-14
 
 ### Added


### PR DESCRIPTION
Don't install fonts in the renderer image, but let Chromium use its default fonts for PDF exports. This reduces the renderer image size with about 44MB.

Closes #10835.