### PR TITLE
Prevent runtime warning in the collector logs.

### DIFF
--- a/components/collector/src/base_collectors/metric_collector.py
+++ b/components/collector/src/base_collectors/metric_collector.py
@@ -60,10 +60,10 @@ class MetricCollector:
         for source in self._metric["sources"].values():
             collector_class = SourceCollector.get_subclass(source["type"], self._metric["type"])
             if collector_class and self.__has_all_mandatory_parameters(source):
-                collectors.append(collector_class(self.__session, source).collect())
+                collectors.append(collector_class(self.__session, source))
             else:
                 return []
-        return collectors
+        return [collector.collect() for collector in collectors]
 
     def __issue_status_collectors(self) -> list[Coroutine]:
         """Create the issue status collector for the metric."""

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -20,6 +20,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 ### Fixed
 
+- Prevent "RuntimeWarning: coroutine 'SourceCollector.collect' was never awaited" in the collector logs. Fixes [#11015](https://github.com/ICTU/quality-time/issues/11015).
 - Make measurement entity table headers sticky again. Fixes [#11036](https://github.com/ICTU/quality-time/issues/11036).
 - Make the JUnit timestamp parsing more robust. Fixes [#11044](https://github.com/ICTU/quality-time/issues/11044).
 


### PR DESCRIPTION
Prevent "RuntimeWarning: coroutine 'SourceCollector.collect' was never awaited" in the collector logs.

Fixes #11015.