### PR TITLE
Use component and module names for logging in Python components.

### DIFF
--- a/components/api_server/src/initialization/database.py
+++ b/components/api_server/src/initialization/database.py
@@ -1,23 +1,25 @@
 """Database initialization."""
 
-import logging
 import os
 
 import pymongo
 from pymongo.database import Database
 
+from utils.log import get_logger
+
+from .app_secrets import initialize_secrets
 from .migrations import perform_migrations
 from .datamodel import import_datamodel
 from .report import import_example_reports, initialize_reports_overview
-from .app_secrets import initialize_secrets
 
 
 def init_database(database: Database) -> None:  # pragma: no feature-test-cover
     """Initialize the database contents."""
-    logging.info("Connected to database: %s", database)
+    logger = get_logger()
+    logger.info("Connected to database: %s", database)
     nr_reports = database.reports.count_documents({})
     nr_measurements = database.measurements.count_documents({})
-    logging.info("Database has %d report documents and %d measurement documents", nr_reports, nr_measurements)
+    logger.info("Database has %d report documents and %d measurement documents", nr_reports, nr_measurements)
     create_indexes(database)
     import_datamodel(database)
     initialize_secrets(database)

--- a/components/api_server/src/initialization/datamodel.py
+++ b/components/api_server/src/initialization/datamodel.py
@@ -1,23 +1,24 @@
 """Data model loader."""
 
 import json
-import logging
 
 from pymongo.database import Database
 
 from shared_data_model import DATA_MODEL_JSON
 
 from database.datamodels import insert_new_datamodel, latest_datamodel
+from utils.log import get_logger
 
 
 def import_datamodel(database: Database) -> None:  # pragma: no feature-test-cover
     """Store the data model in the database."""
+    logger = get_logger()
     data_model = json.loads(DATA_MODEL_JSON)
     if latest := latest_datamodel(database):
         del latest["timestamp"]
         del latest["_id"]
         if data_model == latest:
-            logging.info("Skipping loading the data model; it is unchanged")
+            logger.info("Skipping loading the data model; it is unchanged")
             return
     insert_new_datamodel(database, data_model)
-    logging.info("Data model loaded")
+    logger.info("Data model loaded")

--- a/components/api_server/src/initialization/report.py
+++ b/components/api_server/src/initialization/report.py
@@ -1,23 +1,24 @@
 """Report loaders."""
 
 import json
-import logging
 import pathlib
 
 from pymongo.database import Database
 
 from database.reports import insert_new_report, insert_new_reports_overview, latest_reports_overview, report_exists
+from utils.log import get_logger
 
 
 def initialize_reports_overview(database: Database) -> None:
     """Initialize the reports overview if not present in the database."""
+    logger = get_logger()
     # The coverage measurement of the behave feature tests is unstable. Most of the time it reports the last two lines
     # as covered, sometimes not. It's unclear why. To prevent needless checking of the coverage report coverage
     # measurement of the last two lines and the if-statement has been turned off.
     if latest_reports_overview(database):  # pragma: no feature-test-cover
-        logging.info("Skipping initializing reports overview; it already exists")
+        logger.info("Skipping initializing reports overview; it already exists")
     else:
