### PR TITLE
Remove hadolint check on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,9 +126,3 @@ workflows:
           context: QualityTime
       - unittest_other:
           context: QualityTime
-      - docker/hadolint:
-          context: QualityTime
-          dockerfiles: "components/collector/Dockerfile:components/database/Dockerfile:\
-            components/api_server/Dockerfile:components/frontend/Dockerfile:\
-            components/notifier/Dockerfile:components/proxy/Dockerfile:\
-            components/renderer/Dockerfile:components/testdata/Dockerfile"


### PR DESCRIPTION
It does not work, exits with "Exited with code exit status 100", unclear why.