### PR TITLE
Fix footer not at bottom of the window.

### DIFF
--- a/components/frontend/src/App.css
+++ b/components/frontend/src/App.css
@@ -1,3 +1,9 @@
 html {
-    scroll-padding-top: 204px; /* height of sticky header */
+    height: 100%; /* Make sure the footer can be at the bottom of the page */
+    scroll-padding-top: 204px; /* Height of sticky header */
+}
+body {
+    display: flex; /* Stretch the body... */
+    flex-direction: column; /* ...vertically... */
+    min-height: 100%; /* ...to fill the entire vertical space, so the footer is always at the bottom */
 }

--- a/components/frontend/src/PageContent.jsx
+++ b/components/frontend/src/PageContent.jsx
@@ -134,7 +134,6 @@ export function PageContent({
                 marginBottom: "0px",
                 marginLeft: "0px",
                 marginRight: "0px",
-                minHeight: "65vh",
             }}
         >
             <ToastContainer theme="colored" />

--- a/components/frontend/src/header_footer/Footer.jsx
+++ b/components/frontend/src/header_footer/Footer.jsx
@@ -147,7 +147,7 @@ function QuoteColumn() {
 
 export function Footer({ lastUpdate, report }) {
     return (
-        <AppBar component="footer" position="relative" sx={{ displayPrint: "none" }}>
+        <AppBar component="footer" position="relative" sx={{ displayPrint: "none", flex: 0 }}>
             <Container maxWidth="md" sx={{ padding: "60px" }}>
                 <Grid container spacing={2} columns={{ xs: 1, sm: 3 }}>
                     <Grid size={1}>

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -21,6 +21,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 ### Fixed
 
+- Keep the footer at the bottom of the page even if the browser window is very tall. Fixes [#10877](https://github.com/ICTU/quality-time/issues/10877).
 - The API-server would incorrectly log about encountering unknown SonarQube parameter values when running migration code at startup. Fixes [#11119](https://github.com/ICTU/quality-time/issues/11119).
 
 ## v5.27.0 - 2025-04-04


### PR DESCRIPTION
Keep the footer at the bottom of the page even if the browser window is very tall.

Fixes #10877.