### PR TITLE
Aggregate test case results strictly or leniently

### DIFF
--- a/components/shared_code/src/shared_data_model/metrics.py
+++ b/components/shared_code/src/shared_data_model/metrics.py
@@ -593,9 +593,12 @@ one passed, and one untested test case:
 | MP-3 | Test case 3 | passed      |
 | MP-4 | Test case 4 | untested    |
 
-If multiple test results in the test report file map to one Jira test case (as with MP-1 and MP-3 above), the 'worst'
-test result is reported. Possible test results from worst to best are: errored, failed, skipped, and passed. Test cases
-not found in the test results are listed as untested (as with MP-4 above).
+If multiple test results in the test report file map to one Jira test case (as with MP-1 and MP-3 above), by default
+the test results are aggregated strictly, meaning that the 'worst' test result for each test case is reported.
+Possible test results from worst to best are: errored, failed, skipped, and passed. Test cases not found in the test
+results are listed as untested (as with MP-4 above). It is also possible to aggregate the test results leniently,
+meaning that the 'best' test result for each test case is reported. Use the 'test result aggregation strategy'
+parameter of test report sources to switch between strict and lenient.
 
 In addition to linking individual test results to Jira test cases, it's also possible to link test suites to Jira test
 cases. For example:

--- a/components/shared_code/src/shared_data_model/parameters.py
+++ b/components/shared_code/src/shared_data_model/parameters.py
@@ -177,6 +177,22 @@ class TestResult(MultipleChoiceWithDefaultsParameter):
     metrics: list[str] = ["tests"]
 
 
+class TestResultAggregationStrategy(SingleChoiceParameter):
+    """Test result aggregation strategy."""
+
+    name: str = "Test result aggregation strategy"
+    short_name: str = "test result aggregation"
+    help: str = (
+        "How to aggregate test results of individual tests to create the result of a test case. "
+        "Strict (default) assigns the worst result of the tests to the test case they belong to. "
+        "Lenient assigns the best result of the tests to the test case they belong to. "
+        "Possible test results are, from worst to best: errored, failed, skipped, and passed."
+    )
+    default_value: str | list[str] = "strict"
+    values: list[str] | None = ["strict", "lenient"]
+    metrics: list[str] = ["test_cases"]
+
+
 class Upvotes(IntegerParameter):
     """Minimum number of merge request up-votes parameter."""
 

--- a/components/shared_code/src/shared_data_model/sources/jenkins.py
+++ b/components/shared_code/src/shared_data_model/sources/jenkins.py
@@ -13,6 +13,7 @@ from shared_data_model.parameters import (
     ResultType,
     StringParameter,
     TestResult,
+    TestResultAggregationStrategy,
     access_parameters,
 )
 
