### PR TITLE
Faster opening of home page and reports

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -25,6 +25,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 ### Fixed
 
 - Don't magically create an HTML landing URL for XML sources. Fixes [#11136](https://github.com/ICTU/quality-time/issues/11136).
+- When opening the home page or a specific report don't load reports one by one, but rather all at once, for improved performance. Fixes [#11226](https://github.com/ICTU/quality-time/issues/11226).
 
 ## v5.28.0 - 2025-04-17
 


### PR DESCRIPTION
When opening the home page or a specific report don't load reports one by one, but rather all at once, for improved performance.

Fixes #11226.