### PR TITLE
Filter latest DT-project version.

### DIFF
--- a/components/collector/src/source_collectors/dependency_track/base.py
+++ b/components/collector/src/source_collectors/dependency_track/base.py
@@ -89,7 +89,9 @@ class DependencyTrackBase(SourceCollector):
         project_matches_name = match_string_or_regular_expression(project["name"], names) if names else True
         project_version = project.get("version", "unknown")
         project_matches_version = match_string_or_regular_expression(project_version, versions) if versions else True
-        return project_matches_name and project_matches_version
+        only_include_latest_project_version = self._parameter("only_include_latest_project_versions")
+        project_matches_latest = not (only_include_latest_project_version == "yes" and not self._is_latest(project))
+        return project_matches_name and project_matches_version and project_matches_latest
 
     @staticmethod
     def _latest_version_status(version: str, latest: str) -> Literal["unknown", "up-to-date", "update possible"]:
@@ -99,6 +101,11 @@ class DependencyTrackBase(SourceCollector):
         if latest == version:
             return "up-to-date"
         return "update possible"
+
+    @staticmethod
+    def _is_latest(project: DependencyTrackProject) -> bool:
+        """Return whether the project is the latest version."""
+        return project.get("isLatest", False)
 
 
 class DependencyTrackLatestVersionStatusBase(DependencyTrackBase):

--- a/components/collector/src/source_collectors/dependency_track/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/dependency_track/source_up_to_dateness.py
@@ -65,13 +65,6 @@ class DependencyTrackSourceUpToDateness(DependencyTrackBase, TimePassedCollector
             datetimes.append(datetime)
         return datetimes
 
-    def _project_matches(self, project: DependencyTrackProject, names: list[str], versions: list[str]) -> bool:
-        """Return whether the project name matches the project names and versions."""
-        only_include_latest_project_version = self._parameter("only_include_latest_project_versions")
-        if only_include_latest_project_version == "yes" and not self._is_latest(project):
-            return False
-        return super()._project_matches(project, names, versions)
-
     @classmethod
     def _last_bom_import_datetime(cls, project: DependencyTrackProject) -> datetime | None:
         """Return the last BOM import datetime for the project."""
@@ -86,11 +79,6 @@ class DependencyTrackSourceUpToDateness(DependencyTrackBase, TimePassedCollector
     def _timestamp_to_datetime(timestamp: int | None) -> datetime | None:
         """Convert the timestamp to a datetime."""
         return None if timestamp is None else datetime_from_timestamp(timestamp)
-
-    @staticmethod
-    def _is_latest(project: DependencyTrackProject) -> bool:
-        """Return whether the project is the latest version."""
-        return project.get("isLatest", False)
 
     def _up_to_dateness(self, project: DependencyTrackProject) -> str:
         """Return the up-to-dateness of the project."""

--- a/components/collector/tests/source_collectors/dependency_track/test_dependencies.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_dependencies.py
@@ -116,3 +116,9 @@ class DependencyTrackDependenciesTest(DependencyTrackTestCase):
         self.set_source_parameter("project_versions", ["1.2", "1.3"])
         response = await self.collect(get_request_json_return_value=self.projects(version=""))
         self.assert_measurement(response, value="0", entities=[])
+
+    async def test_filter_by_latest_project(self):
+        """Test that projects can be filtered by being the latest project version."""
+        self.set_source_parameter("only_include_latest_project_versions", "yes")
+        response = await self.collect(get_request_json_side_effect=[self.projects()])
+        self.assert_measurement(response, value="0", entities=[])

--- a/components/collector/tests/source_collectors/dependency_track/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_security_warnings.py
@@ -101,6 +101,12 @@ class DependencyTrackSecurityWarningsTest(DependencyTrackTestCase):
         response = await self.collect(get_request_json_side_effect=[self.projects(), self.findings()])
         self.assert_measurement(response, value="1", entities=self.entities())
 
+    async def test_filter_by_latest_project(self):
+        """Test that projects can be filtered by being the latest project version."""
+        self.set_source_parameter("only_include_latest_project_versions", "yes")
+        response = await self.collect(get_request_json_side_effect=[self.projects()])
+        self.assert_measurement(response, value="0", entities=[])
+
     async def test_include_by_component_name(self):
         """Test filtering by component name."""
         self.set_source_parameter("components_to_include", ["other component"])

--- a/components/shared_code/src/shared_data_model/sources/dependency_track.py
+++ b/components/shared_code/src/shared_data_model/sources/dependency_track.py
@@ -106,7 +106,7 @@ DEPENDENCY_TRACK = Source(
             values=["yes", "no"],
             default_value="no",
             help="Only include project versions that are marked as latest.",
-            metrics=["source_up_to_dateness"],
+            metrics=["dependencies", "security_warnings", "source_up_to_dateness"],
         ),
     },
     entities={

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 ### Added
 
 - When measuring source-up-to-dateness with Dependency-Track as source, also show the up-to-dateness of individual projects in the measurement details. Closes [#10545](https://github.com/ICTU/quality-time/issues/10545).
+- When measuring security warnings or dependencies with Dependency-Track as source, allow for including only project versions that are the latest version. Closes [#11121](https://github.com/ICTU/quality-time/issues/11121).
 
 ### Fixed
 


### PR DESCRIPTION
When measuring security warnings or dependencies with Dependency-Track as source, allow for including only project versions that are the latest version.

Closes #11121.