@@ -212,6 +213,7 @@ JENKINS_TEST_REPORT = Source(
     url=HttpUrl("https://plugins.jenkins.io/junit"),
     parameters={
         "test_result": TestResult(values=["failed", "passed", "skipped"]),
+        "test_result_aggregation_strategy": TestResultAggregationStrategy(),
         **jenkins_access_parameters(
             ALL_JENKINS_TEST_REPORT_METRICS,
             kwargs={

--- a/components/shared_code/src/shared_data_model/sources/junit.py
+++ b/components/shared_code/src/shared_data_model/sources/junit.py
@@ -4,7 +4,7 @@ from pydantic import HttpUrl
 
 from shared_data_model.meta.entity import Color, Entity, EntityAttribute, EntityAttributeType
 from shared_data_model.meta.source import Source
-from shared_data_model.parameters import TestResult, access_parameters
+from shared_data_model.parameters import TestResult, TestResultAggregationStrategy, access_parameters
 
 ALL_JUNIT_METRICS = ["source_up_to_dateness", "test_cases", "test_suites", "tests"]
 
@@ -31,6 +31,7 @@ JUNIT = Source(
     url=HttpUrl("https://junit.org/junit5/"),
     parameters={
         "test_result": TestResult(metrics=["test_suites", "tests"], values=["errored", "failed", "passed", "skipped"]),
+        "test_result_aggregation_strategy": TestResultAggregationStrategy(),
         **access_parameters(ALL_JUNIT_METRICS, source_type="JUnit report", source_type_format="XML"),
     },
     entities={

--- a/components/shared_code/src/shared_data_model/sources/robot_framework.py
+++ b/components/shared_code/src/shared_data_model/sources/robot_framework.py
@@ -4,7 +4,7 @@ from pydantic import HttpUrl
 
 from shared_data_model.meta.entity import Color, Entity, EntityAttribute, EntityAttributeType
 from shared_data_model.meta.source import Source
-from shared_data_model.parameters import TestResult, access_parameters
+from shared_data_model.parameters import TestResult, TestResultAggregationStrategy, access_parameters
 
 from .jenkins import JENKINS_TOKEN_DOCS, jenkins_access_parameters
 
@@ -19,6 +19,7 @@ ROBOT_FRAMEWORK = Source(
     url=HttpUrl("https://robotframework.org"),
     parameters={
         "test_result": TestResult(metrics=["test_suites", "tests"], values=["fail", "pass", "skip"]),
+        "test_result_aggregation_strategy": TestResultAggregationStrategy(),
         **access_parameters(
             ALL_ROBOT_FRAMEWORK_METRICS,
             source_type="Robot Framework report",

--- a/components/shared_code/src/shared_data_model/sources/testng.py
+++ b/components/shared_code/src/shared_data_model/sources/testng.py
@@ -4,7 +4,7 @@ from pydantic import HttpUrl
 
 from shared_data_model.meta.entity import Color, Entity, EntityAttribute, EntityAttributeType
 from shared_data_model.meta.source import Source
-from shared_data_model.parameters import TestResult, access_parameters
+from shared_data_model.parameters import TestResult, TestResultAggregationStrategy, access_parameters
 
 ALL_TESTNG_METRICS = ["source_up_to_dateness", "test_cases", "test_suites", "tests"]
 
@@ -26,6 +26,7 @@ TESTNG = Source(
     url=HttpUrl("https://testng.org"),
     parameters={
         "test_result": TestResult(metrics=["test_suites", "tests"], values=["failed", "ignored", "passed", "skipped"]),
+        "test_result_aggregation_strategy": TestResultAggregationStrategy(),
         **access_parameters(ALL_TESTNG_METRICS, source_type="TestNG report", source_type_format="XML"),
     },
     entities={

--- a/components/shared_code/src/shared_data_model/sources/visual_studio_trx.py
+++ b/components/shared_code/src/shared_data_model/sources/visual_studio_trx.py
@@ -4,7 +4,7 @@ from pydantic import HttpUrl
 
 from shared_data_model.meta.entity import Color, Entity, EntityAttribute
 from shared_data_model.meta.source import Source
-from shared_data_model.parameters import TestResult, access_parameters
+from shared_data_model.parameters import TestResult, TestResultAggregationStrategy, access_parameters
 
 ALL_VISUAL_STUDIO_TRX_METRICS = ["source_up_to_dateness", "test_cases", "tests"]
 
@@ -60,6 +60,7 @@ VISUAL_STUDIO_TRX = Source(
                 "Warning",
             ],
         ),
+        "test_result_aggregation_strategy": TestResultAggregationStrategy(),
         **access_parameters(ALL_VISUAL_STUDIO_TRX_METRICS, source_type="Visual Studio TRX", source_type_format="XML"),
     },
     entities={"tests": TEST_ENTITIES, "test_cases": TEST_ENTITIES},

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -22,6 +22,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 - When measuring inactive branches using GitLab, allow for selecting a group of projects in addition to a single project. Closes [#7991](https://github.com/ICTU/quality-time/issues/7991).
 - When measuring test cases, also look for Jira ids in the test suite names. Closes [#11193](https://github.com/ICTU/quality-time/issues/11193).
+- When measuring test cases, allow for aggregating test results either strictly or leniently. See the documentation on the [test cases metric](https://quality-time.readthedocs.io/en/latest/reference.html#test-cases). Closes [#11193](https://github.com/ICTU/quality-time/issues/11193).
 
 ## v5.37.0 - 2025-08-06
 


### PR DESCRIPTION
When measuring test cases, allow for aggregating test results either strictly or leniently. See the documentation on the [test cases metric](https://quality-time.readthedocs.io/en/latest/reference.html#test-cases).

Closes #11193.