### PR TITLE
Better overflow for dashboard cards

### DIFF
--- a/components/frontend/src/dashboard/FilterCardWithTable.jsx
+++ b/components/frontend/src/dashboard/FilterCardWithTable.jsx
@@ -1,4 +1,4 @@
-import { Table, TableBody } from "@mui/material"
+import { Chip, Table, TableBody, TableCell, TableRow } from "@mui/material"
 import { bool, func, string } from "prop-types"
 
 import { childrenPropType } from "../sharedPropTypes"
@@ -19,3 +19,32 @@ FilterCardWithTable.propTypes = {
     selected: bool,
     title: string,
 }
+
+function Row({ color, label, value }) {
+    return (
+        <TableRow>
+            <TableCell
+                sx={{
+                    fontSize: "12px",
+                    paddingLeft: "0px",
+                    whiteSpace: "nowrap",
+                    width: "100%",
+                    maxWidth: 0,
+                    overflow: "hidden",
+                }}
+            >
+                {label}
+            </TableCell>
+            <TableCell sx={{ paddingRight: "0px", textAlign: "right" }}>
+                <Chip color={color} label={value} size="small" sx={{ borderRadius: 1 }} />
+            </TableCell>
+        </TableRow>
+    )
+}
+Row.propTypes = {
+    color: string,
+    label: string,
+    value: string,
+}
+
+FilterCardWithTable.Row = Row

--- a/components/frontend/src/dashboard/IssuesCard.jsx
+++ b/components/frontend/src/dashboard/IssuesCard.jsx
@@ -1,4 +1,3 @@
-import { Chip, TableCell, TableRow } from "@mui/material"
 import { bool, func } from "prop-types"
 
 import { reportPropType } from "../sharedPropTypes"
@@ -29,25 +28,13 @@ issueStatuses.propTypes = {
     report: reportPropType,
 }
 
-function tableRows(report) {
-    const statuses = issueStatuses(report)
-    return Object.keys(statuses).map((status) => (
-        <TableRow key={status}>
-            <TableCell sx={{ fontSize: "12px", paddingLeft: "0px" }}>{capitalize(status)}</TableCell>
-            <TableCell sx={{ paddingRight: "0px", textAlign: "right" }}>
-                <Chip color={status} label={`${statuses[status]}`} size="small" sx={{ borderRadius: 1 }} />
-            </TableCell>
-        </TableRow>
-    ))
-}
-tableRows.propTypes = {
-    report: reportPropType,
-}
-
 export function IssuesCard({ onClick, report, selected }) {
+    const statuses = issueStatuses(report)
     return (
         <FilterCardWithTable onClick={onClick} selected={selected} title="Issues">
-            {tableRows(report)}
+            {Object.entries(statuses).map(([status, count]) => (
+                <FilterCardWithTable.Row key={status} color={status} label={capitalize(status)} value={count} />
+            ))}
         </FilterCardWithTable>
     )
 }

--- a/components/frontend/src/dashboard/LegendCard.jsx
+++ b/components/frontend/src/dashboard/LegendCard.jsx
@@ -18,7 +18,7 @@ export function LegendCard() {
 
     return (
         <DashboardCard title="Legend" titleFirst={true}>
-            <List sx={{ padding: "0px", paddingLeft: "0px" }}>{listItems}</List>
+            <List sx={{ padding: "0px", paddingLeft: "0px", whiteSpace: "nowrap" }}>{listItems}</List>
         </DashboardCard>
     )
 }

--- a/components/frontend/src/dashboard/MetricsRequiringActionCard.jsx
+++ b/components/frontend/src/dashboard/MetricsRequiringActionCard.jsx
@@ -1,4 +1,3 @@
-import { Chip, TableCell, TableRow } from "@mui/material"
 import { bool, func } from "prop-types"
 
 import { STATUS_NAME, STATUSES_REQUIRING_ACTION } from "../metric/status"
@@ -27,36 +26,15 @@ metricStatuses.propTypes = {
     reports: reportsPropType,
 }
 
-function tableRows(reports) {
-    const statuses = metricStatuses(reports)
-    const rows = Object.keys(statuses).map((status) => (
-        <TableRow key={status}>
-            <TableCell sx={{ fontSize: "12px", paddingLeft: "0px" }}>{STATUS_NAME[status]}</TableCell>
-            <TableCell sx={{ paddingRight: "0px", textAlign: "right" }}>
-                <Chip color={status} label={statuses[status]} size="small" sx={{ borderRadius: 1 }} />
-            </TableCell>
-        </TableRow>
-    ))
-    rows.push(
-        <TableRow key="total">
-            <TableCell sx={{ fontSize: "12px", paddingLeft: "0px" }}>
-                <b>Total</b>
-            </TableCell>
-            <TableCell sx={{ paddingRight: "0px", textAlign: "right" }}>
-                <Chip color="total" label={sum(Object.values(statuses))} size="small" sx={{ borderRadius: 1 }} />
-            </TableCell>
-        </TableRow>,
-    )
-    return rows
-}
-tableRows.propTypes = {
-    reports: reportsPropType,
-}
-
 export function MetricsRequiringActionCard({ onClick, reports, selected }) {
+    const statuses = metricStatuses(reports)
+    const total = sum(Object.values(statuses))
     return (
         <FilterCardWithTable onClick={onClick} selected={selected} title="Action required">
-            {tableRows(reports)}
+            {Object.entries(statuses).map(([status, count]) => (
+                <FilterCardWithTable.Row key={status} color={status} label={STATUS_NAME[status]} value={count} />
+            ))}
+            <FilterCardWithTable.Row key="total" color="total" label={<b>Total</b>} value={total} />
         </FilterCardWithTable>
     )
 }

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,12 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- When the "Action required" and "Issues" cards become narrower, truncate the labels so that the counts column remains visible. Fixes [#11571](https://github.com/ICTU/quality-time/issues/11571).
+
 ## v5.34.0 - 2025-06-26
 
 ### Fixed


### PR DESCRIPTION
When the "Action required" and "Issues" cards become narrower, truncate the labels so that the counts column remains visible.

Fixes #11571.