-        logging.info("Initializing reports overview")  # pragma: no feature-test-cover
+        logger.info("Initializing reports overview")  # pragma: no feature-test-cover
         insert_new_reports_overview(
             database,
             "{{user}} initialized the reports overview",
@@ -27,16 +28,17 @@ def initialize_reports_overview(database: Database) -> None:
 
 def import_report(database: Database, filename: pathlib.Path) -> None:
     """Read the report and store it in the database."""
+    logger = get_logger()
     # The coverage measurement of the behave feature tests is unstable. Most of the time it reports the last two lines
     # as covered, sometimes not. It's unclear why. To prevent needless checking of the coverage report coverage
     # measurement of the last two lines and the if-statement has been turned off.
     with filename.open() as json_report:
         imported_report = json.load(json_report)
     if report_exists(database, imported_report["report_uuid"]):  # pragma: no feature-test-cover
-        logging.info("Skipping import of %s; it already exists", filename)
+        logger.info("Skipping import of %s; it already exists", filename)
     else:  # pragma: no feature-test-cover
         insert_new_report(database, "{{user}} imported a new report", [imported_report["report_uuid"]], imported_report)
-        logging.info("Report %s imported", filename)
+        logger.info("Report %s imported", filename)
 
 
 def import_example_reports(database: Database) -> None:

--- a/components/api_server/src/routes/plugins/auth_plugin.py
+++ b/components/api_server/src/routes/plugins/auth_plugin.py
@@ -1,6 +1,5 @@
 """Route authentication and authorization plugin."""
 
-import logging
 from collections.abc import Callable
 
 import bottle
@@ -8,6 +7,7 @@ import bottle
 from database import sessions
 from database.reports import latest_reports_overview
 from model.session import Session
+from utils.log import get_logger
 from utils.type import SessionId
 
 
@@ -61,5 +61,6 @@ class AuthPlugin:
     @staticmethod
     def abort(status_code: int, message: str, context, session_id: str) -> None:
         """Log the message and abort."""
-        logging.warning(message, context.method, context.rule, session_id)
+        logger = get_logger()
+        logger.warning(message, context.method, context.rule, session_id)
         bottle.abort(status_code, bottle.HTTP_CODES[status_code])

--- a/components/api_server/src/utils/log.py
+++ b/components/api_server/src/utils/log.py
@@ -1,0 +1,10 @@
+"""Logger utilities."""
+
+import logging
+
+from shared.utils.log import get_logger as _get_logger
+
+
+def get_logger() -> logging.Logger:
+    """Return the logger for the current component and the caller's module."""
+    return _get_logger("api_server", call_stack_depth=1)

--- a/components/api_server/tests/utils/test_log.py
+++ b/components/api_server/tests/utils/test_log.py
@@ -1,0 +1,13 @@
+"""Unit tests for the logging utilities."""
+
+import unittest
+
+from utils.log import get_logger
+
+
+class LogTest(unittest.TestCase):
+    """Unit tests for the log utilities."""
+
+    def test_get_logger(self):
+        """Test getting the logger."""
+        self.assertEqual("quality_time.api_server.tests.utils.test_log", get_logger().name)

--- a/components/collector/src/base_collectors/collector.py
+++ b/components/collector/src/base_collectors/collector.py
@@ -13,6 +13,7 @@ from shared.database.reports import get_reports
 from shared.model.metric import Metric
 from shared.model.report import get_metrics_from_reports
 
+from collector_utilities.log import get_logger
 from collector_utilities.type import JSONDict
 from database.measurements import create_measurement
 
@@ -32,12 +33,13 @@ class Collector:
     @staticmethod
     def record_health() -> None:
         """Record the current date and time in a file to allow for health checks."""
+        logger = get_logger()
         filename = pathlib.Path(config.HEALTH_CHECK_FILE)
         try:
             with filename.open("w", encoding="utf-8") as health_check:
                 health_check.write(datetime.now(tz=UTC).isoformat())
         except OSError as reason:
-            logging.error("Could not write health check time stamp to %s: %s", filename, reason)  # noqa: TRY400
+            logger.error("Could not write health check time stamp to %s: %s", filename, reason)  # noqa: TRY400
 
     async def start(self) -> NoReturn:
         """Start fetching measurements indefinitely."""
@@ -107,4 +109,5 @@ class Collector:
     def __log_tasks(self, event: str, warning_threshold: int = 0) -> None:
         """Log the number of running tasks."""
         level = logging.WARNING if len(self.running_tasks) > warning_threshold else logging.INFO
-        logging.log(level, "%s: %d task(s) currently running", event, len(self.running_tasks))
+        logger = get_logger()
+        logger.log(level, "%s: %d task(s) currently running", event, len(self.running_tasks))

--- a/components/collector/src/collector_utilities/log.py
+++ b/components/collector/src/collector_utilities/log.py
@@ -1,0 +1,10 @@
+"""Logger utilities."""
+
+import logging
+
+from shared.utils.log import get_logger as _get_logger
+
+
+def get_logger() -> logging.Logger:
+    """Return the logger for the current component and the caller's module."""
+    return _get_logger("collector", call_stack_depth=1)

--- a/components/collector/tests/base_collectors/test_collector.py
+++ b/components/collector/tests/base_collectors/test_collector.py
@@ -283,12 +283,13 @@ class CollectorTest(unittest.IsolatedAsyncioTestCase):
         mocked_open().write.assert_called_once_with(now.isoformat())
 
     @patch("pathlib.Path.open")
-    @patch("logging.error")
+    @patch("logging.getLogger")
     def test_fail_writing_health_check(self, mocked_log: Mock, mocked_open: Mock):
         """Test that a failure to open the health check file is logged, but otherwise ignored."""
+        logger = mocked_log.return_value = Mock()
         mocked_open.side_effect = OSError("Some error")
         self.collector.record_health()
-        mocked_log.assert_called_once_with(
+        logger.error.assert_called_once_with(
             "Could not write health check time stamp to %s: %s",
             pathlib.Path("/home/collector/health_check.txt"),
             mocked_open.side_effect,

--- a/components/collector/tests/collector_utilities/test_log.py
+++ b/components/collector/tests/collector_utilities/test_log.py
@@ -1,0 +1,13 @@
+"""Unit tests for the logging utilities."""
+
+import unittest
+
+from collector_utilities.log import get_logger
+
+
+class LogTest(unittest.TestCase):
+    """Unit tests for the log utilities."""
+
+    def test_get_logger(self):
+        """Test getting the logger."""
+        self.assertEqual("quality_time.collector.tests.collector_utilities.test_log", get_logger().name)

--- a/components/notifier/src/destinations/ms_teams.py
+++ b/components/notifier/src/destinations/ms_teams.py
@@ -1,10 +1,9 @@
 """Microsoft Teams destination."""
 
-import logging
-
 import pymsteams
 
 from models.notification import MetricNotificationData, Notification
+from notifier_utilities.log import get_logger
 
 ICON_URL = "https://raw.githubusercontent.com/ICTU/quality-time/master/resources/icons/%s.png"
 
@@ -40,9 +39,10 @@ def create_connector_card(destination: str, notification: Notification) -> pymst
 
 def send_notification(destination: str, notification: Notification) -> None:
     """Send notification to Microsoft Teams using a Webhook."""
-    logging.info("Sending notification to configured teams webhook")
+    logger = get_logger()
+    logger.info("Sending notification to configured teams webhook")
     card = create_connector_card(destination, notification)
     try:
         card.send()
     except Exception:
-        logging.exception("Could not deliver notification")
+        logger.exception("Could not deliver notification")

--- a/components/notifier/src/notifier/notifier.py
+++ b/components/notifier/src/notifier/notifier.py
@@ -1,7 +1,6 @@
 """Notifier."""
 
 import asyncio
-import logging
 import pathlib
 from datetime import UTC, datetime
 from os import getenv
@@ -13,38 +12,41 @@ from shared.model.measurement import Measurement
 
 from database.reports import get_reports_and_measurements
 from destinations.ms_teams import send_notification
+from notifier_utilities.log import get_logger
 from strategies.notification_strategy import NotificationFinder
 
 
 async def notify(database: Database, sleep_duration: int = 60) -> NoReturn:
     """Notify our users periodically of the number of red metrics."""
+    logger = get_logger()
     most_recent_measurement_seen = datetime.max.replace(tzinfo=UTC)
     notification_finder = NotificationFinder()
     while True:
         record_health()
-        logging.info("Determining notifications...")
+        logger.info("Determining notifications...")
         try:
             reports, measurements = get_reports_and_measurements(database)
         except Exception:
-            logging.exception("Getting reports and measurements failed")
+            logger.exception("Getting reports and measurements failed")
             reports = []
             measurements = []
 
         for notification in notification_finder.get_notifications(reports, measurements, most_recent_measurement_seen):
             send_notification(str(notification.destination["webhook"]), notification)
         most_recent_measurement_seen = most_recent_measurement_timestamp(measurements)
-        logging.info("Sleeping %.1f seconds...", sleep_duration)
+        logger.info("Sleeping %.1f seconds...", sleep_duration)
         await asyncio.sleep(sleep_duration)
 
 
 def record_health() -> None:
     """Record the current date and time in a file to allow for health checks."""
+    logger = get_logger()
     filepath = pathlib.Path(getenv("HEALTH_CHECK_FILE", "/home/notifier/health_check.txt"))
     try:
         with filepath.open("w", encoding="utf-8") as health_check:
             health_check.write(datetime.now(tz=UTC).isoformat())
     except OSError:
-        logging.exception("Could not write health check time stamp to %s", filepath)
+        logger.exception("Could not write health check time stamp to %s", filepath)
 
 
 def most_recent_measurement_timestamp(measurements: list[Measurement]) -> datetime:

--- a/components/notifier/src/notifier_utilities/log.py
+++ b/components/notifier/src/notifier_utilities/log.py
@@ -1,0 +1,10 @@
+"""Logger utilities."""
+
+import logging
+
+from shared.utils.log import get_logger as _get_logger
+
+
+def get_logger() -> logging.Logger:
+    """Return the logger for the current component and the caller's module."""
+    return _get_logger("notifier", call_stack_depth=1)

--- a/components/notifier/tests/notifier_utilities/test_log.py
+++ b/components/notifier/tests/notifier_utilities/test_log.py
@@ -1,0 +1,13 @@
+"""Unit tests for the logging utilities."""
+
+import unittest
+
+from notifier_utilities.log import get_logger
+
+
+class LogTest(unittest.TestCase):
+    """Unit tests for the log utilities."""
+
+    def test_get_logger(self):
+        """Test getting the logger."""
+        self.assertEqual("quality_time.notifier.tests.notifier_utilities.test_log", get_logger().name)

--- a/components/shared_code/src/shared/utils/log.py
+++ b/components/shared_code/src/shared/utils/log.py
@@ -1,0 +1,11 @@
+"""Logging utilities."""
+
+import logging
+import sys
+
+
+def get_logger(component_name: str, call_stack_depth: int = 0) -> logging.Logger:
+    """Return the logger for the given component and the caller's module."""
+    # Get the module name from the caller's stack frame so we can add it to the logger name:
+    module_name = sys._getframe(call_stack_depth + 1).f_globals["__name__"]  # noqa: SLF001
+    return logging.getLogger(f"quality_time.{component_name}.{module_name}")

--- a/components/shared_code/tests/shared/utils/test_log.py
+++ b/components/shared_code/tests/shared/utils/test_log.py
@@ -1,0 +1,23 @@
+"""Unit tests for the logging utilities."""
+
+import logging
+import unittest
+
+from shared.utils.log import get_logger
+
+
+class LogTest(unittest.TestCase):
+    """Unit tests for the log utilities."""
+
+    def test_get_logger(self):
+        """Test getting the logger."""
+        self.assertEqual("quality_time.shared_code.tests.shared.utils.test_log", get_logger("shared_code").name)
+
+    def test_get_logger_indirectly(self):
+        """Test getting the logger via an extra function call."""
+
+        def get_logger_indirectly() -> logging.Logger:
+            """Return the logger."""
+            return get_logger("component", call_stack_depth=1)
+
+        self.assertEqual("quality_time.component.tests.shared.utils.test_log", get_logger_indirectly().name)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,6 +19,10 @@ If your currently installed *Quality-time* version is not the latest version, pl
 - Use the locale of the user's browser when exporting to PDF so that dates are formatted accordingly in the PDF. Fixes [#8381](https://github.com/ICTU/quality-time/issues/8381).
 - When measuring average issue lead time with Jira as source, the lead times per issue would not be collected. Fixes [#10929](https://github.com/ICTU/quality-time/issues/10929).
 
+### Changed
+
+- Add component and module names to the logging of Python components.
+
 ## v5.26.0 - 2025-02-27
 
 ### Added


### PR DESCRIPTION
Ruff 0.10.0 frowns upon log calls that log to the root logger. Use component and module names to construct a non-root logger name for each log call.