### PR TITLE
Fix scrolling to shared metric link

### DIFF
--- a/components/frontend/src/hooks/hash_fragment.js
+++ b/components/frontend/src/hooks/hash_fragment.js
@@ -1,13 +1,21 @@
 import { useEffect } from "react"
 
+function waitForElementById(id, callback) {
+    const interval = setInterval(() => {
+        const element = document.getElementById(id)
+        if (element !== null) {
+            clearInterval(interval)
+            callback(element)
+        }
+    }, 100) // Check every 100ms
+}
+
 export function useHashFragment(trigger = true) {
     // Hook to automatically scroll to the element indicated by the URL hash after rendering
     useEffect(() => {
         const scrollToHashElement = () => {
             const { hash } = window.location
-            const elementToScroll = document.getElementById(hash?.replace("#", ""))
-            if (!elementToScroll) return
-            elementToScroll.scrollIntoView(true)
+            waitForElementById(hash?.replace("#", ""), (element) => element.scrollIntoView(true))
         }
         if (!trigger) return // Only scroll if trigger is true, e.g. after loading data has finished
         scrollToHashElement()

--- a/components/frontend/src/hooks/hash_fragment.test.js
+++ b/components/frontend/src/hooks/hash_fragment.test.js
@@ -3,6 +3,14 @@ import { vi } from "vitest"
 
 import { useHashFragment } from "./hash_fragment"
 
+beforeEach(() => {
+    vi.useFakeTimers()
+})
+
+afterEach(() => {
+    vi.useRealTimers()
+})
+
 it("does not scroll if trigger is false", () => {
     window.addEventListener = vi.fn()
     const mockScrollIntoView = vi.fn()
@@ -10,6 +18,7 @@ it("does not scroll if trigger is false", () => {
         return { scrollIntoView: mockScrollIntoView }
     }
     renderHook(() => useHashFragment(false))
+    vi.advanceTimersByTime(100)
     expect(mockScrollIntoView).not.toHaveBeenCalled()
     expect(window.addEventListener).not.toHaveBeenCalled()
 })
@@ -20,6 +29,7 @@ it("does not scroll if trigger is true but no element found", () => {
         return null
     }
     renderHook(() => useHashFragment(true))
+    vi.advanceTimersByTime(100)
     expect(window.addEventListener).toHaveBeenCalled()
 })
 
@@ -30,6 +40,7 @@ it("does scroll if trigger is true and element found", () => {
         return { scrollIntoView: mockScrollIntoView }
     }
     renderHook(() => useHashFragment(true))
+    vi.advanceTimersByTime(100)
     expect(mockScrollIntoView).toHaveBeenCalled()
     expect(window.addEventListener).toHaveBeenCalled()
 })

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,12 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- Links to metrics created with the "Share metric" button would not always scroll to the metric. Fixes [#11372](https://github.com/ICTU/quality-time/issues/11372).
+
 ## v5.32.0 - 2025-06-05
 
 ### Added


### PR DESCRIPTION
Links to metrics created with the "Share metric" button would not always scroll to the metric.

Fixes #11372.