### PR TITLE
Add parameter for Harbor robot account prefix

### DIFF
--- a/components/collector/src/source_collectors/harbor/security_warnings.py
+++ b/components/collector/src/source_collectors/harbor/security_warnings.py
@@ -39,7 +39,8 @@ class HarborBase(SourceCollector, ABC):
         returns public projects, making it hard for the user to see that there is something wrong.
         """
         username = cast(str, self._parameter("username"))
-        if username and not username.startswith("robot_"):
+        robot_account_prefix = cast(str, self._parameter("robot_account_prefix"))
+        if username and not username.startswith(robot_account_prefix):
             # This will raise an exception for status >= 400:
             await super()._get_source_responses(URL(await self._api_url() + "/users/current"))
 

--- a/components/shared_code/src/shared_data_model/meta/parameter.py
+++ b/components/shared_code/src/shared_data_model/meta/parameter.py
@@ -130,7 +130,15 @@ class ParameterGroup(NamedModel):
 DEFAULT_PARAMETER_LAYOUT = {
     "location": ParameterGroup(
         name="Source location and credentials",
-        parameters=["url", "api_version", "landing_url", "username", "password", "private_token"],
+        parameters=[
+            "url",
+            "api_version",
+            "landing_url",
+            "username",
+            "password",
+            "private_token",
+            "robot_account_prefix",
+        ],
     ),
     "filter": ParameterGroup(name="Source filters"),
 }

--- a/components/shared_code/src/shared_data_model/sources/harbor.py
+++ b/components/shared_code/src/shared_data_model/sources/harbor.py
@@ -8,6 +8,7 @@ from shared_data_model.parameters import (
     FixAvailability,
     MultipleChoiceWithAdditionParameter,
     Severities,
+    StringParameter,
     access_parameters,
 )
 
@@ -53,6 +54,16 @@ HARBOR = Source(
         ),
         "severities": Severities(values=["unknown", "low", "medium", "high", "critical"]),
         "fix_availability": FixAvailability(),
+        "robot_account_prefix": StringParameter(
+            name="Robot account prefix",
+            help_url=HttpUrl(
+                "https://goharbor.io/docs/2.3.0/administration/robot-accounts/#configure-robot-account-prefix"
+            ),
+            default_value="robot",
+            mandatory=True,
+            placeholder="robot account prefix",
+            metrics=["security_warnings"],
+        ),
         **access_parameters(
             ALL_HARBOR_METRICS,
             include={"private_token": False, "landing_url": False},

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,12 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Added
+
+- Add a parameter to Harbor sources to set the robot account prefix. Closes [#11822](https://github.com/ICTU/quality-time/issues/11822).
+
 ## v5.38.1 - 2025-08-14
 
 ### Fixed


### PR DESCRIPTION
Add a parameter to Harbor sources to set the robot account prefix.

Closes #11822.