### PR TITLE
Refactor source collector.

### DIFF
--- a/components/collector/src/source_collectors/azure_devops/average_issue_lead_time.py
+++ b/components/collector/src/source_collectors/azure_devops/average_issue_lead_time.py
@@ -5,7 +5,7 @@ from typing import Final, cast
 
 from collector_utilities.date_time import days_ago, parse_datetime
 from collector_utilities.type import Value
-from model import Entity, SourceResponses
+from model import Entities, Entity, SourceResponses
 
 from .issues import AzureDevopsIssues
 
@@ -30,7 +30,7 @@ class AzureDevopsAverageIssueLeadTime(AzureDevopsIssues):
         max_change_age = int(cast(str, self._parameter("lookback_days_issues")))
         return change_age <= max_change_age
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Calculate the average lead time of the completed work items."""
         if work_items := await self._work_items(responses):
             lead_times = [lead_time for item in work_items if ((lead_time := self.__lead_time(item)) is not None)]

--- a/components/collector/src/source_collectors/azure_devops/change_failure_rate.py
+++ b/components/collector/src/source_collectors/azure_devops/change_failure_rate.py
@@ -84,11 +84,6 @@ class AzureDevopsChangeFailureRate(AzureDevopsIssues, AzureDevopsPipelines):
         max_age = int(cast(str, self._parameter("lookback_days_pipeline_runs")))
         return entity["failed"] and build_age <= max_age
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Calculate the numerator of the change failure rate."""
-        included_entities = [entity for entity in await self._parse_entities(responses) if self._include_entity(entity)]
         return str(len(included_entities))
-
-    async def _parse_total(self, responses: SourceResponses) -> Value:
-        """Calculate the denominator of the change failure rate."""
-        return str(len(await self._parse_entities(responses)))

--- a/components/collector/src/source_collectors/azure_devops/issues.py
+++ b/components/collector/src/source_collectors/azure_devops/issues.py
@@ -85,7 +85,7 @@ class AzureDevopsIssues(SourceCollector):
         """Override to parse the work items from the WIQL query response."""
         return Entities(self._parse_entity(work_item) for work_item in await self._work_items(responses))
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Override to parse the value from the responses.
 
         We can't just count the entities because due to pagination the response may not contain all work items.

--- a/components/collector/src/source_collectors/azure_devops/merge_requests.py
+++ b/components/collector/src/source_collectors/azure_devops/merge_requests.py
@@ -39,7 +39,7 @@ class AzureDevopsMergeRequests(MergeRequestCollector, AzureDevopsRepositoryBase)
         landing_url = (await self._landing_url(responses)).rstrip("s")
         return Entities([self._create_entity(mr, landing_url) for mr in merge_requests])
 
-    async def _parse_total(self, responses: SourceResponses) -> Value:
+    async def _parse_total(self, responses: SourceResponses, entities: Entities) -> Value:
         """Override to parse the total number of merge requests from the responses."""
         merge_requests = [len((await response.json())["value"]) for response in responses]
         return str(sum(merge_requests))

--- a/components/collector/src/source_collectors/azure_devops/user_story_points.py
+++ b/components/collector/src/source_collectors/azure_devops/user_story_points.py
@@ -4,7 +4,7 @@ from typing import Final
 
 from collector_utilities.functions import decimal_round_half_up
 from collector_utilities.type import Value
-from model import Entity, SourceResponses
+from model import Entities, Entity, SourceResponses
 
 from .issues import AzureDevopsIssues
 
