### PR TITLE
Fix measurement value background color

### DIFF
--- a/components/frontend/src/measurement/MeasurementValue.test.jsx
+++ b/components/frontend/src/measurement/MeasurementValue.test.jsx
@@ -44,7 +44,7 @@ it("renders the value", async () => {
     await expectNoAccessibilityViolations(container)
 })
 
-it("renders an unkown value", async () => {
+it("renders an unknown value", async () => {
     const { container } = renderMeasurementValue({ latestMeasurement: { count: { value: null } } })
     expect(screen.getAllByText(/\?/).length).toBe(1)
     expect(screen.queryAllByTestId("LoopIcon").length).toBe(0)

--- a/components/frontend/src/subject/SubjectTableRow.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.jsx
@@ -116,7 +116,7 @@ deltaLabel.propTypes = {
     previousValue: string,
 }
 
-function DeltaCell({ dateOrderAscending, index, metric, metricValue, previousValue, status }) {
+function DeltaCell({ dateOrderAscending, index, metric, metricValue, previousValue }) {
     const dataModel = useContext(DataModel)
     let label = null
     if (index > 0 && previousValue !== "?" && metricValue !== "?" && previousValue !== metricValue) {
@@ -136,11 +136,7 @@ function DeltaCell({ dateOrderAscending, index, metric, metricValue, previousVal
             </Tooltip>
         )
     }
-    return (
-        <TableCell align="right" className={status}>
-            {label}
-        </TableCell>
-    )
+    return <TableCell align="right">{label}</TableCell>
 }
 DeltaCell.propTypes = {
     dateOrderAscending: bool,
@@ -148,7 +144,6 @@ DeltaCell.propTypes = {
     index: number,
     metricValue: string,
     previousValue: string,
-    status: string,
 }
 
 function metricValueAndStatusOnDate(dataModel, metric, metricUuid, measurements, date) {
@@ -182,12 +177,22 @@ function MeasurementCells({ dates, metric, metricUuid, measurements, settings })
                     metric={metric}
                     metricValue={metricValue}
                     previousValue={previousValue}
-                    status={status}
                 />,
             )
         }
         cells.push(
-            <TableCell align="right" className={status} key={date}>
+            <TableCell
+                align="right"
+                key={date}
+                sx={{
+                    bgcolor: `${status}.bgcolor`,
+                    "&.MuiTableCell-hover": {
+                        "&:hover": {
+                            backgroundColor: `${status}.hover`,
+                        },
+                    },
+                }}
+            >
                 {formatMetricValue(scale, metricValue)}
                 {formatMetricScale(metric, dataModel)}
             </TableCell>,

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 ### Fixed
 
 - Links to metrics created with the "Share metric" button would not always scroll to the metric. Fixes [#11372](https://github.com/ICTU/quality-time/issues/11372).
+- When displaying multiple dates, measurement values would not get a status background color. Fixes [#11375](https://github.com/ICTU/quality-time/issues/11375).
 
 ### Changed
 


### PR DESCRIPTION
When displaying multiple dates, measurement values would not get a status background color.

Fixes #11375.