### PR TITLE
Fix test suites count.

### DIFF
--- a/components/collector/src/source_collectors/junit/test_suites.py
+++ b/components/collector/src/source_collectors/junit/test_suites.py
@@ -33,29 +33,33 @@ class JUnitTestSuites(XMLFileSourceCollector):
         results_to_count = cast(list[str], self._parameter("test_result"))
         return entity["suite_result"] in results_to_count
 
-    @staticmethod
-    def __entity(suite: Element) -> Entity:
+    @classmethod
+    def __entity(cls, suite: Element) -> Entity:
         """Transform a test case into a test suite entity."""
-        name = suite.get("name", "unknown")
+        suite_name = suite.get("name", "unknown")
         tests = len(suite.findall("testcase"))
         skipped = int(suite.get("skipped", 0))
         failed = int(suite.get("failures", 0))
         errored = int(suite.get("errors", 0))
         passed = tests - (errored + failed + skipped)
-        suite_result = "passed"
-        if errored:
-            suite_result = "errored"
-        elif failed:
-            suite_result = "failed"
-        elif skipped:
-            suite_result = "skipped"
         return Entity(
-            key=name,
-            suite_name=name,
-            suite_result=suite_result,
+            key=suite.get("id") or suite_name,
+            suite_name=suite_name,
+            suite_result=cls.__suite_result(errored, failed, skipped),
             tests=str(tests),
             passed=str(passed),
             errored=str(errored),
             failed=str(failed),
             skipped=str(skipped),
         )
+
+    @staticmethod
+    def __suite_result(errored: int, failed: int, skipped: int) -> str:
+        """Return the result of a test suite."""
+        if errored:
+            return "errored"
+        if failed:
+            return "failed"
+        if skipped:
+            return "skipped"
+        return "passed"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -24,6 +24,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 - Keep the footer at the bottom of the page even if the browser window is very tall. Fixes [#10877](https://github.com/ICTU/quality-time/issues/10877).
 - The API-server would incorrectly log about encountering unknown SonarQube parameter values when running migration code at startup. Fixes [#11119](https://github.com/ICTU/quality-time/issues/11119).
 - The renderer component would use 100% CPU while idling. Fixed by downgrading the renderer base image to Alpine 3.20 so the renderer uses a slightly older version of Chromium that does not suffer from this issue. Fixes [#11131](https://github.com/ICTU/quality-time/issues/11131).
+- When measuring test suites with JUnit XML as source, the count of test suites would be incorrect if the test suite names are not unique. Fixed by using the test suite id to disambiguate suites, if available. Fixes [#11138](https://github.com/ICTU/quality-time/issues/11138).
 
 ## v5.27.0 - 2025-04-04
 


### PR DESCRIPTION
When measuring test suites with JUnit XML as source, the count of test suites would be incorrect if the test suite names are not unique. Fixed by using the test suite id to disambiguate suites, if available.

Fixes #11138.