@@ -26,7 +26,7 @@ class AzureDevopsUserStoryPoints(AzureDevopsIssues):
         parsed_entity["story_points"] = self.__story_points(work_item)
         return parsed_entity
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Override to parse the sum of the user story points from the responses."""
         calculated_value = sum(self.__story_points(work_item) for work_item in await self._work_items(responses))
         return str(decimal_round_half_up(calculated_value))

--- a/components/collector/src/source_collectors/bitbucket/base.py
+++ b/components/collector/src/source_collectors/bitbucket/base.py
@@ -5,7 +5,7 @@ from abc import ABC
 from base_collectors import SourceCollector
 from collector_utilities.functions import add_query
 from collector_utilities.type import URL, Value
-from model import SourceResponses
+from model import Entities, SourceResponses
 
 
 class BitbucketBase(SourceCollector, ABC):
@@ -34,7 +34,7 @@ class BitbucketBase(SourceCollector, ABC):
             is_last_page = json["isLastPage"]
         return responses
 
-    async def _parse_total(self, responses: SourceResponses) -> Value:
+    async def _parse_total(self, responses: SourceResponses, entities: Entities) -> Value:
         """Override to parse the total number of entities from the responses."""
         sizes = [(await response.json())["size"] for response in responses]
         return str(sum(sizes))

--- a/components/collector/src/source_collectors/composer/dependencies.py
+++ b/components/collector/src/source_collectors/composer/dependencies.py
@@ -1,33 +1,31 @@
 """Composer dependencies collector."""
 
+from typing import cast
+
 from base_collectors import JSONFileSourceCollector
-from model import Entities, Entity, SourceMeasurement, SourceResponses
+from collector_utilities.type import JSON, JSONDict
+from model import Entities, Entity
 
 
 class ComposerDependencies(JSONFileSourceCollector):
     """Composer collector for dependencies."""
 
-    async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
-        """Override to parse the dependencies."""
-        installed_dependencies: list[dict[str, str]] = []
-        for response in responses:
-            installed_dependencies.extend((await response.json(content_type=None)).get("installed", []))
-        entities = [
-            Entity(
-                key=f"{dependency['name']}@{dependency.get('version', '?')}",
-                name=dependency["name"],
-                version=dependency.get("version", "unknown"),
-                homepage=dependency.get("homepage", ""),
-                latest=dependency.get("latest", "unknown"),
-                latest_status=dependency.get("latest-status", "unknown"),
-                description=dependency.get("description", ""),
-                warning=dependency.get("warning", ""),
-            )
-            for dependency in installed_dependencies
-        ]
-        return SourceMeasurement(
-            entities=Entities([entity for entity in entities if self._include_entity(entity)]),
-            total=str(len(installed_dependencies)),
+    def _parse_json(self, json: JSON, filename: str) -> Entities:
+        """Parse the entities from the JSON."""
+        return Entities(
+            [
+                Entity(
+                    key=f"{dependency['name']}@{dependency.get('version', '?')}",
+                    name=dependency["name"],
+                    version=dependency.get("version", "unknown"),
+                    homepage=dependency.get("homepage", ""),
+                    latest=dependency.get("latest", "unknown"),
+                    latest_status=dependency.get("latest-status", "unknown"),
+                    description=dependency.get("description", ""),
+                    warning=dependency.get("warning", ""),
+                )
+                for dependency in cast(JSONDict, json).get("installed", [])
+            ]
         )
 
     def _include_entity(self, entity: Entity) -> bool:

--- a/components/collector/src/source_collectors/cxsast/security_warnings.py
+++ b/components/collector/src/source_collectors/cxsast/security_warnings.py
@@ -2,7 +2,7 @@
 
 from base_collectors import SourceCollector
 from collector_utilities.type import URL, Value
-from model import SourceResponses
+from model import Entities, SourceResponses
 
 from .base import CxSASTScanBase
 
@@ -16,7 +16,7 @@ class CxSASTSecurityWarnings(CxSASTScanBase):
         stats_api = URL(f"{await self._api_url()}/cxrestapi/sast/scans/{self._scan_id}/resultsStatistics")
         return await SourceCollector._get_source_responses(self, stats_api)  # noqa: SLF001
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Override to parse the number of security warnings from the scan results."""
         stats = await responses[0].json()
         severities = self._parameter("severities")

--- a/components/collector/src/source_collectors/cxsast/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/cxsast/source_up_to_dateness.py
@@ -2,7 +2,7 @@
 
 from collector_utilities.date_time import days_ago, parse_datetime
 from collector_utilities.type import Value
