### PR TITLE
Add SonarQube rule S1309

### DIFF
--- a/components/shared_code/src/shared_data_model/sources/sonarqube.py
+++ b/components/shared_code/src/shared_data_model/sources/sonarqube.py
@@ -273,6 +273,7 @@ SONARQUBE = Source(
                 "php:NoSonar",
                 "plsql:NoSonarCheck",
                 "python:NoSonar",
+                "python:S1309",
                 "tsql:NoSonar",
                 "typescript:S1291",
             ],

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -20,6 +20,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 ### Added
 
+- When measuring suppressed violations with SonarQube as source, also count `noqa` suppressions (using SonarQube rule S1309). Closes [#11811](https://github.com/ICTU/quality-time/issues/11811).
 - Add a parameter to Harbor sources to set the robot account prefix. Closes [#11822](https://github.com/ICTU/quality-time/issues/11822).
 
 ## v5.38.1 - 2025-08-14


### PR DESCRIPTION
When measuring suppressed violations with SonarQube as source, also count `noqa` suppressions (using SonarQube rule S1309).

Closes #11811.