### PR TITLE
Fix API-server logging.

### DIFF
--- a/components/api_server/src/initialization/migrations.py
+++ b/components/api_server/src/initialization/migrations.py
@@ -203,7 +203,8 @@ def change_unmerged_branches_metrics_to_inactive_branches(report) -> str:
 
 def log_unknown_parameter_values(value_mapping: dict[str, str], old_values: list[str], value_type: str, report) -> None:
     """Log old parameter values that do not exist in the mapping."""
-    if unknown_values := [old_value for old_value in old_values if old_value not in value_mapping]:
+    known_values = list(value_mapping.keys()) + list(value_mapping.values())
+    if unknown_values := [old_value for old_value in old_values if old_value not in known_values]:
         message = "Ignoring one or more unknown SonarQube parameter values of type '%s' in report %s: %s"
         logger = get_logger()
         logger.warning(message, value_type, report["report_uuid"], ", ".join(unknown_values))

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,10 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 - When measuring source-up-to-dateness with Dependency-Track as source, also show the up-to-dateness of individual projects in the measurement details. Closes [#10545](https://github.com/ICTU/quality-time/issues/10545).
 
+### Fixed
+
+- The API-server would incorrectly log about encountering unknown SonarQube parameter values when running migration code at startup. Fixes [#11119](https://github.com/ICTU/quality-time/issues/11119).
+
 ## v5.27.0 - 2025-04-04
 
 ### Added


### PR DESCRIPTION
The API-server would incorrectly log about encountering unknown SonarQube parameter values when running migration code at startup.

Fixes #11119.