-from model import SourceResponses
+from model import Entities, SourceResponses
 
 from .base import CxSASTScanBase
 
@@ -10,7 +10,7 @@ from .base import CxSASTScanBase
 class CxSASTSourceUpToDateness(CxSASTScanBase):
     """Collector class to measure the up-to-dateness of a Checkmarx CxSAST scan."""
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Override to parse the date and time of the most recent scan."""
         scan = (await responses[0].json())[0]
         return str(days_ago(parse_datetime(scan["dateAndTime"]["finishedOn"])))

--- a/components/collector/src/source_collectors/gatling/performancetest_duration.py
+++ b/components/collector/src/source_collectors/gatling/performancetest_duration.py
@@ -1,7 +1,7 @@
 """Gatling performancetest duration collector."""
 
 from collector_utilities.type import Value
-from model import SourceResponses
+from model import Entities, SourceResponses
 
 from .base import GatlingLogCollector
 
@@ -9,7 +9,7 @@ from .base import GatlingLogCollector
 class GatlingPerformanceTestDuration(GatlingLogCollector):
     """Collector for the performance test duration."""
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Override to parse the timestamps from the log and calculate the duration in minutes."""
         timestamps = await self._timestamps(responses)
         return str(round((max(timestamps) - min(timestamps)) / 60_000)) if timestamps else "0"

--- a/components/collector/src/source_collectors/github/merge_requests.py
+++ b/components/collector/src/source_collectors/github/merge_requests.py
@@ -109,7 +109,7 @@ class GitHubMergeRequests(GitHubBase):
             pull_requests.extend(json["data"]["repository"]["pullRequests"]["nodes"])
         return Entities(self._create_entity(pr) for pr in pull_requests)
 
-    async def _parse_total(self, responses: SourceResponses) -> Value:
+    async def _parse_total(self, responses: SourceResponses, entities: Entities) -> Value:
         """Override to parse the total number of pull requests."""
         return str((await responses[0].json(content_type=None))["data"]["repository"]["pullRequests"]["totalCount"])
 

--- a/components/collector/src/source_collectors/gitlab/merge_requests.py
+++ b/components/collector/src/source_collectors/gitlab/merge_requests.py
@@ -125,7 +125,7 @@ class GitLabMergeRequests(MergeRequestCollector, GitLabBase):
             merge_requests.extend(json["data"]["project"]["mergeRequests"]["nodes"])
         return Entities(self._create_entity(mr) for mr in merge_requests)
 
-    async def _parse_total(self, responses: SourceResponses) -> Value:
+    async def _parse_total(self, responses: SourceResponses, entities: Entities) -> Value:
         """Override to parse the total number of merge requests."""
         return str((await responses[0].json())["data"]["project"]["mergeRequests"]["count"])
 

--- a/components/collector/src/source_collectors/gitlab/pipeline_duration.py
+++ b/components/collector/src/source_collectors/gitlab/pipeline_duration.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from collector_utilities.date_time import minutes
 from collector_utilities.type import URL, Value
-from model import SourceResponses
+from model import Entities, SourceResponses
 
 from .base import GitLabPipelineBase
 
@@ -19,7 +19,7 @@ class GitLabPipelineDuration(GitLabPipelineBase):
         api_url = await self._gitlab_api_url(f"pipelines/{pipelines[0].id}")
         return await super()._get_source_responses(api_url)
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Parse the value from the responses."""
         durations = [pipeline.pipeline_duration for pipeline in await self._pipelines(responses)]
         return str(minutes(max(durations, default=timedelta())))

--- a/components/collector/src/source_collectors/gitlab/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/gitlab/source_up_to_dateness.py
@@ -13,7 +13,7 @@ import aiohttp
 from base_collectors import SourceCollector, TimePassedCollector
 from collector_utilities.date_time import days_ago, parse_datetime
 from collector_utilities.type import URL, Response, Value
-from model import SourceMeasurement, SourceResponses
+from model import Entities, SourceMeasurement, SourceResponses
 
 from .base import GitLabPipelineBase, GitLabProjectBase
 
@@ -68,7 +68,7 @@ class GitLabFileUpToDateness(GitLabProjectBase):
         commit_api_url = await self._gitlab_api_url(f"repository/commits/{last_commit_id}")
         return await super()._get_source_responses(commit_api_url)
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Override to parse the dates from the commits."""
         commit_responses = responses[1:]
         commit_dates = [parse_datetime((await response.json())["committed_date"]) for response in commit_responses]

