### PR TITLE
Show up-to-dateness of individual DT-projects

### DIFF
--- a/components/collector/src/base_collectors/metric_collector.py
+++ b/components/collector/src/base_collectors/metric_collector.py
@@ -60,7 +60,7 @@ class MetricCollector:
         for source in self._metric["sources"].values():
             collector_class = SourceCollector.get_subclass(source["type"], self._metric["type"])
             if collector_class and self.__has_all_mandatory_parameters(source):
-                collectors.append(collector_class(self.__session, source))
+                collectors.append(collector_class(self.__session, self._metric, source))
             else:
                 return []
         return [collector.collect() for collector in collectors]
@@ -72,7 +72,7 @@ class MetricCollector:
         has_tracker = bool(tracker_type and tracker.get("parameters", {}).get("url"))
         if has_tracker and (collector_class := SourceCollector.get_subclass(tracker_type, "issue_status")):
             return [
-                collector_class(self.__session, tracker).collect_issue_status(issue_id)
+                collector_class(self.__session, self._metric, tracker).collect_issue_status(issue_id)
                 for issue_id in self._metric.get("issue_ids", [])
             ]
         return []

--- a/components/collector/src/source_collectors/azure_devops/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/azure_devops/source_up_to_dateness.py
@@ -53,11 +53,11 @@ class AzureDevopsJobUpToDateness(TimePassedCollector, AzureDevopsJobs):
 class AzureDevopsSourceUpToDateness(SourceCollector, ABC):
     """Factory class to create a collector to get the up-to-dateness of either jobs or files."""
 
-    def __new__(cls, session: aiohttp.ClientSession, source) -> Self:
+    def __new__(cls, session: aiohttp.ClientSession, metric, source) -> Self:
         """Create an instance of either the file up-to-dateness collector or the jobs up-to-dateness collector."""
         file_path = source.get("parameters", {}).get("file_path")
         collector_class = AzureDevopsFileUpToDateness if file_path else AzureDevopsJobUpToDateness
-        instance = collector_class(session, source)
+        instance = collector_class(session, metric, source)
         instance.source_type = cls.source_type
         return cast(Self, instance)
 

--- a/components/collector/src/source_collectors/gitlab/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/gitlab/source_up_to_dateness.py
@@ -87,8 +87,7 @@ class GitLabPipelineUpToDateness(TimePassedCollector, GitLabPipelineBase):
         error_message = "No pipelines found within the lookback period"
         raise CollectorError(error_message)
 
-    @staticmethod
-    def minimum(date_times: Sequence[datetime]) -> datetime:
+    def minimum(self, date_times: Sequence[datetime]) -> datetime:
         """Override to return the newest datetime."""
         return max(date_times)
 
@@ -96,11 +95,11 @@ class GitLabPipelineUpToDateness(TimePassedCollector, GitLabPipelineBase):
 class GitLabSourceUpToDateness(SourceCollector, ABC):
     """Factory class to create a collector to get the up-to-dateness of either pipelines or files."""
 
-    def __new__(cls, session: aiohttp.ClientSession, source) -> Self:
+    def __new__(cls, session: aiohttp.ClientSession, metric, source) -> Self:
         """Create an instance of either the file up-to-dateness collector or the jobs up-to-dateness collector."""
         file_path = source.get("parameters", {}).get("file_path")
         collector_class = GitLabFileUpToDateness if file_path else GitLabPipelineUpToDateness
-        instance = collector_class(session, source)
+        instance = collector_class(session, metric, source)
         instance.source_type = cls.source_type
         return cast(Self, instance)
 

--- a/components/collector/tests/source_collectors/test_collector.py
+++ b/components/collector/tests/source_collectors/test_collector.py
@@ -72,7 +72,7 @@ class CollectorTest(SourceCollectorTestCase):
 
         with patch("aiohttp.ClientSession.get", side_effect=Exception):
             async with aiohttp.ClientSession() as session:
-                response = await FailingLandingUrl(session, self.sources["source_id"]).collect()
+                response = await FailingLandingUrl(session, self.metric, self.sources["source_id"]).collect()
         self.assertEqual("https://api_url", response.landing_url)
 
     async def test_default_parameter_value_supersedes_empty_string(self):
@@ -97,6 +97,6 @@ class CollectorTest(SourceCollectorTestCase):
                 return bool(entity["key"] != "1")
 
         async with aiohttp.ClientSession() as session:
-            collector = ThreeParsedEntities(session, {})
+            collector = ThreeParsedEntities(session, self.metric, {})
             measurement = await collector._parse_source_responses(SourceResponses())  # noqa: SLF001
         self.assertEqual(["0", "2"], [entity["key"] for entity in measurement.entities])

--- a/components/shared_code/src/shared_data_model/meta/entity.py
+++ b/components/shared_code/src/shared_data_model/meta/entity.py
@@ -58,7 +58,7 @@ class EntityAttribute(NamedModel):
     def set_key(self) -> Self:
         """Set the key to the lower case version of the name if there's no key."""
         if self.key is None:
-            self.key = self.name.lower().replace(" ", "_")
+            self.key = self.name.lower().replace(" ", "_").replace("-", "_")
         return self
 
 

--- a/components/shared_code/src/shared_data_model/sources/dependency_track.py
+++ b/components/shared_code/src/shared_data_model/sources/dependency_track.py
@@ -138,6 +138,15 @@ DEPENDENCY_TRACK = Source(
                 EntityAttribute(name="Latest", key="is_latest", type=EntityAttributeType.BOOLEAN),
                 EntityAttribute(name="Last BOM import", type=EntityAttributeType.DATETIME),
                 EntityAttribute(name="Last BOM analysis", type=EntityAttributeType.DATETIME),
+                EntityAttribute(
+                    name="Up-to-date",
+                    color={
+                        "nearly": Color.WARNING,
+                        "no": Color.NEGATIVE,
+                        "yes": Color.POSITIVE,
+                        "unknown": Color.ACTIVE,
+                    },
+                ),
             ],
         ),
     },

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,12 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Added
+
+- When measuring source-up-to-dateness with Dependency-Track as source, also show the up-to-dateness of individual projects in the measurement details. Closes [#10545](https://github.com/ICTU/quality-time/issues/10545).
+
 ## v5.27.0 - 2025-04-04
 
 ### Added


### PR DESCRIPTION
When measuring source-up-to-dateness with Dependency-Track as source, also show the up-to-dateness of individual projects in the measurement details.

Closes #10545.