### PR TITLE
Ignore measurement entities that no longer exist.

### DIFF
--- a/components/frontend/src/measurement/MeasurementValue.jsx
+++ b/components/frontend/src/measurement/MeasurementValue.jsx
@@ -60,8 +60,10 @@ measurementValueLabel.propTypes = {
 function ignoredEntitiesCount(measurement) {
     const count = Object.fromEntries(IGNORABLE_SOURCE_ENTITY_STATUSES.map((status) => [status, 0]))
     measurement?.sources?.forEach((source) => {
-        Object.values(source.entity_user_data ?? {}).forEach((entity) => {
-            if (Object.keys(count).includes(entity.status)) {
+        // Ignore entity user data that refers to entities that no longer exist by checking the entity keys
+        const validKeys = (source.entities ?? []).map((entity) => entity.key)
+        Object.entries(source.entity_user_data ?? {}).forEach(([entityKey, entity]) => {
+            if (validKeys.includes(entityKey) && Object.keys(count).includes(entity.status)) {
                 count[entity.status]++
             }
         })

--- a/components/frontend/src/measurement/MeasurementValue.test.jsx
+++ b/components/frontend/src/measurement/MeasurementValue.test.jsx
@@ -213,16 +213,43 @@ it("shows ignored measurement entities", async () => {
         latest_measurement: {
             start: "2022-01-16T00:31:00",
             end: "2022-01-16T00:51:00",
-            count: { value: "42" },
+            count: { value: "1" },
             sources: [
-                { entity_user_data: { entity1: { status: "false_positive" }, entity2: { status: "confirmed" } } },
+                {
+                    entities: [{ key: "entity1" }, { key: "entity2" }],
+                    entity_user_data: { entity1: { status: "false_positive" }, entity2: { status: "confirmed" } },
+                },
                 {},
             ],
         },
     })
-    await userEvent.hover(screen.queryByText(/42/))
+    await userEvent.hover(screen.queryByText(/1/))
     await waitFor(async () => {
         expect(screen.queryByText(/Ignored foo/)).not.toBe(null)
+        await expectNoAccessibilityViolations(container)
+    })
+})
+
+it("does not show ignored measurement entities that no longer exist", async () => {
+    const { container } = renderMeasurementValue({
+        status: "target_met",
+        unit: "foo",
+        latest_measurement: {
+            start: "2022-01-16T00:31:00",
+            end: "2022-01-16T00:51:00",
+            count: { value: "1" },
+            sources: [
+                {
+                    entities: [{ key: "entity2" }],
+                    entity_user_data: { entity1: { status: "false_positive" }, entity2: { status: "confirmed" } },
+                },
+                {},
+            ],
+        },
+    })
+    await userEvent.hover(screen.queryByText(/1/))
+    await waitFor(async () => {
+        expect(screen.queryByText(/Ignored foo/)).toBe(null)
         await expectNoAccessibilityViolations(container)
     })
 })

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 ### Fixed
 
 - Use the locale of the user's browser when exporting to PDF so that dates are formatted accordingly in the PDF. Fixes [#8381](https://github.com/ICTU/quality-time/issues/8381).
+- In the measurement value popup, don't show status information for measurement entities that no longer exist. Fixes [#10373](https://github.com/ICTU/quality-time/issues/10373).
 - Show an error message when measurement entities cannot be loaded. Fixes [#10478](https://github.com/ICTU/quality-time/issues/10478).
 - When measuring average issue lead time with Jira as source, the lead times per issue would not be collected. Fixes [#10929](https://github.com/ICTU/quality-time/issues/10929).
 - Wait for all measurement entities to have been loaded before exporting to PDF. Fixes [#10992](https://github.com/ICTU/quality-time/issues/10992).


### PR DESCRIPTION
In the measurement value popup, don't show status information for measurement entities that no longer exist.

Fixes #10373.