### PR TITLE
Specify Dependency-Track private token permissions

### DIFF
--- a/components/shared_code/src/shared_data_model/sources/dependency_track.py
+++ b/components/shared_code/src/shared_data_model/sources/dependency_track.py
@@ -54,7 +54,7 @@ DEPENDENCY_TRACK = Source(
             metrics=ALL_DEPENDENCY_TRACK_METRICS,
         ),
         "private_token": PrivateToken(
-            name="API key",
+            name="API key (with view_portfolio and view_vulnerability permissions)",
             help_url=HttpUrl("https://docs.dependencytrack.org/integrations/rest-api/"),
             metrics=["dependencies", "source_up_to_dateness", "security_warnings"],
         ),

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 ### Fixed
 
+- Add a note to the Dependency-Track private token parameter to indicate which API permissions the token needs. Fixes [#9169](https://github.com/ICTU/quality-time/issues/9169).
 - Fix links in PDF-exports not being clickable. Fixes [#11636](https://github.com/ICTU/quality-time/issues/11636).
 
 ### Changed


### PR DESCRIPTION
Add a note to the Dependency-Track private token parameter to indicate which API permissions the token needs.

Fixes #9169.