### PR TITLE
The "software version" metric is now "informative" by default.

### DIFF
--- a/components/api_server/src/model/defaults.py
+++ b/components/api_server/src/model/defaults.py
@@ -21,6 +21,7 @@ def default_metric_attributes(metric_type: str):
         "scale": metric.default_scale,
         "unit": None,
         "addition": metric.addition,
+        "evaluate_targets": metric.evaluate_targets,
         "accept_debt": False,
         "debt_target": None,
         "direction": None,

--- a/components/api_server/tests/model/test_defaults.py
+++ b/components/api_server/tests/model/test_defaults.py
@@ -25,19 +25,20 @@ class DefaultAttributesTest(DataModelTestCase):
         self.assertEqual(
             {
                 "name": None,
-                "type": "dependencies",
+                "type": "software_version",
                 "accept_debt": False,
-                "addition": "sum",
+                "addition": "min",
                 "debt_target": None,
                 "direction": None,
-                "near_target": "10",
-                "target": "0",
-                "scale": "count",
+                "evaluate_targets": False,
+                "near_target": "0.9",
+                "target": "1.0",
+                "scale": "version_number",
                 "sources": {},
-                "tags": ["maintainability"],
+                "tags": ["ci"],
                 "unit": None,
             },
-            default_metric_attributes("dependencies"),
+            default_metric_attributes("software_version"),
         )
 
     def test_default_subject_attributes(self):

--- a/components/shared_code/src/shared_data_model/meta/metric.py
+++ b/components/shared_code/src/shared_data_model/meta/metric.py
@@ -47,6 +47,7 @@ class Metric(DocumentedModel):
     direction: Direction = Direction.FEWER_IS_BETTER
     target: str = "0"
     near_target: str = "10"
+    evaluate_targets: bool = True
     sources: list[str] = Field(..., min_length=1)
     tags: list[Tag] = []
     rationale: str = ""  # Answers the question "Why measure this metric?", included in documentation and UI

--- a/components/shared_code/src/shared_data_model/metrics.py
+++ b/components/shared_code/src/shared_data_model/metrics.py
@@ -434,6 +434,7 @@ report(s).
         direction=Direction.MORE_IS_BETTER,
         target="1.0",
         near_target="0.9",
+        evaluate_targets=False,
         sources=[
             "performancetest_runner",
             "sonarqube",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,12 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Added
+
+- Changed the "software version" metric to be "informative" by default. Closes [#10847](https://github.com/ICTU/quality-time/issues/10847).
+
 ## v5.28.0 - 2025-04-17
 
 ### Added

--- a/docs/src/create_reference_md.py
+++ b/docs/src/create_reference_md.py
@@ -113,6 +113,7 @@ def metric_section(metric_key: str, metric: Metric, level: int) -> str:
         markdown += markdown_paragraph(f"*More information* {explanation}")
         if explanation_urls := metric.explanation_urls:  # pragma: no branch
             markdown += see_also_links(explanation_urls)
+    markdown += definition_list("Evaluate metric against target by default", "Yes" if metric.evaluate_targets else "No")
     markdown += definition_list("Default target", metric_target(metric))
     markdown += definition_list("Scales", *metric_scales(metric))
     markdown += definition_list("Default tags", *[tag.value for tag in metric.tags])

--- a/docs/src/software.md
+++ b/docs/src/software.md
@@ -208,6 +208,7 @@ class Metric(DescribedModel):
     direction: Direction = Direction.FEWER_IS_BETTER
     target: str = "0"
     near_target: str = "10"
+    evaluate_targets: bool = True
     sources: list[str] = Field(..., min_items=1)
     tags: list[Tag] = []
     rationale: str = ""  # Answers the question "Why measure this metric?", included in documentation and UI
@@ -228,6 +229,8 @@ The `addition` determines how values from multiple sources are combined: possibl
 The `direction` specifies whether smaller measurement values are better or worse.
 
 The `target` is the default target value for the metric. The `near_target` is when the metric becomes red. Values between `target` and `near_target` are yellow.
+
+The `evaluate_targets` flag determines whether the metric is "Informative" or not. If `evaluate_targets` is `True`, the measurement values are compared to the `target` and `near_target` and the metric status depends on the result of the comparison. If `evaluate_targets` is `False`, the metric status is "Informative" regardless of the measurement value. Unless there are no measurements, in which case the status is "Unknown". Note that the user can change any metric from being evaluated to informative and vice versa, so all metrics should have a `target` and `near_target` value.
 
 The list of `sources` contains the keys of source types that support this metric type.
 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -247,7 +247,7 @@ The "Metric {index}`unit <Unit>`" derives its default value from the metric type
 
 The "Metric {index}`target <Target>`" determines at what value a measurement is below or above target. In the example below only measurement values of 0 are on target. The "Metric near target" determines when the measurement value is sufficiently close to the target to no longer require immediate action. Metrics near their target are yellow.
 
-If you don't want to evaluate the metric against targets, but only want to track its measurement value, you can set the "Evaluate metric targets?" field to "No". The metric status will always be "Informative", unless the source data is missing.
+If you don't want to evaluate the metric against targets, but only want to track its measurement value, you can set the "Evaluate metric targets?" field to "No". The metric status will always be "Informative", unless the source data is missing. Vice versa, if a metric is "Informative" by default you can set the "Evaluate metric targets?" field to "Yes" to have the metric be evaluated against targets.
 
 ```{index} Technical debt
 ```

--- a/tests/feature_tests/src/features/metric.feature
+++ b/tests/feature_tests/src/features/metric.feature
@@ -10,6 +10,13 @@ Feature: metric
     When the client creates a metric
     Then the metric type is "violations"
 
+  Scenario: add metric that is not evaluated by default
+    When the client creates a metric with type "software_version"
+    And the client creates a source with type "sonarqube"
+    And the collector measures "1.1" with status "informative"
+    And the client waits a second
+    Then the metric status is "informative"
+
   Scenario: delete metric
     Given an existing metric
     When the client deletes the metric


### PR DESCRIPTION
Closes #10847.