### PR TITLE
Configuring Grafana k6 slow transactions

### DIFF
--- a/components/collector/src/base_collectors/source_collector.py
+++ b/components/collector/src/base_collectors/source_collector.py
@@ -408,8 +408,8 @@ class TransactionEntity(Entity):
         name, response_time = self["name"], float(self[response_time_to_evaluate])
         for transaction_specific_target_response_time in transaction_specific_target_response_times:
             re_or_name, target = transaction_specific_target_response_time.rsplit(":", maxsplit=1)
-            if match_string_or_regular_expression(name, [re_or_name]) and response_time <= float(target):
-                return False
+            if match_string_or_regular_expression(name, [re_or_name]):
+                return response_time > float(target)
         return bool(response_time > target_response_time)
 
 
@@ -421,7 +421,7 @@ class SlowTransactionsCollector(SourceCollector):
         super().__init__(session, metric, source)
         self.__transactions_to_include = cast(list[str], self._parameter("transactions_to_include"))
         self.__transactions_to_ignore = cast(list[str], self._parameter("transactions_to_ignore"))
-        self.__response_time_to_evaluate = cast(str, self._parameter("response_time_to_evaluate"))
+        self._response_time_to_evaluate = cast(str, self._parameter("response_time_to_evaluate"))
         self.__target_response_time = float(cast(int, self._parameter("target_response_time")))
         self.__transaction_specific_target_response_times = cast(
             list[str],
@@ -434,7 +434,7 @@ class SlowTransactionsCollector(SourceCollector):
             self.__transactions_to_include,
             self.__transactions_to_ignore,
         ) and entity.is_slow(
-            self.__response_time_to_evaluate,
+            self._response_time_to_evaluate,
             self.__target_response_time,
             self.__transaction_specific_target_response_times,
         )

--- a/components/collector/src/source_collectors/grafana_k6/slow_transactions.py
+++ b/components/collector/src/source_collectors/grafana_k6/slow_transactions.py
@@ -2,14 +2,44 @@
 
 from typing import cast
 
-from base_collectors import JSONFileSourceCollector
+from shared_data_model import DATA_MODEL
+
+from base_collectors import JSONFileSourceCollector, SlowTransactionsCollector, TransactionEntity
 from collector_utilities.type import JSON
-from model import Entities, Entity
+from model import Entities
 
 from .base import Metric, SummaryJSON
 
 
-class GrafanaK6SlowTransactions(JSONFileSourceCollector):
+def is_default_response_time(response_time_to_evaluate: str) -> bool:
+    """Return whether the response time to evaluate is the default type."""
+    default_value = DATA_MODEL.sources["grafana_k6"].parameters["response_time_to_evaluate"].default_value
+    return response_time_to_evaluate == default_value
+
+
+class GrafanaK6TransactionEntity(TransactionEntity):
+    """Entity for a Grafana k6 transaction."""
+
+    def is_slow(
+        self,
+        response_time_to_evaluate: str,
+        target_response_time: float,
+        transaction_specific_target_response_times: list[str],
+    ) -> bool:
+        """Return whether the transaction is slow."""
+        # If the user did not change the response time to evaluate, the thresholds from the summary.json have already
+        # been used (in GrafanaK6SlowTransactions._include_metric() below) to determine that this transaction is slow,
+        # so return True in that case. Otherwise, evaluate the response time against the target response time.
+        return (
+            True
+            if is_default_response_time(response_time_to_evaluate)
+            else super().is_slow(
+                response_time_to_evaluate, target_response_time, transaction_specific_target_response_times
+            )
+        )
+
+
+class GrafanaK6SlowTransactions(SlowTransactionsCollector, JSONFileSourceCollector):
     """Collector for the number of slow transactions in a Grafana k6 JSON (summary.json) report."""
 
     def _parse_json(self, json: JSON, filename: str) -> Entities:
@@ -20,7 +50,7 @@ class GrafanaK6SlowTransactions(JSONFileSourceCollector):
             if not self._include_metric(metric):
                 continue
             values = metric["values"]
