### PR TITLE
Replace last uses of pipx with uvx

### DIFF
--- a/components/api_server/pyproject.toml
+++ b/components/api_server/pyproject.toml
@@ -53,7 +53,7 @@ lint.ignore = [
     "D203",   # https://docs.astral.sh/ruff/rules/one-blank-line-before-class/ - prevent warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible. Ignoring `one-blank-line-before-class`
     "D213",   # https://docs.astral.sh/ruff/rules/multi-line-summary-second-line/ - prevent warning: `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Ignoring `multi-line-summary-second-line`
     "FBT",    # https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt - not sure of the value of preventing "boolean traps"
-    "I001",   # https://docs.astral.sh/ruff/rules/unsorted-imports/ - (probably) because ruff is run with pipx it can't differentiate between dependencies and modules
+    "I001",   # https://docs.astral.sh/ruff/rules/unsorted-imports/ - (probably) because ruff is run with uvx it can't differentiate between dependencies and modules
     "ISC001", # https://docs.astral.sh/ruff/rules/single-line-implicit-string-concatenation/ - this rule may cause conflicts when used with the ruff formatter
     "PD",     # https://docs.astral.sh/ruff/rules/#pandas-vet-pd - pandas isn't used
     "PT",     # https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt - pytest isn't used

--- a/components/shared_code/pyproject.toml
+++ b/components/shared_code/pyproject.toml
@@ -25,7 +25,7 @@ optional-dependencies.tools = [
     "fixit==2.1.0",
     "mypy==1.16.0",
     "pip-audit==2.9.0",
-    "pydantic==2.11.5",     # Needed because pipx needs to inject Pydantic into the mpyp venv, see ci/quality.sh
+    "pydantic==2.11.5",     # Needed because uvx needs to inject Pydantic into the mpyp venv, see ci/quality.sh
     "pyproject-fmt==2.6.0",
     "ruff==0.11.13",
     "vulture==2.14",

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -24,7 +24,7 @@ optional-dependencies.tools = [
     "fixit==2.1.0",
     "mypy==1.16.0",
     "pip-audit==2.9.0",
-    "pydantic==2.11.5",     # Needed because pipx needs to inject Pydantic into the mpyp venv, see ci/quality.sh
+    "pydantic==2.11.5",     # Needed because uvx needs to inject Pydantic into the mpyp venv, see ci/quality.sh
     "pyproject-fmt==2.6.0",
     "ruff==0.11.13",
     "vale==3.0.3.0",        # Documentation grammar and style checker

--- a/release/release.py
+++ b/release/release.py
@@ -166,7 +166,7 @@ def main() -> None:
     check_preconditions(bump, current_version)
     if check_preconditions_only:
         return
-    cmd = ["pipx", "run", bump_my_version_spec(), "bump"]
+    cmd = ["uvx", bump_my_version_spec(), "bump"]
     if bump == "release":
         cmd.append("pre_release_label")  # Bump the pre-release label from "rc" to "final" (being optional and omitted)
     elif bump == "rc":


### PR DESCRIPTION
- Run bump-my-version with uvx instead of pipx.
- Refer to uvx in comments instead of pipx.