### PR TITLE
Failed Jenkins jobs grace period

### DIFF
--- a/components/collector/src/source_collectors/jenkins/base.py
+++ b/components/collector/src/source_collectors/jenkins/base.py
@@ -48,9 +48,9 @@ class JenkinsJobs(SourceCollector):
         return Entities(
             [
                 Entity(
-                    build_date=self.__build_date(job),
-                    build_datetime=self.__build_datetime(job),
-                    build_result=self.__build_result(job),
+                    build_date=self.__job_build_date(job),
+                    build_datetime=self.__job_build_datetime(job),
+                    build_result=self.__job_build_result(job),
                     key=job["name"],
                     name=job["name"],
                     url=job["url"],
@@ -83,19 +83,24 @@ class JenkinsJobs(SourceCollector):
         """Return whether to include this build or not."""
         return True
 
-    def __build_datetime(self, job: Job) -> datetime | None:
+    def __job_build_datetime(self, job: Job) -> datetime | None:
         """Return the datetime of the most recent build of the job."""
         builds = self._builds(job)
         return datetime_from_timestamp(int(builds[0]["timestamp"])) if builds else None
 
-    def __build_date(self, job: Job) -> str:
+    def __job_build_date(self, job: Job) -> str:
         """Return the date of the most recent build of the job."""
-        build_datetime = self.__build_datetime(job)
+        build_datetime = self.__job_build_datetime(job)
         return str(build_datetime.date()) if build_datetime else ""
 
-    def __build_result(self, job: Job) -> str:
+    def __job_build_result(self, job: Job) -> str:
         """Return the result of the most recent build of the job."""
         for build in self._builds(job):
-            if status := build.get("result"):
-                return str(status).capitalize().replace("_", " ")
+            if "result" in build:
+                return self._build_result(build)
         return "Not built"
+
+    @staticmethod
+    def _build_result(build: Build) -> str:
+        """Return the result of the build."""
+        return str(build.get("result", "Not built")).capitalize().replace("_", " ")

--- a/components/collector/src/source_collectors/jenkins/failed_jobs.py
+++ b/components/collector/src/source_collectors/jenkins/failed_jobs.py
@@ -1,8 +1,12 @@
 """Jenkins failed jobs collector."""
 
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+from collector_utilities.date_time import datetime_from_timestamp
 from model import Entity
 
-from .base import JenkinsJobs
+from .base import Build, JenkinsJobs
 
 
 class JenkinsFailedJobs(JenkinsJobs):
@@ -11,3 +15,11 @@ class JenkinsFailedJobs(JenkinsJobs):
     def _include_entity(self, entity: Entity) -> bool:
         """Extend to count the job if its build status matches the failure types selected by the user."""
         return super()._include_entity(entity) and entity["build_result"] in self._parameter("failure_type")
+
+    def _include_build(self, build: Build) -> bool:
+        """Return whether to include this build or not."""
+        if self._build_result(build) not in self._parameter("failure_type"):
+            return True  # No need to apply the grace period to builds that have not failed
+        grace_period = timedelta(days=int(cast(str, self._parameter("grace_days"))))
+        build_age = datetime.now(tz=UTC) - datetime_from_timestamp(int(build["timestamp"]))
+        return build_age > grace_period

--- a/components/collector/tests/source_collectors/jenkins/base.py
+++ b/components/collector/tests/source_collectors/jenkins/base.py
@@ -18,4 +18,3 @@ class JenkinsTestCase(SourceCollectorTestCase):
             {"timestamp": 1552686531953},
         ]
         self.job_url = "https://job"
-        self.job2_url = "https://job2"

--- a/components/collector/tests/source_collectors/jenkins/test_failed_jobs.py
+++ b/components/collector/tests/source_collectors/jenkins/test_failed_jobs.py
@@ -1,5 +1,7 @@
 """Unit tests for the Jenkins failed jobs collector."""
 
+from datetime import UTC, datetime, timedelta
+
 from collector_utilities.date_time import datetime_from_timestamp
 
 from .base import JenkinsTestCase
@@ -10,130 +12,140 @@ class JenkinsFailedJobsTest(JenkinsTestCase):
 
     METRIC_TYPE = "failed_jobs"
 
-    def setUp(self):
-        """Extend to set up Jenkins data."""
-        super().setUp()
-        self.jenkins_json = {
-            "jobs": [
-                {"name": "job", "url": self.job_url, "buildable": True, "color": "red", "builds": self.builds},
-                {"name": "job2", "url": self.job2_url, "buildable": True, "color": "red", "builds": self.builds},
-            ],
+    def jenkins_json(self, nr_jobs: int = 1, builds: list | None = None, buildable: bool = True) -> dict:
+        """Create a Jenkins JSON fixture."""
+        builds = self.builds if builds is None else builds
+        jobs = [
+            {
+                "name": f"job{index}",
+                "url": f"https://job{index}",
+                "buildable": buildable,
+                "color": "red",
+                "builds": builds,
+            }
+            for index in range(1, nr_jobs + 1)
+        ]
+        return {"jobs": jobs}
+
+    def timestamp(self, days_ago: int = 0) -> int:
+        """Return a Jenkins timestamp."""
+        return round((datetime.now(tz=UTC) - timedelta(days=days_ago)).timestamp() * 1000)
+
+    def expected_entity(
+        self,
+        build_date: str = "",
+        build_datetime: datetime | None = None,
+        build_result: str = "Failure",
+        job_nr: int = 1,
+    ):
+        """Return an expected entity."""
+        build_date = build_date or "2019-03-15"
+        build_datetime = build_datetime or datetime_from_timestamp(self.builds[0]["timestamp"])
+        return {
+            "build_date": build_date,
+            "build_datetime": build_datetime,
+            "build_result": build_result,
+            "key": f"job{job_nr}",
+            "name": f"job{job_nr}",
+            "url": f"https://job{job_nr}",
         }
 
     async def test_failed_child_job(self):
         """Test that the number of failed jobs is returned, including failed child jobs."""
-        self.jenkins_json["jobs"][0]["jobs"] = [
+        jenkins_json = self.jenkins_json(nr_jobs=2)
+        jenkins_json["jobs"][0]["jobs"] = [
             {"name": "child_job", "url": "https://child_job", "buildable": True, "color": "red", "builds": self.builds},
         ]
-        response = await self.collect(get_request_json_return_value=self.jenkins_json)
+        response = await self.collect(get_request_json_return_value=jenkins_json)
         self.assert_measurement(response, value="3")
 
     async def test_failed_jobs(self):
         """Test that the failed jobs are returned."""
-        jenkins_json = {
-            "jobs": [{"name": "job", "url": self.job_url, "buildable": True, "color": "red", "builds": self.builds}],
-        }
-        response = await self.collect(get_request_json_return_value=jenkins_json)
-        expected_entities = [
-            {
-                "build_date": "2019-03-15",
-                "build_datetime": datetime_from_timestamp(self.builds[0]["timestamp"]),
-                "build_result": "Failure",
-                "key": "job",
-                "name": "job",
-                "url": self.job_url,
-            },
-        ]
-        self.assert_measurement(response, entities=expected_entities)
+        response = await self.collect(get_request_json_return_value=self.jenkins_json(nr_jobs=1))
+        self.assert_measurement(response, entities=[self.expected_entity()])
+
+    async def test_ignore_unbuildable_failed_jobs(self):
+        """Test that the unbuildable failed jobs are ignored."""
+        response = await self.collect(get_request_json_return_value=self.jenkins_json(nr_jobs=1, buildable=False))
+        self.assert_measurement(response, entities=[])
 
     async def test_include_jobs(self):
         """Test that any job that is not explicitly included fails if jobs_to_include is not empty."""
-        self.set_source_parameter("jobs_to_include", ["job"])
-        response = await self.collect(get_request_json_return_value=self.jenkins_json)
-        expected_entities = [
-            {
-                "build_date": "2019-03-15",
-                "build_datetime": datetime_from_timestamp(self.builds[0]["timestamp"]),
-                "build_result": "Failure",
-                "key": "job",
-                "name": "job",
-                "url": self.job_url,
-            },
-        ]
-        self.assert_measurement(response, entities=expected_entities)
+        self.set_source_parameter("jobs_to_include", ["job1"])
+        response = await self.collect(get_request_json_return_value=self.jenkins_json(nr_jobs=2))
+        self.assert_measurement(response, entities=[self.expected_entity()])
 
     async def test_include_jobs_by_regular_expression(self):
         """Test that any job that is not explicitly included fails if jobs_to_include is not empty."""
-        self.set_source_parameter("jobs_to_include", ["job."])
-        response = await self.collect(get_request_json_return_value=self.jenkins_json)
-        expected_entities = [
-            {
-                "build_date": "2019-03-15",
-                "build_datetime": datetime_from_timestamp(self.builds[0]["timestamp"]),
-                "build_result": "Failure",
-                "key": "job2",
-                "name": "job2",
-                "url": self.job2_url,
-            },
-        ]
-        self.assert_measurement(response, entities=expected_entities)
+        self.set_source_parameter("jobs_to_include", ["job[23]"])
+        response = await self.collect(get_request_json_return_value=self.jenkins_json(nr_jobs=2))
+        self.assert_measurement(response, entities=[self.expected_entity(job_nr=2)])
 
     async def test_ignore_jobs(self):
         """Test that a failed job can be ignored."""
         self.set_source_parameter("jobs_to_ignore", ["job2"])
-        response = await self.collect(get_request_json_return_value=self.jenkins_json)
-        expected_entities = [
-            {
-                "build_date": "2019-03-15",
-                "build_datetime": datetime_from_timestamp(self.builds[0]["timestamp"]),
-                "build_result": "Failure",
-                "key": "job",
-                "name": "job",
-                "url": self.job_url,
-            },
-        ]
-        self.assert_measurement(response, entities=expected_entities)
+        response = await self.collect(get_request_json_return_value=self.jenkins_json(nr_jobs=2))
+        self.assert_measurement(response, entities=[self.expected_entity()])
 
     async def test_ignore_jobs_by_regular_expression(self):
         """Test that failed jobs can be ignored by regular expression."""
-        self.set_source_parameter("jobs_to_ignore", ["job."])
-        response = await self.collect(get_request_json_return_value=self.jenkins_json)
-        expected_entities = [
-            {
-                "build_date": "2019-03-15",
-                "build_datetime": datetime_from_timestamp(self.builds[0]["timestamp"]),
-                "build_result": "Failure",
-                "key": "job",
-                "name": "job",
-                "url": self.job_url,
-            },
-        ]
-        self.assert_measurement(response, entities=expected_entities)
+        self.set_source_parameter("jobs_to_ignore", ["job[23]"])
+        response = await self.collect(get_request_json_return_value=self.jenkins_json(nr_jobs=2))
+        self.assert_measurement(response, entities=[self.expected_entity()])
 
     async def test_include_and_ignore_jobs(self):
         """Test that jobs can be included and ignored."""
         self.set_source_parameter("jobs_to_include", ["job."])
         self.set_source_parameter("jobs_to_ignore", [".*2"])
-        self.jenkins_json["jobs"].append(
-            {"name": "job3", "url": "https://job3", "buildable": True, "color": "red", "builds": self.builds},
-        )
-        response = await self.collect(get_request_json_return_value=self.jenkins_json)
-        expected_entities = [
-            {
-                "build_date": "2019-03-15",
-                "build_datetime": datetime_from_timestamp(self.builds[0]["timestamp"]),
-                "build_result": "Failure",
-                "key": "job3",
-                "name": "job3",
-                "url": "https://job3",
-            },
-        ]
-        self.assert_measurement(response, entities=expected_entities)
+        response = await self.collect(get_request_json_return_value=self.jenkins_json(nr_jobs=2))
+        self.assert_measurement(response, entities=[self.expected_entity()])
 
     async def test_no_builds(self):
         """Test no builds."""
-        jenkins_json = {
-            "jobs": [{"name": "job", "url": self.job_url, "buildable": False, "color": "notbuilt", "builds": []}],
-        }
-        response = await self.collect(get_request_json_return_value=jenkins_json)
+        response = await self.collect(get_request_json_return_value=self.jenkins_json(nr_jobs=1, builds=[]))
+        self.assert_measurement(response, entities=[])
+
+    async def test_ignore_job_if_all_failed_builds_are_in_the_grace_period(self):
+        """Test that jobs can be ignored by grace period."""
+        self.set_source_parameter("grace_days", "5")
+        builds = [
+            {"result": "FAILURE", "timestamp": self.timestamp()},
+            {"result": "FAILURE", "timestamp": self.timestamp(days_ago=4)},
+        ]
+        response = await self.collect(get_request_json_return_value=self.jenkins_json(nr_jobs=1, builds=builds))
+        self.assert_measurement(response, entities=[])
+
+    async def test_do_not_ignore_job_if_not_all_failed_builds_are_in_the_grace_period(self):
+        """Test that jobs can be ignored by grace period."""
+        self.set_source_parameter("grace_days", "5")
+        old_build_timestamp = self.timestamp(days_ago=6)
+        builds = [
+            {"result": "FAILURE", "timestamp": self.timestamp()},
+            {"result": "FAILURE", "timestamp": old_build_timestamp},
+        ]
+        response = await self.collect(get_request_json_return_value=self.jenkins_json(nr_jobs=1, builds=builds))
+        expected_entity = self.expected_entity(
+            build_date=datetime_from_timestamp(old_build_timestamp).date().isoformat(),
+            build_datetime=datetime_from_timestamp(old_build_timestamp),
+        )
+        self.assert_measurement(response, entities=[expected_entity])
+
+    async def test_grace_period_does_not_impact_successful_job_with_failure_in_grace_period(self):
+        """Test that jobs can be ignored by grace period."""
+        self.set_source_parameter("grace_days", "5")
+        builds = [
+            {"result": "SUCCESS", "timestamp": self.timestamp()},
+            {"result": "FAILURE", "timestamp": self.timestamp(days_ago=4)},
+        ]
+        response = await self.collect(get_request_json_return_value=self.jenkins_json(nr_jobs=1, builds=builds))
+        self.assert_measurement(response, entities=[])
+
+    async def test_grace_period_does_not_impact_successful_job_with_failure_before_grace_period(self):
+        """Test that jobs can be ignored by grace period."""
+        self.set_source_parameter("grace_days", "5")
+        builds = [
+            {"result": "SUCCESS", "timestamp": self.timestamp()},
+            {"result": "FAILURE", "timestamp": self.timestamp(days_ago=6)},
+        ]
+        response = await self.collect(get_request_json_return_value=self.jenkins_json(nr_jobs=1, builds=builds))
         self.assert_measurement(response, entities=[])

--- a/components/shared_code/src/shared_data_model/sources/jenkins.py
+++ b/components/shared_code/src/shared_data_model/sources/jenkins.py
@@ -124,6 +124,14 @@ the "Username" field and the private token in the "**Password**" field.
                 "unused_jobs",
             ],
         ),
+        "grace_days": Days(
+            name="Number of days after which to count failed jobs as failed",
+            short_name="grace days",
+            help="Count failed jobs as failed only when it has been failing for at least the number of 'grace days'.",
+            min_value="0",
+            default_value="0",
+            metrics=["failed_jobs"],
+        ),
         "lookback_days": Days(
             name="Number of days to look back for selecting job builds",
             short_name="number of days to look back",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 ### Added
 
 - Add Grafana k6 summary.json reports as source for the 'performancetest duration' metric. Closes [#11170](https://github.com/ICTU/quality-time/issues/11170).
+- Allow for ignoring failed Jenkins jobs for a while before Quality-time reports them as failed. Closes [#11320](https://github.com/ICTU/quality-time/issues/11320).
 
 ## v5.30.0 - 2025-05-15
 


### PR DESCRIPTION
Allow for ignoring failed Jenkins jobs for a while before Quality-time reports them as failed.

Closes #11320.