--- a/components/collector/src/source_collectors/jenkins/pipeline_duration.py
+++ b/components/collector/src/source_collectors/jenkins/pipeline_duration.py
@@ -8,7 +8,7 @@ from base_collectors import SourceCollector
 from collector_utilities.date_time import minutes
 from collector_utilities.functions import match_string_or_regular_expression
 from collector_utilities.type import URL, Value
-from model import SourceResponses
+from model import Entities, SourceResponses
 
 from .base import Build, Job
 
@@ -37,7 +37,7 @@ class JenkinsPipelineDuration(SourceCollector):
             return URL(build["url"])
         return URL(await super()._landing_url(responses) + f"/job/{self._parameter('pipeline')}")
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Parse the value from the responses."""
         build = await self._build(responses)
         return str(minutes(timedelta(milliseconds=build["duration"]))) if build else "0"

--- a/components/collector/src/source_collectors/jenkins_test_report/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/jenkins_test_report/source_up_to_dateness.py
@@ -3,7 +3,7 @@
 from base_collectors import SourceCollector
 from collector_utilities.date_time import datetime_from_timestamp, days_ago, parse_datetime
 from collector_utilities.type import URL, Value
-from model import SourceResponses
+from model import Entities, SourceResponses
 
 
 class JenkinsTestReportSourceUpToDateness(SourceCollector):
@@ -15,7 +15,7 @@ class JenkinsTestReportSourceUpToDateness(SourceCollector):
         job_url = URL(f"{urls[0]}/lastSuccessfulBuild/api/json")
         return await super()._get_source_responses(test_report_url, job_url)
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Override to parse the timestamp from either the job or the test report."""
         timestamps = [
             suite.get("timestamp") for suite in (await responses[0].json()).get("suites", []) if suite.get("timestamp")

--- a/components/collector/src/source_collectors/jmeter_csv/performancetest_duration.py
+++ b/components/collector/src/source_collectors/jmeter_csv/performancetest_duration.py
@@ -1,7 +1,7 @@
 """JMeter CSV performancetest duration collector."""
 
 from collector_utilities.type import Value
-from model import SourceResponses
+from model import Entities, SourceResponses
 
 from .base import JMeterCSVCollector
 
@@ -9,7 +9,7 @@ from .base import JMeterCSVCollector
 class JMeterCSVPerformanceTestDuration(JMeterCSVCollector):
     """Collector for the performance test duration."""
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Override to parse the timestamps from the samples and calculate the duration in minutes."""
         timestamps = await self._timestamps(responses)
         return str(round((max(timestamps) - min(timestamps)) / 60_000)) if timestamps else "0"

--- a/components/collector/src/source_collectors/manual_number/all_metrics.py
+++ b/components/collector/src/source_collectors/manual_number/all_metrics.py
@@ -2,12 +2,16 @@
 
 from base_collectors import SourceCollector
 from collector_utilities.type import Value
-from model import SourceResponses
+from model import Entities, SourceResponses
 
 
 class ManualNumber(SourceCollector):
     """Manual number collector."""
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Override to return the user-supplied manual number."""
         return str(self._parameter("number"))
+
+    async def _parse_total(self, responses: SourceResponses, entities: Entities) -> Value:
+        """Override to return the total, which is always 100 to support metrics with a percentage scale."""
+        return "100"

--- a/components/collector/src/source_collectors/performancetest_runner/performancetest_duration.py
+++ b/components/collector/src/source_collectors/performancetest_runner/performancetest_duration.py
@@ -5,7 +5,7 @@ from typing import cast
 from bs4 import Tag
 
 from collector_utilities.type import Response, Value
-from model import SourceResponses
+from model import Entities, SourceResponses
 
 from .base import PerformanceTestRunnerBaseClass
 
@@ -13,7 +13,7 @@ from .base import PerformanceTestRunnerBaseClass
 class PerformanceTestRunnerPerformanceTestDuration(PerformanceTestRunnerBaseClass):
     """Collector for the performance test duration."""
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Override to parse the performance test durations from the responses and return the sum in minutes."""
         durations = []
         for response in responses:

--- a/components/collector/src/source_collectors/performancetest_runner/performancetest_scalability.py
+++ b/components/collector/src/source_collectors/performancetest_runner/performancetest_scalability.py
@@ -5,7 +5,7 @@ from typing import cast
 from bs4 import Tag
 
 from collector_utilities.type import Response, Value
-from model import SourceResponses
+from model import Entities, SourceResponses
 
 from .base import PerformanceTestRunnerBaseClass
 
@@ -13,12 +13,12 @@ from .base import PerformanceTestRunnerBaseClass
 class PerformanceTestRunnerScalability(PerformanceTestRunnerBaseClass):
     """Collector for the scalability metric."""
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Override to parse the scalability breaking point from the responses."""
         breaking_points = [await self.__breaking_point_vusers(response) for response in responses]
         return str(min(breaking_points))
 
-    async def _parse_total(self, responses: SourceResponses) -> Value:
+    async def _parse_total(self, responses: SourceResponses, entities: Entities) -> Value:
         """Override to compute the total number of virtual users from the responses."""
         breaking_points = [
             (

--- a/components/collector/src/source_collectors/performancetest_runner/performancetest_stability.py
+++ b/components/collector/src/source_collectors/performancetest_runner/performancetest_stability.py
@@ -5,7 +5,7 @@ from typing import cast
 from bs4 import Tag
 
 from collector_utilities.type import Response, Value
-from model import SourceResponses
+from model import Entities, SourceResponses
 
 from .base import PerformanceTestRunnerBaseClass
 
@@ -13,7 +13,7 @@ from .base import PerformanceTestRunnerBaseClass
 class PerformanceTestRunnerPerformanceTestStability(PerformanceTestRunnerBaseClass):
     """Collector for the performance test stability."""
 
-    async def _parse_value(self, responses: SourceResponses) -> Value:
+    async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Override to parse the trend break percentage from the responses and return the minimum percentage."""
         trend_breaks = [int(await self.__trendbreak_stability(response)) for response in responses]
         return str(min(trend_breaks))

--- a/components/collector/src/source_collectors/quality_time/metrics.py
+++ b/components/collector/src/source_collectors/quality_time/metrics.py
@@ -8,7 +8,7 @@ from shared_data_model import DATA_MODEL
 
 from collector_utilities.date_time import parse_datetime
 from collector_utilities.type import URL, Response, Value
-from model import Entities, Entity, SourceMeasurement, SourceResponses
+from model import Entities, Entity, SourceResponses
 
 from .base import QualityTimeCollector
 
@@ -22,13 +22,11 @@ class QualityTimeMetrics(QualityTimeCollector):
         """Extend to add the reports API path."""
         return URL(await super()._api_url() + "/api/internal/report")
 
-    async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
-        """Get the metric entities from the responses."""
+    async def _parse_entities(self, responses: SourceResponses) -> Entities:
+        """Parse the entities from the responses."""
         landing_url = await self._landing_url(responses)
         metrics_and_entities = await self.__get_metrics_and_entities(responses[0])
-        parsed_entities = [self.__parse_entity(entity, metric, landing_url) for metric, entity in metrics_and_entities]
-        entities = Entities([entity for entity in parsed_entities if self._include_entity(entity)])
-        return SourceMeasurement(total=str(len(metrics_and_entities)), entities=entities)
+        return Entities([self.__parse_entity(entity, metric, landing_url) for metric, entity in metrics_and_entities])
 
     def _include_entity(self, entity: Entity) -> bool:
         """Return whether to include the entity in the measurement."""

--- a/components/collector/tests/base_collectors/test_collector.py
+++ b/components/collector/tests/base_collectors/test_collector.py
@@ -84,7 +84,7 @@ class CollectorTest(unittest.IsolatedAsyncioTestCase):
             "api_url": str(kwargs.get("api_url", self.url)),
             "landing_url": str(kwargs.get("landing_url", self.url)),
             "value": None if connection_error else str(kwargs.get("value", "1")),
-            "total": None if connection_error else str(kwargs.get("total", "100")),
+            "total": None if connection_error else str(kwargs.get("total", "1")),
             "entities": [] if connection_error else entities,
             "connection_error": connection_error,
             "parse_error": None,
@@ -266,6 +266,7 @@ class CollectorTest(unittest.IsolatedAsyncioTestCase):
             self.expected_measurement(
                 source_parameter_hash="8c3b464958e9ad0f20fb2e3b74c80519",
                 value="0",
+                total="100",
                 entities=[],
                 api_url="",
                 landing_url="",

--- a/components/collector/tests/source_collectors/npm/test_dependencies.py
+++ b/components/collector/tests/source_collectors/npm/test_dependencies.py
@@ -26,7 +26,7 @@ class NpmDependenciesTest(SourceCollectorTestCase):
             },
         ]
         response = await self.collect(get_request_json_return_value=npm_json)
-        self.assert_measurement(response, value="2", total="100", entities=expected_entities)
+        self.assert_measurement(response, value="2", total="2", entities=expected_entities)
 
     async def test_multiple_dependents_per_dependency(self):
         """Test that the number of dependencies is returned if a dependency has multiple dependents."""
@@ -53,4 +53,4 @@ class NpmDependenciesTest(SourceCollectorTestCase):
             },
         ]
         response = await self.collect(get_request_json_return_value=npm_json)
-        self.assert_measurement(response, value="2", total="100", entities=expected_entities)
+        self.assert_measurement(response, value="2", total="2", entities=expected_entities)

--- a/components/collector/tests/source_collectors/pip/test_dependencies.py
+++ b/components/collector/tests/source_collectors/pip/test_dependencies.py
@@ -20,4 +20,4 @@ class PipDependenciesTest(SourceCollectorTestCase):
             {"key": "pip@20_1", "name": "pip", "version": "20.1", "latest": "20.1.1"},
         ]
         response = await self.collect(get_request_json_return_value=pip_json)
-        self.assert_measurement(response, value="2", total="100", entities=expected_entities)
+        self.assert_measurement(response, value="2", total="2", entities=expected_entities)

--- a/components/collector/tests/source_collectors/quality_time/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/quality_time/test_source_up_to_dateness.py
@@ -20,14 +20,14 @@ class QualityTimeSourceUpToDatenessTest(QualityTimeTestCase):
         self.set_source_parameter("reports", ["r1"])
         response = await self.collect(get_request_json_return_value=self.reports)
         expected_age = days_ago(parse("2020-06-24T07:53:17+00:00"))
-        self.assert_measurement(response, value=str(expected_age), total="100", entities=[])
+        self.assert_measurement(response, value=str(expected_age), total="0", entities=[])
 
     async def test_source_up_to_dateness_report(self):
         """Test that the source up-to-dateness of a specific report can be measured."""
         self.set_source_parameter("reports", ["r2"])
         response = await self.collect(get_request_json_return_value=self.reports)
         expected_age = days_ago(datetime.min)
-        self.assert_measurement(response, value=str(expected_age), total="100", entities=[])
+        self.assert_measurement(response, value=str(expected_age), total="0", entities=[])
 
     def assert_measurement(self, measurement, *, source_index: int = 0, **attributes: list | str | None) -> None:
         """Override to pass the api URLs."""


### PR DESCRIPTION
Pass parsed entities to the parse_total and parse_value methods so entities do not need to be parsed multiple times.