### PR TITLE
Filtering missing metrics by subject

### DIFF
--- a/components/collector/tests/source_collectors/quality_time/base.py
+++ b/components/collector/tests/source_collectors/quality_time/base.py
@@ -15,12 +15,12 @@ class QualityTimeTestCase(SourceCollectorTestCase):
         self.reports = {
             "reports": [
                 {
-                    "title": "R1",
+                    "title": "Report 1",
                     "report_uuid": "r1",
                     "subjects": {
                         "s1": {
                             "type": "software",
-                            "name": "S1",
+                            "name": "Subject 1",
                             "metrics": {
                                 "m1": {
                                     "tags": ["security"],
@@ -86,7 +86,7 @@ class QualityTimeTestCase(SourceCollectorTestCase):
                         },
                     },
                 },
-                {"title": "R2", "report_uuid": "r2"},
+                {"title": "Report 2", "report_uuid": "r2"},
             ],
         }
 

--- a/components/collector/tests/source_collectors/quality_time/test_metrics.py
+++ b/components/collector/tests/source_collectors/quality_time/test_metrics.py
@@ -16,8 +16,8 @@ class QualityTimeMetricsTest(QualityTimeTestCase):
         self.entities = [
             {
                 "key": "m2",
-                "report": "R1",
-                "subject": "S1",
+                "report": "Report 1",
+                "subject": "Subject 1",
                 "metric": "Violations",
                 "report_url": f"{self.url}/r1",
                 "subject_url": f"{self.url}/r1#s1",

--- a/components/shared_code/src/shared_data_model/sources/quality_time.py
+++ b/components/shared_code/src/shared_data_model/sources/quality_time.py
@@ -194,6 +194,13 @@ QUALITY_TIME = Source(
             help="Ignore metric types that are missing in the subjects to ignore.",
             metrics=["missing_metrics"],
         ),
+        "subjects_to_include": MultipleChoiceWithAdditionParameter(
+            name="Subjects to include (subject names or identifiers)",
+            short_name="subjects to include",
+            help="If provided, only count metric types that are missing in the subjects to include.",
+            placeholder="all subjects",
+            metrics=["missing_metrics"],
+        ),
         "tags": MultipleChoiceWithAdditionParameter(
             name="Tags",
             help="If provided, only count metrics with one ore more of the given tags.",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -20,6 +20,10 @@ If your currently installed *Quality-time* version is not the latest version, pl
 - The dashboard and subject tables would be too wide in the PDF-exports. Lower the PDF scale to make them narrower. Fixes [#11570](https://github.com/ICTU/quality-time/issues/11570).
 - When the "Action required" and "Issues" cards become narrower, truncate the labels so that the counts column remains visible. Fixes [#11571](https://github.com/ICTU/quality-time/issues/11571).
 
+### Added
+
+- When measuring missing metrics, allow for configuring 'subjects to include' to only count missing metrics in the configured subjects. Closes [#11106](https://github.com/ICTU/quality-time/issues/11106).
+
 ## v5.34.0 - 2025-06-26
 
 ### Fixed


### PR DESCRIPTION
When measuring missing metrics, allow for configuring 'subjects to include' to only count missing metrics in the configured subjects.

Closes #11106.