### PR TITLE
Fix renderer using 100% CPU

### DIFF
--- a/components/renderer/Dockerfile
+++ b/components/renderer/Dockerfile
@@ -1,9 +1,11 @@
-FROM node:23.10.0-alpine3.21
+FROM node:23.10.0-alpine3.20
+
+# Note the base image is alpine3.20 as work-around for this issue: https://github.com/ICTU/quality-time/issues/11131
 
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time PDF render service"
 
-RUN apk add --no-cache chromium=135.0.7049.52-r0
+RUN apk add --no-cache chromium=131.0.6778.108-r0
 
 WORKDIR /home/renderer
 COPY package*.json /home/renderer/

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -23,6 +23,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 - Keep the footer at the bottom of the page even if the browser window is very tall. Fixes [#10877](https://github.com/ICTU/quality-time/issues/10877).
 - The API-server would incorrectly log about encountering unknown SonarQube parameter values when running migration code at startup. Fixes [#11119](https://github.com/ICTU/quality-time/issues/11119).
+- The renderer component would use 100% CPU while idling. Fixed by downgrading the renderer base image to Alpine 3.20 so the renderer uses a slightly older version of Chromium that does not suffer from this issue. Fixes [#11131](https://github.com/ICTU/quality-time/issues/11131).
 
 ## v5.27.0 - 2025-04-04
 


### PR DESCRIPTION
The renderer component would use 100% CPU while idling. Fixed by downgrading the renderer base image to Alpine 3.20 so the renderer uses a slightly older version of Chromium that does not suffer from this issue.

Fixes #11131.