### PR TITLE
When measuring average issue lead time with Jira as source, the lead …

### DIFF
--- a/components/collector/src/source_collectors/jira/average_issue_lead_time.py
+++ b/components/collector/src/source_collectors/jira/average_issue_lead_time.py
@@ -24,7 +24,7 @@ class JiraAverageIssueLeadTime(JiraIssues):
     def _create_entity(self, issue: dict, url: URL) -> Entity:
         """Extend to also add the lead time to the entity."""
         entity = super()._create_entity(issue, url)
-        entity["lead_time"] = self.__lead_time(issue["fields"])
+        entity["lead_time"] = str(self.__lead_time(issue["fields"]))
         return entity
 
     @classmethod

--- a/components/collector/tests/source_collectors/jira/base.py
+++ b/components/collector/tests/source_collectors/jira/base.py
@@ -22,7 +22,7 @@ class JiraTestCase(SourceCollectorTestCase):
         self.set_source_parameter("board", "Board 2")
         self.created = "2020-08-06T16:36:48.000+0200"
 
-    def issue(self, key: str = "1", **fields: str):
+    def issue(self, key: str = "1", **fields: str | dict[str, dict[str, str]]):
         """Create a Jira issue."""
         return {"id": key, "key": key, "fields": dict(created=self.created, summary=f"Summary {key}", **fields)}
 

--- a/components/collector/tests/source_collectors/jira/test_average_issue_lead_time.py
+++ b/components/collector/tests/source_collectors/jira/test_average_issue_lead_time.py
@@ -15,7 +15,7 @@ class JiraAverageIssueLeadTimeTest(JiraTestCase):
         status_issue = self.issue(status={"statusCategory": {"key": "done"}}, updated=updated_value)
         issues_json = {"total": 1, "issues": [status_issue]}
         response = await self.get_response(issues_json)
-        self.assert_measurement(response, value="3", entities=[self.entity(updated=updated_value, lead_time=3)])
+        self.assert_measurement(response, value="3", entities=[self.entity(updated=updated_value, lead_time="3")])
 
     async def test_exclude_status_category(self):
         """Test that issues are excluded if statusCategory is not done."""
@@ -29,9 +29,7 @@ class JiraAverageIssueLeadTimeTest(JiraTestCase):
     async def test_exclude_updated_field(self):
         """Test that issues are excluded if there is no field updated."""
         self.set_source_parameter("lookback_days", "424242")
-        status_issue = self.issue(
-            status={"statusCategory": {"key": "done"}},
-        )
+        status_issue = self.issue(status={"statusCategory": {"key": "done"}})
         issues_json = {"total": 0, "issues": [status_issue]}
         response = await self.get_response(issues_json)
         self.assert_measurement(response, value="0", entities=[])

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,12 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- When measuring average issue lead time with Jira as source, the lead times per issue would not be collected. Fixes [#10929](https://github.com/ICTU/quality-time/issues/10929).
+
 ## v5.26.0 - 2025-02-27
 
 ### Added


### PR DESCRIPTION
…times per issue would not be collected.

Fixes #10929.