### PR TITLE
Button to ignore measurement entities

### DIFF
--- a/components/frontend/src/source/SourceEntities.test.jsx
+++ b/components/frontend/src/source/SourceEntities.test.jsx
@@ -178,15 +178,35 @@ it("renders a message if there are no measurements", async () => {
 
 it("shows the hide ignored entities button", async () => {
     const { container } = renderSourceEntities()
-    expect(screen.getAllByText("Hide ignored entities").length).toBe(1)
+    expect(screen.getAllByLabelText(/Hide the 0 entities that have been/).length).toBe(1)
+    await expectNoAccessibilityViolations(container)
+})
+
+it("shows the hide ignored entities button with one ignored entity", async () => {
+    const fixture = JSON.parse(JSON.stringify(sourceFixture))
+    fixture.entity_user_data["2"].status_end_date = "3000-01-01"
+    const { container } = renderSourceEntities({ measurements: [{ sources: [fixture] }] })
+    expect(screen.getAllByLabelText(/Hide the 1 entity name that has been/).length).toBe(1)
+    await expectNoAccessibilityViolations(container)
+})
+
+it("shows the hide ignored entities button with two ignored entities", async () => {
+    const fixture = JSON.parse(JSON.stringify(sourceFixture))
+    fixture.entity_user_data["1"].status = "false_positive"
+    fixture.entity_user_data["1"].status_end_date = "3000-01-01"
+    fixture.entity_user_data["2"].status_end_date = "3000-01-01"
+    const { container } = renderSourceEntities({ measurements: [{ sources: [fixture] }] })
+    expect(screen.getAllByLabelText(/Hide the 2 entities that have been/).length).toBe(1)
     await expectNoAccessibilityViolations(container)
 })
 
 it("shows the show ignored entities button", async () => {
-    const { container } = renderSourceEntities()
-    const hideEntitiesButton = screen.getByText("Hide ignored entities")
-    await userEvent.click(hideEntitiesButton)
-    expect(hideEntitiesButton).toHaveTextContent("Show ignored entities")
+    const fixture = JSON.parse(JSON.stringify(sourceFixture))
+    fixture.entity_user_data["2"].status_end_date = "3000-01-01"
+    const { container } = renderSourceEntities({ measurements: [{ sources: [fixture] }] })
+    const hideEntitiesTooltip = screen.getByLabelText(/Hide the 1 entity name that has been/)
+    await userEvent.click(hideEntitiesTooltip.firstChild) // Get the button inside the tooltip
+    expect(hideEntitiesTooltip).toHaveAccessibleName(/Show the 1 entity name that has been/)
     await expectNoAccessibilityViolations(container)
 })
 

--- a/components/frontend/src/source/SourceEntity.jsx
+++ b/components/frontend/src/source/SourceEntity.jsx
@@ -11,7 +11,7 @@ import { IGNORABLE_SOURCE_ENTITY_STATUSES, SOURCE_ENTITY_STATUS_NAME } from "./s
 import { SourceEntityAttribute } from "./SourceEntityAttribute"
 import { SourceEntityDetails } from "./SourceEntityDetails"
 
-function entityCanBeIgnored(status, statusEndDateString) {
+export function entityCanBeIgnored(status, statusEndDateString) {
     const statusEndDate = new Date(statusEndDateString)
     const now = new Date()
     if (statusEndDate < now) {
@@ -77,7 +77,9 @@ export function SourceEntity({
             onExpand={setExpanded}
             style={{ maxHeight: "100px", overflow: "auto" }}
         >
-            <TableCell sx={style}>{SOURCE_ENTITY_STATUS_NAME[status]}</TableCell>
+            <TableCell colSpan={2} sx={{ paddingLeft: "6px", ...style }}>
+                {SOURCE_ENTITY_STATUS_NAME[status]}
+            </TableCell>
             <TableCell sx={style}>
                 {status === "unconfirmed" ? "" : <TimeAgoWithDate dateFirst noTime date={statusEndDate} />}
             </TableCell>

--- a/components/frontend/src/theme.js
+++ b/components/frontend/src/theme.js
@@ -76,6 +76,10 @@ const theme2 = createTheme(theme1, {
             color: { main: theme1.palette.error.main },
             name: "edit_scope_reports",
         }),
+        entity_status_count_badge: theme1.palette.augmentColor({
+            color: { main: grey[300] },
+            name: "entity_status_count_badge",
+        }),
     },
     typography: {
         h1: {

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,12 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Changed
+
+- Replace the button to hide ignored measurement entities at the bottom of entity tables with an icon button in the table header. Also add a badge with the number of ignored measurement entities. Closes [#11702](https://github.com/ICTU/quality-time/issues/11702).
+
 ## v5.36.1 - 2025-07-18
 
 ### Fixed


### PR DESCRIPTION
Replace the button to hide ignored measurement entities at the bottom of entity tables with an icon button in the table header. Also add a badge with the number of ignored measurement entities.

Closes #11702.