### PR TITLE
Add Jira API version parameter

### DIFF
--- a/components/collector/src/source_collectors/jira/base.py
+++ b/components/collector/src/source_collectors/jira/base.py
@@ -20,3 +20,8 @@ class JiraBase(SourceCollector):
         if token := self._parameter("private_token"):
             headers["Authorization"] = f"Bearer {token}"
         return headers
+
+    @property
+    def _rest_api_version(self) -> str:
+        """Return the Jira REST API version set by the user."""
+        return str(self._parameter("api_version"))

--- a/components/collector/src/source_collectors/jira/issues.py
+++ b/components/collector/src/source_collectors/jira/issues.py
@@ -23,7 +23,7 @@ class JiraIssues(JiraBase):
     async def _api_url(self) -> URL:
         """Extend to get the fields from Jira and create a field name to field id mapping."""
         url = await super()._api_url()
-        fields_url = URL(f"{url}/rest/api/2/field")
+        fields_url = URL(f"{url}/rest/api/{self._rest_api_version}/field")
         response = (await super()._get_source_responses(fields_url))[0]
         self._field_ids = {}
         for field in await response.json():
@@ -33,7 +33,7 @@ class JiraIssues(JiraBase):
         jql = str(self._parameter("jql", quote=True))
         fields = self._fields()
         max_results = await self._determine_max_results()
-        return URL(f"{url}/rest/api/2/search?jql={jql}&fields={fields}&maxResults={max_results}")
+        return URL(f"{url}/rest/api/{self._rest_api_version}/search?jql={jql}&fields={fields}&maxResults={max_results}")
 
     async def _landing_url(self, responses: SourceResponses) -> URL:
         """Extend to add the JQL query to the landing URL."""
@@ -123,7 +123,8 @@ class JiraIssues(JiraBase):
         """Maximum number of issues to retrieve per page."""
         if isinstance(self.max_results, int):  # NB: using cached_property is not doable on asyncio coroutine
             return self.max_results
-        preference_url = URL(f"{self._parameter('url')}/rest/api/2/mypreferences?key=jira.search.views.default.max")
+        url = self._parameter("url")
+        preference_url = URL(f"{url}/rest/api/{self._rest_api_version}/mypreferences?key=jira.search.views.default.max")
         result_value = await (await super()._get_source_responses(preference_url))[0].json()
         self.max_results = result_value if isinstance(result_value, int) else self.DEFAULT_MAX_RESULTS
         return self.max_results

--- a/components/collector/src/source_collectors/jira/source_version.py
+++ b/components/collector/src/source_collectors/jira/source_version.py
@@ -13,7 +13,7 @@ class JiraSourceVersion(JiraBase, VersionCollector):
 
     async def _api_url(self) -> URL:
         """Extend to get the server info from Jira."""
-        return URL(f"{await super()._api_url()}/rest/api/2/serverInfo")
+        return URL(f"{await super()._api_url()}/rest/api/{self._rest_api_version}/serverInfo")
 
     async def _parse_source_response_version(self, response: Response) -> Version:
         """Override to return the Jira version."""

--- a/components/collector/tests/source_collectors/jira/test_issues.py
+++ b/components/collector/tests/source_collectors/jira/test_issues.py
@@ -55,3 +55,22 @@ class JiraIssuesTest(JiraTestCase):
         )
         self.assert_measurement(result, value="1", entities=[self.entity()])
         self.assertIn(f"&maxResults={JiraIssues.DEFAULT_MAX_RESULTS}&", get_mock.mock_calls[2].args[0])
+
+    async def test_api_v2(self):
+        """Test that the Jira API version used is v2 by default."""
+        issues_json = {"total": 1, "issues": [self.issue()]}
+        _, get_mock, _ = await self.collect(
+            get_request_json_side_effect=[[{"id": "field", "name": "Field"}], 50, issues_json, issues_json],
+            return_mocks=True,
+        )
+        self.assertTrue(get_mock.mock_calls[2].startswith("https://jira/rest/api/2"))
+
+    async def test_api_v3(self):
+        """Test that the Jira API version can be set to v3."""
+        self.set_source_parameter("api_version", "v3")
+        issues_json = {"total": 1, "issues": [self.issue()]}
+        _, get_mock, _ = await self.collect(
+            get_request_json_side_effect=[[{"id": "field", "name": "Field"}], 50, issues_json, issues_json],
+            return_mocks=True,
+        )
+        self.assertTrue(get_mock.mock_calls[2].startswith("https://jira/rest/api/3"))

