### PR TITLE
Make it easier to reset trend graph zoom

### DIFF
--- a/components/frontend/src/metric/TrendGraph.jsx
+++ b/components/frontend/src/metric/TrendGraph.jsx
@@ -152,7 +152,7 @@ export function TrendGraph({ metric, measurements, loading }) {
                         brushDimension="x"
                         brushDomain={visibleDomain}
                         brushStyle={{ fill: primaryColor, fillOpacity: 0.2 }}
-                        defaultBrushArea="move" // Move the brush area when the user clicks outside the brush area
+                        defaultBrushArea="all" // Clear the brush area when the user clicks outside it
                         onBrushDomainChange={setVisibleDomain}
                     />
                 }

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 ### Changed
 
+- Clicking outside the trend graph's zoom brush now resets the zoom level, instead of moving the visible data points. Closes [#11441](https://github.com/ICTU/quality-time/issues/11441).
 - Don't zoom trend graphs on scroll. Closes [#11442](https://github.com/ICTU/quality-time/issues/11442).
 - Refresh SonarQube language rules to be up to date with version 2025.3 of SonarQube. Closes [#11422](https://github.com/ICTU/quality-time/issues/11422).
 


### PR DESCRIPTION
Clicking outside the trend graph's zoom brush now resets the zoom level, instead of moving the visible data points.

Closes #11441.