### PR TITLE
Fix the renderer using 100% CPU

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
 
   unittest_frontend:
     docker:
-      - image: cimg/node:23.10
+      - image: cimg/node:23.11
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/components/frontend/Dockerfile
+++ b/components/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23.10.0-alpine3.21 AS compile-image
+FROM node:23.11.0-alpine3.21 AS compile-image
 
 WORKDIR /home/frontend
 COPY public /home/frontend/public

--- a/components/renderer/Dockerfile
+++ b/components/renderer/Dockerfile
@@ -1,9 +1,11 @@
-FROM node:23.10.0-alpine3.21
+FROM node:23.11.0-bookworm-slim
 
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time PDF render service"
 
-RUN apk add --no-cache chromium=135.0.7049.52-r0
+RUN apt-get update && \
+    apt-get --no-install-recommends -y install chromium=135.0.7049.84-1~deb12u1 && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/renderer
 COPY package*.json /home/renderer/

--- a/components/renderer/src/index.js
+++ b/components/renderer/src/index.js
@@ -58,11 +58,10 @@ app.get("/api/render", async (req, res) => {
 app.listen(RENDERER_PORT, async () => {
     try {
         browser = await puppeteer.launch({
-            executablePath: "/usr/bin/chromium-browser",
+            executablePath: "/usr/bin/chromium",
             defaultViewport: { width: 1500, height: 1000 },
             args: ["--disable-dev-shm-usage", "--no-sandbox"],
-            // Opt in to new Chrome headless implementation, see https://developer.chrome.com/articles/new-headless/:
-            headless: "new",
+            headless: "true",
         });
         console.log(`Renderer started on port ${RENDERER_PORT}. Using proxy ${PROXY}`);
     } catch (error) {

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -23,6 +23,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 - Keep the footer at the bottom of the page even if the browser window is very tall. Fixes [#10877](https://github.com/ICTU/quality-time/issues/10877).
 - The API-server would incorrectly log about encountering unknown SonarQube parameter values when running migration code at startup. Fixes [#11119](https://github.com/ICTU/quality-time/issues/11119).
+- The renderer would use 100% CPU while idling. Fixed by using a different base image (Debian) for the renderer with a different version of Chromium. Fixes [#11131](https://github.com/ICTU/quality-time/issues/11131).
 
 ## v5.27.0 - 2025-04-04
 


### PR DESCRIPTION
The renderer would use 100% CPU while idling. Fixed by using a different base image (Debian) for the renderer with a different version of Chromium.

Fixes #11131.