-            entity = Entity(
+            entity = GrafanaK6TransactionEntity(
                 key=metric_key,
                 name=metric_key,
                 count=str(values["count"]),
@@ -30,12 +60,14 @@ class GrafanaK6SlowTransactions(JSONFileSourceCollector):
                 max_response_time=str(values["max"]),
                 thresholds=self._format_thresholds(metric),
             )
-            entities.append(entity)
+            if self._is_to_be_included_and_is_slow(entity):
+                entities.append(entity)
         return entities
 
-    @staticmethod
-    def _include_metric(metric: Metric) -> bool:
+    def _include_metric(self, metric: Metric) -> bool:
         """Return whether the metric should be included in the result."""
+        if not is_default_response_time(self._response_time_to_evaluate):
+            return True  # Defer evaluating the slowness to GrafanaK6TransactionEntity.is_slow(), see above.
         threshold_evaluations = metric.get("thresholds", {}).values()
         return metric["contains"] == "time" and any(not evaluation["ok"] for evaluation in threshold_evaluations)
 

--- a/components/shared_code/src/shared_data_model/parameters.py
+++ b/components/shared_code/src/shared_data_model/parameters.py
@@ -227,6 +227,65 @@ class ResultType(MultipleChoiceParameter):
     metrics: list[str] = ["job_runs_within_time_period"]
 
 
+class TransactionsToIgnore(MultipleChoiceWithAdditionParameter):
+    """Transactions to ignore parameter."""
+
+    name: str = "Transactions to ignore (regular expressions or transaction names)"
+    short_name: str = "transactions to ignore"
+    help: str = "Transactions to ignore can be specified by transaction name or by regular expression."
+    metrics: list[str] = ["slow_transactions", "tests"]
+
+
+class TransactionsToInclude(MultipleChoiceWithAdditionParameter):
+    """Transactions to include parameter."""
+
+    name: str = "Transactions to include (regular expressions or transaction names)"
+    short_name: str = "transactions to include"
+    help: str = "Transactions to include can be specified by transaction name or by regular expression."
+    placeholder: str = "all transactions"
+    metrics: list[str] = ["slow_transactions", "tests"]
+
+
+PERCENTILE_50, PERCENTILE_75, PERCENTILE_90, PERCENTILE_95, PERCENTILE_98, PERCENTILE_99 = (
+    f"{percentile}th percentile" for percentile in (50, 75, 90, 95, 98, 99)
+)
+
+
+class ResponseTimeToEvaluate(SingleChoiceParameter):
+    """Response time to evaluate parameter."""
+
+    name: str = "Response time type to evaluate against the target response time"
+    short_name: str = "response time types to evaluate"
+    help: str = "Which response time type to compare with the target response time to determine slow transactions."
+    metrics: list[str] = ["slow_transactions"]
+
+
+class TargetResponseTime(IntegerParameter):
+    """Target response time parameter."""
+
+    name: str = "Target response time"
+    short_name: str = "target response time"
+    help: str = "The response times of the transactions should be less than or equal to the target response time."
+    default_value: str = "1000"
+    unit: str = "milliseconds"
+    metrics: list[str] = ["slow_transactions"]
+
+
+class TransactionSpecificTargetResponseTimes(MultipleChoiceWithAdditionParameter):
+    """Transaction-specific target response times parameter."""
+
+    name: str = (
+        "Transaction-specific target response times (regular expressions or transaction names:target response time)"
+    )
+    short_name: str = "transactions-specific target response times"
+    help: str = (
+        "Transactions-specific target responses times (in milliseconds) can be specified by transaction name or by "
+        "regular expression, separated from the target response time by a colon, e.g.: '/api/v?/search/.*:1500'."
+    )
+    placeholder: str = "none"
+    metrics: list[str] = ["slow_transactions"]
+
+
 def access_parameters(
     metrics: list[str],
     include: dict[str, bool] | None = None,

--- a/components/shared_code/src/shared_data_model/sources/gatling.py
+++ b/components/shared_code/src/shared_data_model/sources/gatling.py
@@ -5,19 +5,20 @@ from pydantic import HttpUrl
 from shared_data_model.meta.entity import Entity, EntityAttribute, EntityAttributeType
 from shared_data_model.meta.source import Source
 from shared_data_model.parameters import (
-    MultipleChoiceWithAdditionParameter,
-    SingleChoiceParameter,
+    PERCENTILE_50,
+    PERCENTILE_75,
+    PERCENTILE_95,
+    PERCENTILE_99,
+    ResponseTimeToEvaluate,
+    TargetResponseTime,
     TestResult,
+    TransactionSpecificTargetResponseTimes,
+    TransactionsToIgnore,
+    TransactionsToInclude,
     access_parameters,
 )
 
-from .jmeter import (
-    JMETER_SLOW_TRANSACTION_ENTITY_ATTRIBUTES,
-    PERCENTILE_95,
-    PERCENTILE_99,
-    TARGET_RESPONSE_TIME,
-    TRANSACTION_SPECIFIC_TARGET_RESPONSE_TIMES,
-)
+from .jmeter import JMETER_SLOW_TRANSACTION_ENTITY_ATTRIBUTES
 
 GATLING_JSON_METRICS = ["slow_transactions", "tests"]
 GATLING_LOG_METRICS = ["performancetest_duration", "source_up_to_dateness", "source_version"]
@@ -28,28 +29,7 @@ GATLING_DESCRIPTION = (
     "integration."
 )
 
-TRANSACTIONS_TO_IGNORE = MultipleChoiceWithAdditionParameter(
-    name="Transactions to ignore (regular expressions or transaction names)",
-    short_name="transactions to ignore",
-    help="Transactions to ignore can be specified by transaction name or by regular expression.",
-    metrics=GATLING_JSON_METRICS,
-)
-
-TRANSACTIONS_TO_INCLUDE = MultipleChoiceWithAdditionParameter(
-    name="Transactions to include (regular expressions or transaction names)",
-    short_name="transactions to include",
-    help="Transactions to include can be specified by transaction name or by regular expression.",
-    placeholder="all",
-    metrics=GATLING_JSON_METRICS,
-)
-
-PERCENTILE_50 = "50th percentile"
-PERCENTILE_75 = "75th percentile"
-
-RESPONSE_TIME_TO_EVALUATE = SingleChoiceParameter(
-    name="Response time type to evaluate against the target response time",
-    short_name="response time types to evaluate",
-    help="Which response time type to compare with the target response time to determine slow transactions.",
+RESPONSE_TIME_TO_EVALUATE = ResponseTimeToEvaluate(
     default_value=PERCENTILE_95,
     values=[PERCENTILE_50, PERCENTILE_75, PERCENTILE_95, PERCENTILE_99, "mean", "minimum", "maximum"],
     api_values={
@@ -61,7 +41,6 @@ RESPONSE_TIME_TO_EVALUATE = SingleChoiceParameter(
         "minimum": "min_response_time",
         "maximum": "max_response_time",
     },
-    metrics=["slow_transactions"],
 )
 
 GATLING_SLOW_TRANSACTION_ENTITY_ATTRIBUTES = JMETER_SLOW_TRANSACTION_ENTITY_ATTRIBUTES.copy()
@@ -79,7 +58,7 @@ GATLING_SLOW_TRANSACTION_ENTITY_ATTRIBUTES.insert(
 GATLING_SLOW_TRANSACTION_ENTITY_ATTRIBUTES.insert(
     8,
     EntityAttribute(
-        name="75 percentile",
+        name="75th percentile",
         help="75th percentile response time (milliseconds)",
         key="percentile_75_response_time",
         type=EntityAttributeType.FLOAT,
@@ -100,10 +79,10 @@ GATLING = Source(
     parameters={
         "test_result": TestResult(values=["failed", "success"]),
         "response_time_to_evaluate": RESPONSE_TIME_TO_EVALUATE,
-        "target_response_time": TARGET_RESPONSE_TIME,
-        "transaction_specific_target_response_times": TRANSACTION_SPECIFIC_TARGET_RESPONSE_TIMES,
-        "transactions_to_ignore": TRANSACTIONS_TO_IGNORE,
-        "transactions_to_include": TRANSACTIONS_TO_INCLUDE,
+        "target_response_time": TargetResponseTime(),
+        "transaction_specific_target_response_times": TransactionSpecificTargetResponseTimes(),
+        "transactions_to_ignore": TransactionsToIgnore(),
+        "transactions_to_include": TransactionsToInclude(),
         **access_parameters(GATLING_METRICS, source_type="Gatling report", source_type_format="HTML"),
     },
     entities=ENTITIES,

--- a/components/shared_code/src/shared_data_model/sources/grafana_k6.py
+++ b/components/shared_code/src/shared_data_model/sources/grafana_k6.py
@@ -4,11 +4,44 @@ from pydantic import HttpUrl
 
 from shared_data_model.meta.entity import Entity, EntityAttribute, EntityAttributeType
 from shared_data_model.meta.source import Source
-from shared_data_model.parameters import access_parameters
+from shared_data_model.parameters import (
+    PERCENTILE_90,
+    PERCENTILE_95,
+    PERCENTILE_98,
+    PERCENTILE_99,
+    ResponseTimeToEvaluate,
+    TargetResponseTime,
+    TransactionSpecificTargetResponseTimes,
+    TransactionsToIgnore,
+    TransactionsToInclude,
+    access_parameters,
+)
 
 FLOAT = EntityAttributeType.FLOAT
 HELP = "response time (milliseconds)"
 ALL_GRAFANA_K6_METRICS = ["performancetest_duration", "slow_transactions"]
+
+DEFAULT_THRESHOLD_TO_EVALUATE = "none (use thresholds in summary.json)"
+RESPONSE_TIME_TO_EVALUATE = ResponseTimeToEvaluate(
+    default_value=DEFAULT_THRESHOLD_TO_EVALUATE,
+    values=[
+        PERCENTILE_90,
+        PERCENTILE_95,
+        PERCENTILE_98,
+        PERCENTILE_99,
+        "average",
+        "median",
+        "minimum",
+        "maximum",
+        DEFAULT_THRESHOLD_TO_EVALUATE,
+    ],
+    api_values={
+        "average": "average_response_time",
+        "median": "median_response_time",
+        "minimum": "min_response_time",
+        "maximum": "max_response_time",
+    },
+)
 
 GRAFANA_K6 = Source(
     name="Grafana k6",
@@ -18,6 +51,11 @@ GRAFANA_K6 = Source(
     ),
     url=HttpUrl("https://k6.io"),
     parameters={
+        "response_time_to_evaluate": RESPONSE_TIME_TO_EVALUATE,
+        "target_response_time": TargetResponseTime(),
+        "transaction_specific_target_response_times": TransactionSpecificTargetResponseTimes(),
+        "transactions_to_ignore": TransactionsToIgnore(metrics=["slow_transactions"]),
+        "transactions_to_include": TransactionsToInclude(metrics=["slow_transactions"]),
         **access_parameters(ALL_GRAFANA_K6_METRICS, source_type="Grafana k6 summary.json", source_type_format="JSON"),
     },
     entities={

--- a/components/shared_code/src/shared_data_model/sources/jmeter.py
+++ b/components/shared_code/src/shared_data_model/sources/jmeter.py
@@ -5,64 +5,29 @@ from pydantic import HttpUrl
 from shared_data_model.meta.entity import Entity, EntityAttribute, EntityAttributeType
 from shared_data_model.meta.source import Source
 from shared_data_model.parameters import (
-    IntegerParameter,
-    MultipleChoiceWithAdditionParameter,
-    SingleChoiceParameter,
+    PERCENTILE_90,
+    PERCENTILE_95,
+    PERCENTILE_99,
+    ResponseTimeToEvaluate,
+    TargetResponseTime,
     TestResult,
+    TransactionSpecificTargetResponseTimes,
+    TransactionsToIgnore,
+    TransactionsToInclude,
     access_parameters,
 )
 
-JMETER_JSON_METRICS = ["slow_transactions", "tests"]
-JMETER_CSV_METRICS = [*JMETER_JSON_METRICS, "performancetest_duration", "source_up_to_dateness"]
+JSON_METRICS = ["slow_transactions", "tests"]
+CSV_METRICS = [*JSON_METRICS, "performancetest_duration", "source_up_to_dateness"]
 
-JMETER_URL = HttpUrl("https://jmeter.apache.org")
+URL = HttpUrl("https://jmeter.apache.org")
 
-JMETER_DESCRIPTION = (
+DESCRIPTION = (
     "Apache JMeter application is open source software, a 100% pure Java application designed to "
     "load test functional behavior and measure performance."
 )
 
-TRANSACTIONS_TO_IGNORE = MultipleChoiceWithAdditionParameter(
-    name="Transactions to ignore (regular expressions or transaction names)",
-    short_name="transactions to ignore",
-    help="Transactions to ignore can be specified by transaction name or by regular expression.",
-    metrics=JMETER_JSON_METRICS,
-)
-
-TRANSACTIONS_TO_INCLUDE = MultipleChoiceWithAdditionParameter(
-    name="Transactions to include (regular expressions or transaction names)",
-    short_name="transactions to include",
-    help="Transactions to include can be specified by transaction name or by regular expression.",
-    placeholder="all",
-    metrics=JMETER_JSON_METRICS,
-)
-
-TARGET_RESPONSE_TIME = IntegerParameter(
-    name="Target response time",
-    short_name="target response time",
-    help="The response times of the transactions should be less than or equal to the target response time.",
-    default_value="1000",
-    unit="milliseconds",
-    metrics=["slow_transactions"],
-)
-
-TRANSACTION_SPECIFIC_TARGET_RESPONSE_TIMES = MultipleChoiceWithAdditionParameter(
-    name="Transaction-specific target response times (regular expressions or transaction names:target response time)",
-    short_name="transactions-specific target response times",
-    help="Transactions-specific target responses times (in milliseconds) can be specified by transaction name or by "
-    "regular expression, separated from the target response time by a colon, e.g.: '/api/v?/search/.*:1500'.",
-    placeholder="none",
-    metrics=["slow_transactions"],
-)
-
-PERCENTILE_90 = "90th percentile"
-PERCENTILE_95 = "95th percentile"
-PERCENTILE_99 = "99th percentile"
-
-RESPONSE_TIME_TO_EVALUATE = SingleChoiceParameter(
-    name="Response time type to evaluate against the target response time",
-    short_name="response time types to evaluate",
-    help="Which response time type to compare with the target response time to determine slow transactions.",
+RESPONSE_TIME_TO_EVALUATE = ResponseTimeToEvaluate(
     default_value=PERCENTILE_90,
     values=[PERCENTILE_90, PERCENTILE_95, PERCENTILE_99, "mean", "median", "minimum", "maximum"],
     api_values={
@@ -74,7 +39,6 @@ RESPONSE_TIME_TO_EVALUATE = SingleChoiceParameter(
         "minimum": "min_response_time",
         "maximum": "max_response_time",
     },
-    metrics=["slow_transactions"],
 )
 
 # Slow transaction entity attributes:
@@ -101,34 +65,27 @@ ENTITIES = {
     ),
 }
 
+PARAMETERS = {
+    "test_result": TestResult(values=["failed", "success"]),
+    "response_time_to_evaluate": RESPONSE_TIME_TO_EVALUATE,
+    "target_response_time": TargetResponseTime(),
+    "transaction_specific_target_response_times": TransactionSpecificTargetResponseTimes(),
+    "transactions_to_ignore": TransactionsToIgnore(),
+    "transactions_to_include": TransactionsToInclude(),
+}
+
 JMETER_CSV = Source(
     name="JMeter CSV",
-    description=JMETER_DESCRIPTION,
-    url=JMETER_URL,
-    parameters={
-        "test_result": TestResult(values=["failed", "success"]),
-        "response_time_to_evaluate": RESPONSE_TIME_TO_EVALUATE,
-        "target_response_time": TARGET_RESPONSE_TIME,
-        "transaction_specific_target_response_times": TRANSACTION_SPECIFIC_TARGET_RESPONSE_TIMES,
-        "transactions_to_ignore": TRANSACTIONS_TO_IGNORE,
-        "transactions_to_include": TRANSACTIONS_TO_INCLUDE,
-        **access_parameters(JMETER_CSV_METRICS, source_type="JMeter report", source_type_format="CSV"),
-    },
+    description=DESCRIPTION,
+    url=URL,
+    parameters=PARAMETERS | access_parameters(CSV_METRICS, source_type="JMeter report", source_type_format="CSV"),
     entities=ENTITIES,
 )
 
 JMETER_JSON = Source(
     name="JMeter JSON",
-    description=JMETER_DESCRIPTION,
-    url=JMETER_URL,
-    parameters={
-        "test_result": TestResult(values=["failed", "success"]),
-        "response_time_to_evaluate": RESPONSE_TIME_TO_EVALUATE,
-        "target_response_time": TARGET_RESPONSE_TIME,
-        "transaction_specific_target_response_times": TRANSACTION_SPECIFIC_TARGET_RESPONSE_TIMES,
-        "transactions_to_ignore": TRANSACTIONS_TO_IGNORE,
-        "transactions_to_include": TRANSACTIONS_TO_INCLUDE,
-        **access_parameters(JMETER_JSON_METRICS, source_type="JMeter report", source_type_format="JSON"),
-    },
+    description=DESCRIPTION,
+    url=URL,
+    parameters=PARAMETERS | access_parameters(JSON_METRICS, source_type="JMeter report", source_type_format="JSON"),
     entities=ENTITIES,
 )

--- a/components/shared_code/src/shared_data_model/sources/performancetest_runner.py
+++ b/components/shared_code/src/shared_data_model/sources/performancetest_runner.py
@@ -6,19 +6,20 @@ from shared_data_model.meta.entity import Color, Entity, EntityAttribute
 from shared_data_model.meta.source import Source
 from shared_data_model.parameters import (
     MultipleChoiceParameter,
-    MultipleChoiceWithAdditionParameter,
     TestResult,
+    TransactionsToIgnore,
+    TransactionsToInclude,
     access_parameters,
 )
 
-TRANSACTION_METRICS = ["slow_transactions", "tests"]
 ALL_PERFORMANCETEST_RUNNER_METRICS = [
-    *TRANSACTION_METRICS,
     "performancetest_duration",
     "performancetest_stability",
     "scalability",
+    "slow_transactions",
     "software_version",
     "source_up_to_dateness",
+    "tests",
 ]
 
 PERFORMANCETEST_RUNNER = Source(
@@ -35,19 +36,8 @@ PERFORMANCETEST_RUNNER = Source(
             api_values={"high": "red", "warning": "yellow"},
             metrics=["slow_transactions"],
         ),
-        "transactions_to_ignore": MultipleChoiceWithAdditionParameter(
-            name="Transactions to ignore (regular expressions or transaction names)",
-            short_name="transactions to ignore",
-            help="Transactions to ignore can be specified by transaction name or by regular expression.",
-            metrics=TRANSACTION_METRICS,
-        ),
-        "transactions_to_include": MultipleChoiceWithAdditionParameter(
-            name="Transactions to include (regular expressions or transaction names)",
-            short_name="transactions to include",
-            help="Transactions to include can be specified by transaction name or by regular expression.",
-            placeholder="all",
-            metrics=TRANSACTION_METRICS,
-        ),
+        "transactions_to_ignore": TransactionsToIgnore(),
+        "transactions_to_include": TransactionsToInclude(),
         **access_parameters(
             ALL_PERFORMANCETEST_RUNNER_METRICS,
             source_type="Performancetest-runner report",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,12 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Added
+
+- When measuring 'slow transactions' using Grafana k6 as source, allow for filtering transactions and configuring the response times to evaluate. Closes [#11462](https://github.com/ICTU/quality-time/issues/11462).
+
 ## v5.33.0 - 2025-06-20
 
 ### Changed


### PR DESCRIPTION
When measuring 'slow transactions' using Grafana k6 as source, allow for:
- filtering transactions by name,
- configuring the response time type to evaluate,
- setting the target response time and transaction-specific response times.

Closes #11462.