### PR TITLE
When adding a new source to a metric, don't show the spinner until th…

### DIFF
--- a/components/frontend/src/__fixtures__/fixtures.js
+++ b/components/frontend/src/__fixtures__/fixtures.js
@@ -28,6 +28,9 @@ export const dataModel = {
     metrics: {
         metric_type: { name: "Metric type", tags: [] },
     },
+    sources: {
+        source_type: { name: "Source type", metrics: ["metric_type"], parameters: {} },
+    },
 }
 
 export const report = {
@@ -42,7 +45,7 @@ export const report = {
                     type: "metric_type",
                     tags: ["other tag"],
                     target: "1",
-                    sources: { source_uuid: { name: "Source" } },
+                    sources: { source_uuid: { name: "Source", type: "source_type" } },
                     status: "target_not_met",
                     recent_measurements: [],
                     latest_measurement: { count: 1 },
@@ -54,7 +57,7 @@ export const report = {
                     tags: ["tag"],
                     target: "2",
                     issue_ids: ["ABC-42"],
-                    sources: { source_uuid2: { name: "Source 2" } },
+                    sources: { source_uuid2: { name: "Source 2", type: "source_type" } },
                     status: "informative",
                     recent_measurements: [],
                     latest_measurement: { count: 2 },

--- a/components/frontend/src/measurement/MeasurementValue.jsx
+++ b/components/frontend/src/measurement/MeasurementValue.jsx
@@ -15,6 +15,7 @@ import {
     isMeasurementOutdated,
     isMeasurementRequested,
     isMeasurementStale,
+    isSourceConfigurationComplete,
     sum,
 } from "../utils"
 import { IgnoreIcon, LoadingIcon } from "../widgets/icons"
@@ -104,8 +105,10 @@ export function MeasurementValue({ metric, reportDate }) {
     value = formatMetricValue(scale, value)
     const unit = getMetricUnit(metric, dataModel)
     const stale = isMeasurementStale(metric, reportDate)
+    const complete = isSourceConfigurationComplete(dataModel, metric)
     const outdated = isMeasurementOutdated(metric)
     const requested = isMeasurementRequested(metric)
+    const updating = complete && (outdated || requested)
     const hasIgnoredEntities = sum(ignoredEntitiesCount(metric.latest_measurement)) > 0
     return (
         <Tooltip
@@ -114,6 +117,10 @@ export function MeasurementValue({ metric, reportDate }) {
                 <div>
                     <WarningMessage showIf={stale} title="This metric was not recently measured">
                         This may indicate a problem with Quality-time itself. Please contact a system administrator.
+                    </WarningMessage>
+                    <WarningMessage showIf={!complete} title="Source configuration incomplete">
+                        The source configuration of this metric is not complete. Add at least one source and make sure
+                        all mandatory parameters for all sources have been provided.
                     </WarningMessage>
                     <WarningMessage showIf={outdated} title="Latest measurement out of date">
                         The source configuration of this metric was changed after the latest measurement.
@@ -143,7 +150,7 @@ export function MeasurementValue({ metric, reportDate }) {
                 </div>
             }
         >
-            {measurementValueLabel(hasIgnoredEntities, stale, outdated || requested, value)}
+            {measurementValueLabel(hasIgnoredEntities, stale, updating, value)}
         </Tooltip>
     )
 }

--- a/components/frontend/src/metric/MetricDetails.jsx
+++ b/components/frontend/src/metric/MetricDetails.jsx
@@ -23,7 +23,7 @@ import {
 import { Logo } from "../source/Logo"
 import { SourceEntities } from "../source/SourceEntities"
 import { Sources } from "../source/Sources"
-import { getSourceName, isMeasurementRequested } from "../utils"
+import { getSourceName, isMeasurementRequested, isSourceConfigurationComplete } from "../utils"
 import { ButtonRow } from "../widgets/ButtonRow"
 import { ActionButton } from "../widgets/buttons/ActionButton"
 import { DeleteButton } from "../widgets/buttons/DeleteButton"
@@ -37,16 +37,22 @@ import { MetricDebtParameters } from "./MetricDebtParameters"
 import { TrendGraph } from "./TrendGraph"
 
 function RequestMeasurementButton({ metric, metric_uuid, reload }) {
+    const dataModel = useContext(DataModel)
+    const configurationComplete = isSourceConfigurationComplete(dataModel, metric)
     const measurementRequested = isMeasurementRequested(metric)
     return (
         <ActionButton
             action="Measure"
-            disabled={measurementRequested}
+            disabled={!configurationComplete || measurementRequested}
             icon={<RefreshIcon />}
             itemType="metric"
             loading={measurementRequested}
             onClick={() => set_metric_attribute(metric_uuid, "measurement_requested", new Date().toISOString(), reload)}
-            popup={`Measure this metric as soon as possible`}
+            popup={
+                configurationComplete
+                    ? "Measure this metric as soon as possible"
+                    : "The source configuration of this metric is not complete. Add at least one source and make sure all mandatory parameters for all sources have been provided."
+            }
         />
     )
 }

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -21,6 +21,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 ### Fixed
 
+- When adding a new source to a metric, don't show the spinner until the source has been configured sufficiently to start collecting data. Fixes [#9994](https://github.com/ICTU/quality-time/issues/9994).
 - Increase contrast for disabled items in the menu bar. Fixes [#10840](https://github.com/ICTU/quality-time/issues/10840).
 - Links to documentation on Read the Docs for subjects, metrics, or sources with hyphens in their name wouldn't scroll to the right location. Fixes [#10843](https://github.com/ICTU/quality-time/issues/10843).
 - Metric details were not shown in exports to PDF. Fixes [#10845](https://github.com/ICTU/quality-time/issues/10845).


### PR DESCRIPTION
…e source has been configured sufficiently to start collecting data.

Fixes #9994.