--- a/components/frontend/src/report/ReportSources.jsx
+++ b/components/frontend/src/report/ReportSources.jsx
@@ -13,10 +13,12 @@ import { TableRowWithDetails } from "../widgets/TableRowWithDetails"
 import { InfoMessage } from "../widgets/WarningMessage"
 import { reportSources } from "./report_utils"
 
-export function SourceParameters({ reload, report, source, sourceUuid }) {
+function SourceParameters({ reload, report, source, sourceUuid }) {
     const dataModel = useContext(DataModel)
-    const allParameters = dataModel.sources[source.type].parameters
-    const locationParameterKeys = ["url", "landing_url", "username", "password", "private_token"]
+    const sourceType = dataModel.sources[source.type]
+    const allParameters = sourceType.parameters
+    const defaultLocationParameterKeys = ["url", "landing_url", "username", "password", "private_token"]
+    const locationParameterKeys = sourceType?.parameter_layout?.location?.parameters ?? defaultLocationParameterKeys
     let parameters
     if (new Set(Object.keys(allParameters)).intersection(new Set(locationParameterKeys)).size === 0) {
         parameters = <InfoMessage title="No location parameters">This source has no location parameters.</InfoMessage>

--- a/components/shared_code/src/shared_data_model/meta/parameter.py
+++ b/components/shared_code/src/shared_data_model/meta/parameter.py
@@ -130,7 +130,7 @@ class ParameterGroup(NamedModel):
 DEFAULT_PARAMETER_LAYOUT = {
     "location": ParameterGroup(
         name="Source location and credentials",
-        parameters=["url", "landing_url", "username", "password", "private_token"],
+        parameters=["url", "api_version", "landing_url", "username", "password", "private_token"],
     ),
     "filter": ParameterGroup(name="Source filters"),
 }

--- a/components/shared_code/src/shared_data_model/parameters.py
+++ b/components/shared_code/src/shared_data_model/parameters.py
@@ -124,6 +124,14 @@ class PrivateToken(Password):
     validation_path: str = ""  # URL path to use for the validation of tokens
 
 
+class APIVersion(SingleChoiceParameter):
+    """API version to use."""
+
+    name: str = "API version"
+    mandatory: bool = True
+    help: str | None = "Version of the API (application programming interface) to use for retrieving information."
+
+
 class Days(IntegerParameter):
     """Number of days parameter."""
 

--- a/components/shared_code/src/shared_data_model/sources/jira.py
+++ b/components/shared_code/src/shared_data_model/sources/jira.py
@@ -7,6 +7,7 @@ from shared_data_model.meta.entity import Color, Entity, EntityAttribute, Entity
 from shared_data_model.meta.source import Source
 from shared_data_model.meta.unit import Unit
 from shared_data_model.parameters import (
+    APIVersion,
     Days,
     IntegerParameter,
     SingleChoiceParameter,
@@ -60,6 +61,12 @@ JIRA = Source(
     url=HttpUrl("https://www.atlassian.com/software/jira"),
     issue_tracker=True,
     parameters={
+        "api_version": APIVersion(
+            values=["v2", "v3"],
+            api_values={"v2": "2", "v3": "3"},
+            default_value="v2",
+            metrics=ALL_JIRA_METRICS,
+        ),
         "board": StringParameter(
             name="Board (name or id)",
             short_name="board",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -22,6 +22,10 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 - Replace the report date picker with a panel that contains the report date picker and the settings for number of dates, time between dates, and date order. Closes [#11616](https://github.com/ICTU/quality-time/issues/11616).
 
+### Added
+
+- When configuring Jira as source, allow for picking the Jira API version. Closes [#11652](https://github.com/ICTU/quality-time/issues/11652).
+
 ## v5.35.0 - 2025-07-04
 
 ### Fixed


### PR DESCRIPTION
When configuring Jira as source, allow for picking the Jira API version.

Closes #11652.