### PR TITLE
Skip credential check for Harbor robot users

### DIFF
--- a/components/collector/src/source_collectors/harbor/security_warnings.py
+++ b/components/collector/src/source_collectors/harbor/security_warnings.py
@@ -31,12 +31,15 @@ class HarborBase(SourceCollector, ABC):
         return all_responses
 
     async def _check_credentials(self) -> None:
-        """Check that the credentials are valid.
+        """Check that the user credentials are valid.
+
+        Only works for real users. Robot users don't have a /current endpoint.
 
         This needs to be done explicitly because Harbor doesn't throw an error on invalid credentials but quietly only
         returns public projects, making it hard for the user to see that there is something wrong.
         """
-        if self._parameter("username"):
+        username = cast(str, self._parameter("username"))
+        if username and not username.startswith("robot_"):
             # This will raise an exception for status >= 400:
             await super()._get_source_responses(URL(await self._api_url() + "/users/current"))
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,6 +14,10 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 ## [Unreleased]
 
+### Fixed
+
+- Skip credential check for Harbor robot users (it only works for regular users). Fixes [#11353](https://github.com/ICTU/quality-time/issues/11353).
+
 ### Added
 
 - When measuring inactive branches using GitLab, allow for selecting a group of projects in addition to a single project. Closes [#7991](https://github.com/ICTU/quality-time/issues/7991).


### PR DESCRIPTION
When measuring security warnings using Harbor as source with a robot user, skip the credential check. It only works for regular users.

Fixes #11353.