### PR TITLE
Increase limit of 100 measurement entities.

### DIFF
--- a/components/collector/src/model/measurement.py
+++ b/components/collector/src/model/measurement.py
@@ -16,7 +16,7 @@ from .issue_status import IssueStatus
 class SourceMeasurement:
     """Class to hold measurement values, entities, and error messages from collecting the measurement from a source."""
 
-    MAX_ENTITIES: ClassVar[int] = 100  # The maximum number of entities (e.g. violations, issues) to send to the server
+    MAX_ENTITIES: ClassVar[int] = 250  # The maximum number of entities (e.g. violations, issues) to send to the server
 
     value: Value | None = None
     total: Value | None = "100"

--- a/components/collector/src/source_collectors/azure_devops/issues.py
+++ b/components/collector/src/source_collectors/azure_devops/issues.py
@@ -7,7 +7,7 @@ import aiohttp
 from base_collectors import SourceCollector
 from collector_utilities.functions import iterable_to_batches
 from collector_utilities.type import URL, Value
-from model import Entities, Entity, SourceMeasurement, SourceResponses
+from model import Entities, Entity, SourceResponses
 
 
 class AzureDevopsIssues(SourceCollector):
@@ -46,8 +46,7 @@ class AzureDevopsIssues(SourceCollector):
     async def _get_work_item_responses(self, auth: aiohttp.BasicAuth) -> SourceResponses:
         """Separately get each work item from the API."""
         api_url = await self._api_wit_url(endpoint="workitemsbatch")
-        batch_size = min(self.MAX_IDS_PER_WORK_ITEMS_API_CALL, SourceMeasurement.MAX_ENTITIES)
-        id_iter = iterable_to_batches(self._issue_ids_to_fetch, batch_size)
+        id_iter = iterable_to_batches(self._issue_ids_to_fetch, self.MAX_IDS_PER_WORK_ITEMS_API_CALL)
         responses = [
             await self._session.post(
                 api_url,

--- a/components/collector/src/source_collectors/sonarqube/violations.py
+++ b/components/collector/src/source_collectors/sonarqube/violations.py
@@ -29,7 +29,8 @@ class SonarQubeViolations(SonarQubeCollector):
         component = self._parameter("component")
         branch = self._parameter("branch")
         # If there's more than 500 issues only the first 500 are returned. This is no problem since we limit
-        # the number of "entities" sent to the server anyway (that limit is 100 currently).
+        # the number of "entities" sent to the server anyway (that limit is 250 currently).
+        # Issue: https://github.com/ICTU/quality-time/issues/11004
         api = f"{url}/api/issues/search?componentKeys={component}&branch={branch}&resolved=false&ps={self.PAGE_SIZE}"
         return URL(api + self._url_parameters())
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,12 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Changed
+
+- Increase the number of measurement entities (violations, issues, etc.) stored per measurement to 250 max. Closes [#6278](https://github.com/ICTU/quality-time/issues/6278).
+
 ## v5.29.0 - 2025-05-08
 
 ### Added

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -363,7 +363,9 @@ To reorder sources, expand the metric in the metric table and click the sources 
 
 ### Configuring entities
 
-An entity is a measured entity, such as one single failed job in GitLab for a metric that measures failed GitLab jobs or a single violation in SonarQube for a metric that measures violations. What exactly an entity is, and what properties it has depends on what the metric in question is measuring. Not every metric will have entities.
+An entity is a measured entity, such as one single failed job in GitLab for a metric that measures failed GitLab jobs or a single violation in SonarQube for a metric that measures violations. What exactly an entity is, and what properties it has depends on what the metric in question is measuring.
+
+Not every metric will have entities. For example, the source up-to-dateness metric has "days" as unit. These are not shown as measurement entities. But, the issues metric does show the individual issues as measurement entities. To prevent performance issues and limit the storage capacity needed, Quality-time stores and shows at most 250 entities per metric.
 
 To add a source to a metric, expand the metric in the metric table and then click the tab with the source name. It will show a list of entities with all its details.
 


### PR DESCRIPTION
Increase the limit of 100 measurement entities per metric source.

Closes #6278.