### PR TITLE
Fix Bitbucket documentation.

### DIFF
--- a/components/shared_code/src/shared_data_model/sources/bitbucket.py
+++ b/components/shared_code/src/shared_data_model/sources/bitbucket.py
@@ -30,13 +30,6 @@ BITBUCKET = Source(
     "enabling developers to collaborate on code with features like pull requests, "
     "CI/CD, and seamless integration with tools like Jira and Trello.",
     url=HttpUrl("https://bitbucket.org/product/guides/getting-started/overview#a-brief-overview-of-bitbucket/"),
-    documentation={
-        "generic": """```{note}
-The pagination for the Bitbucket collector has not yet been implemented,\
-and the current limit for retrieving branches for the inactive branches metric using the API is set to 100.\
-Pagination will be implemented in a future update.
-```""",
-    },
     parameters={
         "url": URL(
             name="Bitbucket instance URL",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -21,6 +21,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 - Show an error message when measurement entities cannot be loaded. Fixes [#10478](https://github.com/ICTU/quality-time/issues/10478).
 - When measuring average issue lead time with Jira as source, the lead times per issue would not be collected. Fixes [#10929](https://github.com/ICTU/quality-time/issues/10929).
 - Wait for all measurement entities to have been loaded before exporting to PDF. Fixes [#10992](https://github.com/ICTU/quality-time/issues/10992).
+- The documentation for Bitbucket incorrectly said that pagination when retrieving Bitbucket data is not implemented. Fixes [#11005](https://github.com/ICTU/quality-time/issues/11005).
 
 ### Changed
 


### PR DESCRIPTION
The documentation for Bitbucket incorrectly said that pagination when retrieving Bitbucket data is not implemented.

Fixes #11005.