### PR TITLE
11662 hide empty columns 

### DIFF
--- a/components/frontend/src/__fixtures__/fixtures.js
+++ b/components/frontend/src/__fixtures__/fixtures.js
@@ -2,6 +2,7 @@ import { renderHook } from "@testing-library/react"
 
 import {
     allSettingsAreDefault,
+    entries,
     resetSettings,
     useDateIntervalURLSearchQuery,
     useDateOrderURLSearchQuery,
@@ -9,6 +10,7 @@ import {
     useHiddenCardsURLSearchQuery,
     useHiddenColumnsURLSearchQuery,
     useHiddenTagsURLSearchQuery,
+    useHideEmptyColumnsURLSearchQuery,
     useLanguageURLSearchQuery,
     useMetricsToHideURLSearchQuery,
     useNrDatesURLSearchQuery,
@@ -116,6 +118,7 @@ export function createTestableSettings() {
         hiddenCards: testableQuery(useHiddenCardsURLSearchQuery),
         hiddenColumns: testableQuery(useHiddenColumnsURLSearchQuery),
         hiddenTags: testableQuery(useHiddenTagsURLSearchQuery),
+        hideEmptyColumns: testableQuery(useHideEmptyColumnsURLSearchQuery),
         language: testableQuery(useLanguageURLSearchQuery),
         metricsToHide: testableQuery(useMetricsToHideURLSearchQuery),
         nrDates: testableQuery(useNrDatesURLSearchQuery),
@@ -132,6 +135,9 @@ export function createTestableSettings() {
         },
         allDefault: function () {
             return allSettingsAreDefault(this)
+        },
+        entries: function () {
+            return entries(this)
         },
     }
 }

--- a/components/frontend/src/__fixtures__/fixtures.js
+++ b/components/frontend/src/__fixtures__/fixtures.js
@@ -2,7 +2,6 @@ import { renderHook } from "@testing-library/react"
 
 import {
     allSettingsAreDefault,
-    entries,
     resetSettings,
     useDateIntervalURLSearchQuery,
     useDateOrderURLSearchQuery,
@@ -135,9 +134,6 @@ export function createTestableSettings() {
         },
         allDefault: function () {
             return allSettingsAreDefault(this)
-        },
-        entries: function () {
-            return entries(this)
         },
     }
 }

--- a/components/frontend/src/app_ui_settings.js
+++ b/components/frontend/src/app_ui_settings.js
@@ -29,6 +29,10 @@ export function useHiddenColumnsURLSearchQuery(reportUuid) {
     return useArrayURLSearchQuery(urlSearchQueryKey("hidden_columns", reportUuid))
 }
 
+export function useHideEmptyColumnsURLSearchQuery(reportUuid) {
+    return useBooleanURLSearchQuery(urlSearchQueryKey("hide_empty_columns", reportUuid))
+}
+
 export function useHiddenTagsURLSearchQuery(reportUuid) {
     return useArrayURLSearchQuery(urlSearchQueryKey("hidden_tags", reportUuid))
 }
@@ -89,6 +93,7 @@ export function useSettings(reportUuid) {
         expandedItems: useExpandedItemsSearchQuery(reportUuid),
         hiddenCards: useHiddenCardsURLSearchQuery(reportUuid),
         hiddenColumns: useHiddenColumnsURLSearchQuery(reportUuid),
+        hideEmptyColumns: useHideEmptyColumnsURLSearchQuery(reportUuid),
         hiddenTags: useHiddenTagsURLSearchQuery(reportUuid),
         language: useLanguageURLSearchQuery(),
         metricsToHide: useMetricsToHideURLSearchQuery(reportUuid),
@@ -117,6 +122,7 @@ export function resetSettings(settings) {
     settings.hiddenCards.reset()
     settings.hiddenColumns.reset()
     settings.hiddenTags.reset()
+    settings.hideEmptyColumns.reset()
     settings.language.reset()
     settings.metricsToHide.reset()
     settings.nrDates.reset()
@@ -138,6 +144,7 @@ export function allSettingsAreDefault(settings) {
         settings.hiddenCards.isDefault() &&
         settings.hiddenColumns.isDefault() &&
         settings.hiddenTags.isDefault() &&
+        settings.hideEmptyColumns.isDefault() &&
         settings.language.isDefault() &&
         settings.metricsToHide.isDefault() &&
         settings.nrDates.isDefault() &&

--- a/components/frontend/src/header_footer/SettingsPanel.test.jsx
+++ b/components/frontend/src/header_footer/SettingsPanel.test.jsx
@@ -28,6 +28,7 @@ function renderSettingsPanel({
                 hiddenCards: settings.hiddenCards,
                 hiddenColumns: settings.hiddenColumns,
                 hiddenTags: settings.hiddenTags,
+                hideEmptyColumns: settings.hideEmptyColumns,
                 metricsToHide: settings.metricsToHide,
                 nrDates: settings.nrDates,
                 showIssueCreationDate: settings.showIssueCreationDate,
@@ -102,6 +103,19 @@ it("shows a column", async () => {
     history.push("?hidden_columns=status")
     renderSettingsPanel()
     fireEvent.click(screen.getAllByText(/Status/)[0])
+    expect(history.location.search).toBe("")
+})
+
+it("hides empty columns", async () => {
+    renderSettingsPanel()
+    fireEvent.click(screen.getByText(/Empty columns/))
+    expect(history.location.search).toBe("?hide_empty_columns=true")
+})
+
+it("show empty columns", async () => {
+    history.push("?hide_empty_columns=true")
+    renderSettingsPanel()
+    fireEvent.click(screen.getByText(/Empty columns/))
     expect(history.location.search).toBe("")
 })
 

--- a/components/frontend/src/header_footer/settings_menu/VisibleColumnsMenu.jsx
+++ b/components/frontend/src/header_footer/settings_menu/VisibleColumnsMenu.jsx
@@ -57,7 +57,6 @@ export function VisibleColumnMenu({ settings }) {
             <Divider />
             <SettingsMenuItem
                 active={!settings.hideEmptyColumns.value}
-                help={"Show empty columns?"}
                 onClick={settings.hideEmptyColumns.set}
                 onClickData={!settings.hideEmptyColumns.value}
             >

--- a/components/frontend/src/header_footer/settings_menu/VisibleColumnsMenu.jsx
+++ b/components/frontend/src/header_footer/settings_menu/VisibleColumnsMenu.jsx
@@ -1,3 +1,4 @@
+import Divider from "@mui/material/Divider"
 import { bool, string } from "prop-types"
 
 import { popupContentPropType, settingsPropType, stringsURLSearchQueryPropType } from "../../sharedPropTypes"
@@ -53,6 +54,15 @@ export function VisibleColumnMenu({ settings }) {
             <VisibleColumnMenuItem column="comment" {...visibleColumnMenuItemProps} />
             <VisibleColumnMenuItem column="issues" {...visibleColumnMenuItemProps} />
             <VisibleColumnMenuItem column="tags" {...visibleColumnMenuItemProps} />
+            <Divider />
+            <SettingsMenuItem
+                active={!settings.hideEmptyColumns.value}
+                help={"Show empty columns?"}
+                onClick={settings.hideEmptyColumns.set}
+                onClickData={!settings.hideEmptyColumns.value}
+            >
+                Empty columns
+            </SettingsMenuItem>
         </SettingsMenu>
     )
 }

--- a/components/frontend/src/hooks/url_search_query.test.js
+++ b/components/frontend/src/hooks/url_search_query.test.js
@@ -41,7 +41,7 @@ it("sets a boolean value", () => {
 })
 
 it("resets a boolean value", () => {
-    const { result } = renderHook(() => useBooleanURLSearchQuery("key", 0))
+    const { result } = renderHook(() => useBooleanURLSearchQuery("key"))
     act(() => {
         result.current.set(true)
     })

--- a/components/frontend/src/metric/MetricDetails.jsx
+++ b/components/frontend/src/metric/MetricDetails.jsx
@@ -216,6 +216,7 @@ export function MetricDetails({
                 metricUuid={metricUuid}
                 reload={measurementsReload}
                 report={report}
+                settings={settings}
                 sourceUuid={sourceUuid}
             />,
         )

--- a/components/frontend/src/source/SourceEntities.test.jsx
+++ b/components/frontend/src/source/SourceEntities.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
+import { createTestableSettings } from "../__fixtures__/fixtures"
 import { DataModel } from "../context/DataModel"
 import { expectNoAccessibilityViolations } from "../testUtils"
 import { SourceEntities } from "./SourceEntities"
@@ -114,6 +115,7 @@ function renderSourceEntities({
                 metric={metric}
                 metricUuid="metric_uuid"
                 report={{ issue_tracker: null }}
+                settings={createTestableSettings()}
                 sourceUuid="source_uuid"
             />
         </DataModel.Provider>,

--- a/components/frontend/src/source/SourceEntity.jsx
+++ b/components/frontend/src/source/SourceEntity.jsx
@@ -2,7 +2,13 @@ import { TableCell } from "@mui/material"
 import { bool, func, string } from "prop-types"
 import { useState } from "react"
 
-import { entityAttributesPropType, entityPropType, entityStatusPropType, reportPropType } from "../sharedPropTypes"
+import {
+    entityAttributesPropType,
+    entityPropType,
+    entityStatusPropType,
+    reportPropType,
+    stringsPropType,
+} from "../sharedPropTypes"
 import { DivWithHtml } from "../widgets/DivWithHtml"
 import { TableRowWithDetails } from "../widgets/TableRowWithDetails"
 import { TimeAgoWithDate } from "../widgets/TimeAgoWithDate"
@@ -25,6 +31,7 @@ entityCanBeIgnored.propTypes = {
 }
 
 export function SourceEntity({
+    columnsToHide,
     metricUuid,
     sourceUuid,
     hideIgnoredEntities,
@@ -80,12 +87,16 @@ export function SourceEntity({
             <TableCell colSpan={2} sx={{ paddingLeft: "6px", ...style }}>
                 {SOURCE_ENTITY_STATUS_NAME[status]}
             </TableCell>
-            <TableCell sx={style}>
-                {status === "unconfirmed" ? "" : <TimeAgoWithDate dateFirst noTime date={statusEndDate} />}
-            </TableCell>
-            <TableCell sx={style}>
-                <DivWithHtml>{rationale}</DivWithHtml>
-            </TableCell>
+            {!columnsToHide.includes("status_end_date") && (
+                <TableCell sx={style}>
+                    {status === "unconfirmed" ? "" : <TimeAgoWithDate dateFirst noTime date={statusEndDate} />}
+                </TableCell>
+            )}
+            {!columnsToHide.includes("rationale") && (
+                <TableCell sx={style}>
+                    <DivWithHtml>{rationale}</DivWithHtml>
+                </TableCell>
+            )}
             <TableCell sx={style}>
                 {entity.first_seen ? <TimeAgoWithDate dateFirst date={entity.first_seen} /> : ""}
             </TableCell>
@@ -102,6 +113,7 @@ export function SourceEntity({
     )
 }
 SourceEntity.propTypes = {
+    columnsToHide: stringsPropType,
     metricUuid: string,
     sourceUuid: string,
     hideIgnoredEntities: bool,

--- a/components/frontend/src/source/SourceEntity.test.jsx
+++ b/components/frontend/src/source/SourceEntity.test.jsx
@@ -19,6 +19,7 @@ function renderSourceEntity({
             <Table>
                 <TableBody>
                     <SourceEntity
+                        columnsToHide={[]}
                         entity={{ attr1: "good", attr2: "bad", first_seen: firstSeen }}
                         entityAttributes={[{ key: "attr1" }, { key: "attr2", color: { bad: "warning" } }]}
                         entityName="entity"

--- a/components/frontend/src/source/source_entity_column.js
+++ b/components/frontend/src/source/source_entity_column.js
@@ -1,0 +1,23 @@
+import { array } from "prop-types"
+
+import { settingsPropType, sourcePropType } from "../sharedPropTypes"
+import { entityStatusEndDate, entityStatusRationale } from "./source_entity_status"
+
+export function determineColumnsToHide(settings, source, sourceEntities) {
+    if (!settings.hideEmptyColumns.value) {
+        return []
+    }
+    const emptyColumns = []
+    if (sourceEntities.every((entity) => entityStatusRationale(source, entity) === "")) {
+        emptyColumns.push("rationale")
+    }
+    if (sourceEntities.every((entity) => entityStatusEndDate(source, entity) === "")) {
+        emptyColumns.push("status_end_date")
+    }
+    return emptyColumns
+}
+determineColumnsToHide.propTypes = {
+    settings: settingsPropType,
+    source: sourcePropType,
+    sourceEntries: array,
+}

--- a/components/frontend/src/source/source_entity_column.test.js
+++ b/components/frontend/src/source/source_entity_column.test.js
@@ -1,0 +1,27 @@
+import history from "history/browser"
+
+import { createTestableSettings } from "../__fixtures__/fixtures"
+import { determineColumnsToHide } from "./source_entity_column"
+
+beforeEach(() => history.push(""))
+
+it("determines the columns to hide if empty columns are not hidden", async () => {
+    const columnsToHide = determineColumnsToHide(createTestableSettings(), {}, [])
+    expect(columnsToHide).toEqual([])
+})
+
+it("determines the columns to hide if empty columns are hidden", async () => {
+    history.push("?hide_empty_columns=true")
+    const columnsToHide = determineColumnsToHide(createTestableSettings(), {}, [{}])
+    expect(columnsToHide).toEqual(["rationale", "status_end_date"])
+})
+
+it("determines the columns to hide if empty columns are hidden and the columns are not empty", async () => {
+    history.push("?hide_empty_columns=true")
+    const columnsToHide = determineColumnsToHide(
+        createTestableSettings(),
+        { entity_user_data: { entity_key: { rationale: "rationale", status_end_date: "2026-01-01" } } },
+        [{ key: "entity_key" }],
+    )
+    expect(columnsToHide).toEqual([])
+})

--- a/components/frontend/src/source/source_entity_status.js
+++ b/components/frontend/src/source/source_entity_status.js
@@ -1,3 +1,5 @@
+import { entityPropType, sourcePropType } from "../sharedPropTypes"
+
 export const IGNORABLE_SOURCE_ENTITY_STATUSES = ["false_positive", "fixed", "wont_fix"]
 
 export const SOURCE_ENTITY_STATUS_NAME = {
@@ -23,4 +25,28 @@ export const SOURCE_ENTITY_STATUS_DESCRIPTION = {
     false_positive:
         "False positive means an entity has been incorrectly identified as a problem and should be ignored.",
     wont_fix: "Won't fix means that an entity can be ignored because it will not be fixed.",
+}
+
+export function entityStatus(source, entity) {
+    return source.entity_user_data?.[entity.key]?.status ?? "unconfirmed"
+}
+entityStatus.propTypes = {
+    source: sourcePropType,
+    entity: entityPropType,
+}
+
+export function entityStatusEndDate(source, entity) {
+    return source.entity_user_data?.[entity.key]?.status_end_date ?? ""
+}
+entityStatusEndDate.propTypes = {
+    source: sourcePropType,
+    entity: entityPropType,
+}
+
+export function entityStatusRationale(source, entity) {
+    return source.entity_user_data?.[entity.key]?.rationale ?? ""
+}
+entityStatusRationale.propTypes = {
+    source: sourcePropType,
+    entity: entityPropType,
 }

--- a/components/frontend/src/subject/SubjectTable.jsx
+++ b/components/frontend/src/subject/SubjectTable.jsx
@@ -2,7 +2,9 @@ import "./SubjectTable.css"
 
 import { Table, TableContainer } from "@mui/material"
 import { array, func, object, string } from "prop-types"
+import { useContext } from "react"
 
+import { DataModel } from "../context/DataModel"
 import {
     datesPropType,
     measurementsPropType,
@@ -12,6 +14,7 @@ import {
     settingsPropType,
     stringsPropType,
 } from "../sharedPropTypes"
+import { determineColumnsToHide } from "./subject_column"
 import { SubjectTableBody } from "./SubjectTableBody"
 import { SubjectTableFooter } from "./SubjectTableFooter"
 import { SubjectTableHeader } from "./SubjectTableHeader"
@@ -30,8 +33,10 @@ export function SubjectTable({
     subject,
     subjectUuid,
 }) {
+    const dataModel = useContext(DataModel)
     // Sort measurements in reverse order so that if there multiple measurements on a day, we find the most recent one:
     const reversedMeasurements = measurements.slice().sort((m1, m2) => (m1.start < m2.start ? 1 : -1))
+    const columnsToHide = determineColumnsToHide(dataModel, measurements, metricEntries, dates.length, report, settings)
     return (
         <TableContainer sx={{ overflowX: "visible" }}>
             <Table
@@ -43,10 +48,16 @@ export function SubjectTable({
                     },
                 }}
             >
-                <SubjectTableHeader columnDates={dates} handleSort={handleSort} settings={settings} />
+                <SubjectTableHeader
+                    columnDates={dates}
+                    columnsToHide={columnsToHide}
+                    handleSort={handleSort}
+                    settings={settings}
+                />
                 <SubjectTableBody
                     changedFields={changedFields}
                     dates={dates}
+                    columnsToHide={columnsToHide}
                     handleSort={handleSort}
                     measurements={measurements}
                     metricEntries={metricEntries}

--- a/components/frontend/src/subject/SubjectTable.test.jsx
+++ b/components/frontend/src/subject/SubjectTable.test.jsx
@@ -256,3 +256,11 @@ it("adds a source", async () => {
         type: "source_type",
     })
 })
+
+it("hides empty columns", async () => {
+    history.push("?hide_empty_columns=true")
+    renderSubjectTable()
+    expect(screen.queryAllByText(/Comment/).length).toBe(0)
+    expect(screen.queryAllByText(/Issues/).length).toBe(0)
+    expect(screen.queryAllByText(/Tags/).length).toBe(1) // Not empty
+})

--- a/components/frontend/src/subject/SubjectTableBody.jsx
+++ b/components/frontend/src/subject/SubjectTableBody.jsx
@@ -14,6 +14,7 @@ import { SubjectTableRow } from "./SubjectTableRow"
 
 export function SubjectTableBody({
     changedFields,
+    columnsToHide,
     dates,
     handleSort,
     measurements,
@@ -34,6 +35,7 @@ export function SubjectTableBody({
                     <SubjectTableRow
                         changedFields={changedFields}
                         dates={dates}
+                        columnsToHide={columnsToHide}
                         handleSort={handleSort}
                         index={index}
                         key={metricUuid}
@@ -56,6 +58,7 @@ export function SubjectTableBody({
 }
 SubjectTableBody.propTypes = {
     changedFields: stringsPropType,
+    columnsToHide: stringsPropType,
     dates: datesPropType,
     handleSort: func,
     measurements: measurementsPropType,

--- a/components/frontend/src/subject/SubjectTableHeader.jsx
+++ b/components/frontend/src/subject/SubjectTableHeader.jsx
@@ -4,7 +4,7 @@ import { bool, func, string } from "prop-types"
 import { zIndexTableHeader } from "../defaults"
 import { StatusIcon } from "../measurement/StatusIcon"
 import { STATUS_DESCRIPTION, STATUSES } from "../metric/status"
-import { datesPropType, settingsPropType } from "../sharedPropTypes"
+import { datesPropType, settingsPropType, stringsPropType } from "../sharedPropTypes"
 import { HyperLink } from "../widgets/HyperLink"
 import { IgnoreIcon, TriangleRightIcon } from "../widgets/icons"
 import { SortableTableHeaderCell, UnsortableTableHeaderCell } from "../widgets/TableHeaderCell"
@@ -290,7 +290,7 @@ MeasurementHeaderCells.propTypes = {
     showDeltaColumns: bool,
 }
 
-export function SubjectTableHeader({ columnDates, handleSort, settings }) {
+export function SubjectTableHeader({ columnDates, columnsToHide, handleSort, settings }) {
     const sortProps = {
         sortColumn: settings.sortColumn.value,
         sortDirection: settings.sortDirection,
@@ -304,16 +304,16 @@ export function SubjectTableHeader({ columnDates, handleSort, settings }) {
                 {nrDates > 1 && (
                     <MeasurementHeaderCells
                         columnDates={columnDates}
-                        showDeltaColumns={settings.hiddenColumns.excludes("delta")}
+                        showDeltaColumns={!columnsToHide.includes("delta")}
                     />
                 )}
-                {nrDates === 1 && settings.hiddenColumns.excludes("trend") && (
+                {!columnsToHide.includes("trend") && (
                     <UnsortableTableHeaderCell width="2" label="Trend (7 days)" help={trendHelp} />
                 )}
-                {nrDates === 1 && settings.hiddenColumns.excludes("status") && (
+                {!columnsToHide.includes("status") && (
                     <SortableTableHeaderCell column="status" label="Status" help={statusHelp()} {...sortProps} />
                 )}
-                {nrDates === 1 && settings.hiddenColumns.excludes("measurement") && (
+                {!columnsToHide.includes("measurement") && (
                     <SortableTableHeaderCell
                         column="measurement"
                         label="Measurement"
@@ -322,7 +322,7 @@ export function SubjectTableHeader({ columnDates, handleSort, settings }) {
                         {...sortProps}
                     />
                 )}
-                {nrDates === 1 && settings.hiddenColumns.excludes("target") && (
+                {!columnsToHide.includes("target") && (
                     <SortableTableHeaderCell
                         column="target"
                         label="Target"
@@ -331,25 +331,25 @@ export function SubjectTableHeader({ columnDates, handleSort, settings }) {
                         {...sortProps}
                     />
                 )}
-                {settings.hiddenColumns.excludes("unit") && (
+                {!columnsToHide.includes("unit") && (
                     <SortableTableHeaderCell column="unit" label="Unit" help={unitHelp} {...sortProps} />
                 )}
-                {settings.hiddenColumns.excludes("source") && (
+                {!columnsToHide.includes("source") && (
                     <SortableTableHeaderCell column="source" label="Sources" help={sourcesHelp} {...sortProps} />
                 )}
-                {settings.hiddenColumns.excludes("time_left") && (
+                {!columnsToHide.includes("time_left") && (
                     <SortableTableHeaderCell column="time_left" label="Time left" help={timeLeftHelp} {...sortProps} />
                 )}
-                {nrDates > 1 && settings.hiddenColumns.excludes("overrun") && (
+                {!columnsToHide.includes("overrun") && (
                     <SortableTableHeaderCell column="overrun" label="Overrun" help={overrunHelp} {...sortProps} />
                 )}
-                {settings.hiddenColumns.excludes("comment") && (
+                {!columnsToHide.includes("comment") && (
                     <SortableTableHeaderCell column="comment" label="Comment" help={commentHelp} {...sortProps} />
                 )}
-                {settings.hiddenColumns.excludes("issues") && (
+                {!columnsToHide.includes("issues") && (
                     <SortableTableHeaderCell column="issues" label="Issues" help={issuesHelp} {...sortProps} />
                 )}
-                {settings.hiddenColumns.excludes("tags") && (
+                {!columnsToHide.includes("tags") && (
                     <SortableTableHeaderCell column="tags" label="Tags" help={tagsHelp} {...sortProps} />
                 )}
             </TableRow>
@@ -358,6 +358,7 @@ export function SubjectTableHeader({ columnDates, handleSort, settings }) {
 }
 SubjectTableHeader.propTypes = {
     columnDates: datesPropType,
+    columnsToHide: stringsPropType,
     handleSort: func,
     settings: settingsPropType,
 }

--- a/components/frontend/src/subject/SubjectTableHeader.test.jsx
+++ b/components/frontend/src/subject/SubjectTableHeader.test.jsx
@@ -7,11 +7,11 @@ import { createTestableSettings } from "../__fixtures__/fixtures"
 import { expectNoAccessibilityViolations } from "../testUtils"
 import { SubjectTableHeader } from "./SubjectTableHeader"
 
-function renderSubjectTableHeader(columnDates) {
+function renderSubjectTableHeader(columnDates, columnsToHide) {
     const settings = createTestableSettings()
     return render(
         <Table>
-            <SubjectTableHeader columnDates={columnDates} settings={settings} />
+            <SubjectTableHeader columnDates={columnDates} columnsToHide={columnsToHide ?? []} settings={settings} />
         </Table>,
     )
 }
@@ -24,7 +24,7 @@ it("shows the column dates and unit", async () => {
     const date1 = new Date("2022-02-02")
     const date2 = new Date("2022-02-03")
     const { container } = renderSubjectTableHeader([date1, date2])
-    ;[
+    const headers = [
         date1.toLocaleDateString(),
         "𝚫",
         date2.toLocaleDateString(),
@@ -35,18 +35,15 @@ it("shows the column dates and unit", async () => {
         "Comment",
         "Issues",
         "Tags",
-    ].forEach((header) => expect(screen.getAllByText(header).length).toBe(1))
-    ;["Trend (7 days)", "Status", "Measurement", "Target"].forEach((header) =>
-        expect(screen.queryAllByText(header).length).toBe(0),
-    )
+    ]
+    headers.forEach((header) => expect(screen.getAllByText(header).length).toBe(1))
     await expectNoAccessibilityViolations(container)
 })
 
 it("does not show the column dates", async () => {
     const date1 = new Date("2022-02-02")
     const { container } = renderSubjectTableHeader([date1])
-    ;[date1.toLocaleDateString(), "Overrun"].forEach((header) => expect(screen.queryAllByText(header).length).toBe(0))
-    ;[
+    const headers = [
         "Trend (7 days)",
         "Status",
         "Measurement",
@@ -57,25 +54,24 @@ it("does not show the column dates", async () => {
         "Comment",
         "Issues",
         "Tags",
-    ].forEach((header) => expect(screen.queryAllByText(header).length).toBe(1))
+    ]
+    headers.forEach((header) => expect(screen.queryAllByText(header).length).toBe(1))
     await expectNoAccessibilityViolations(container)
 })
 
 it("hides columns", async () => {
-    history.push("?hidden_columns=trend,status,measurement,target,source,comment,issues,tags")
     const date1 = new Date("2022-02-02")
-    const { container } = renderSubjectTableHeader([date1])
-    ;["Trend (7 days)", "Status", "Measurement", "Target", "Sources", "Comment", "Issues", "Tags"].forEach((header) =>
-        expect(screen.queryAllByText(header).length).toBe(0),
-    )
+    const columns = ["trend", "status", "measurement", "target", "source", "comment", "issues", "tags"]
+    const { container } = renderSubjectTableHeader([date1], columns)
+    const headers = ["Trend (7 days)", "Status", "Measurement", "Target", "Sources", "Comment", "Issues", "Tags"]
+    headers.forEach((header) => expect(screen.queryAllByText(header).length).toBe(0))
     await expectNoAccessibilityViolations(container)
 })
 
 it("hides the delta columns", async () => {
-    history.push("?hidden_columns=delta")
     const date1 = new Date("2022-02-02")
     const date2 = new Date("2022-02-03")
-    const { container } = renderSubjectTableHeader([date1, date2])
+    const { container } = renderSubjectTableHeader([date1, date2], ["delta"])
     expect(screen.queryAllByText("𝚫").length).toBe(0)
     await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/subject/SubjectTableRow.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.jsx
@@ -211,6 +211,7 @@ MeasurementCells.propTypes = {
 
 export function SubjectTableRow({
     changedFields,
+    columnsToHide,
     dates,
     handleSort,
     index,
@@ -268,40 +269,40 @@ export function SubjectTableRow({
                     settings={settings}
                 />
             )}
-            {nrDates === 1 && settings.hiddenColumns.excludes("trend") && (
+            {!columnsToHide.includes("trend") && (
                 <TableCell sx={{ width: "150px" }}>
                     <TrendSparkline measurements={metric.recent_measurements} reportDate={reportDate} scale={scale} />
                 </TableCell>
             )}
-            {nrDates === 1 && settings.hiddenColumns.excludes("status") && (
+            {!columnsToHide.includes("status") && (
                 <TableCell>
                     <Typography sx={{ paddingLeft: "6px", fontSize: "24px" }}>
                         <StatusIcon status={metric.status} statusStart={metric.status_start} />
                     </Typography>
                 </TableCell>
             )}
-            {nrDates === 1 && settings.hiddenColumns.excludes("measurement") && (
+            {!columnsToHide.includes("measurement") && (
                 <TableCell align="right">
                     <MeasurementValue metric={metric} reportDate={reportDate} />
                 </TableCell>
             )}
-            {nrDates === 1 && settings.hiddenColumns.excludes("target") && (
+            {!columnsToHide.includes("target") && (
                 <TableCell align="right">
                     <MeasurementTarget metric={metric} />
                 </TableCell>
             )}
-            {settings.hiddenColumns.excludes("unit") && <TableCell>{unit}</TableCell>}
-            {settings.hiddenColumns.excludes("source") && (
+            {!columnsToHide.includes("unit") && <TableCell>{unit}</TableCell>}
+            {!columnsToHide.includes("source") && (
                 <TableCell>
                     <MeasurementSources metric={metric} />
                 </TableCell>
             )}
-            {settings.hiddenColumns.excludes("time_left") && (
+            {!columnsToHide.includes("time_left") && (
                 <TableCell>
                     <TimeLeft metric={metric} report={report} />
                 </TableCell>
             )}
-            {nrDates > 1 && settings.hiddenColumns.excludes("overrun") && (
+            {!columnsToHide.includes("overrun") && (
                 <TableCell>
                     <Overrun
                         metric={metric}
@@ -312,17 +313,17 @@ export function SubjectTableRow({
                     />
                 </TableCell>
             )}
-            {settings.hiddenColumns.excludes("comment") && (
+            {!columnsToHide.includes("comment") && (
                 <TableCell>
                     <DivWithHtml>{metric.comment}</DivWithHtml>
                 </TableCell>
             )}
-            {settings.hiddenColumns.excludes("issues") && (
+            {!columnsToHide.includes("issues") && (
                 <TableCell>
                     <IssueStatus metric={metric} issueTrackerMissing={!report.issue_tracker} settings={settings} />
                 </TableCell>
             )}
-            {settings.hiddenColumns.excludes("tags") && (
+            {!columnsToHide.includes("tags") && (
                 <TableCell>
                     {getMetricTags(metric).map((tag) => (
                         <Tag key={tag} tag={tag} />
@@ -334,6 +335,7 @@ export function SubjectTableRow({
 }
 SubjectTableRow.propTypes = {
     changedFields: stringsPropType,
+    columnsToHide: stringsPropType,
     dates: datesPropType,
     handleSort: func,
     index: number,

--- a/components/frontend/src/subject/SubjectTableRow.test.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.test.jsx
@@ -48,6 +48,7 @@ function renderSubjectTableRow({
             <Table>
                 <TableBody>
                     <SubjectTableRow
+                        columnsToHide={[]}
                         dates={dates}
                         measurements={[]}
                         metric={{

--- a/components/frontend/src/subject/subject_column.js
+++ b/components/frontend/src/subject/subject_column.js
@@ -1,0 +1,56 @@
+import { array, number } from "prop-types"
+
+import { dataModelPropType, measurementsPropType, reportPropType, settingsPropType } from "../sharedPropTypes"
+import {
+    getMetricComment,
+    getMetricIssueIds,
+    getMetricResponseOverrun,
+    getMetricResponseTimeLeft,
+    getMetricTags,
+} from "../utils"
+
+export function determineColumnsToHide(dataModel, measurements, metricEntries, nrDates, report, settings) {
+    // First, add columns that are hidden explicitly by the user:
+    const columnsToHide = new Set(settings.hiddenColumns.value)
+    // Next, if the user wants to hide empty columns, add any empty columns:
+    if (settings.hideEmptyColumns.value) {
+        if (metricEntries.every(([_, metric]) => getMetricComment(metric) === "")) {
+            columnsToHide.add("comment")
+        }
+        if (metricEntries.every(([_, metric]) => getMetricIssueIds(metric).length === 0)) {
+            columnsToHide.add("issues")
+        }
+        if (metricEntries.every(([_, metric]) => getMetricTags(metric).length === 0)) {
+            columnsToHide.add("tags")
+        }
+        if (metricEntries.every(([_, metric]) => getMetricResponseTimeLeft(metric, report) === null)) {
+            columnsToHide.add("time_left")
+        }
+        if (
+            metricEntries.every(
+                ([metricUuid, metric]) =>
+                    getMetricResponseOverrun(metricUuid, metric, report, measurements, dataModel).overruns.length === 0,
+            )
+        ) {
+            columnsToHide.add("overrun")
+        }
+    }
+    // Finally, hide columns depending on how many dates are being shown:
+    if (nrDates <= 1) {
+        columnsToHide.add("overrun")
+    } else {
+        columnsToHide.add("trend")
+        columnsToHide.add("status")
+        columnsToHide.add("measurement")
+        columnsToHide.add("target")
+    }
+    return Array.from(columnsToHide).toSorted()
+}
+determineColumnsToHide.propTypes = {
+    dataModel: dataModelPropType,
+    measurements: measurementsPropType,
+    metricEntries: array,
+    nrDates: number,
+    report: reportPropType,
+    settings: settingsPropType,
+}

--- a/components/frontend/src/subject/subject_column.test.js
+++ b/components/frontend/src/subject/subject_column.test.js
@@ -1,0 +1,30 @@
+import history from "history/browser"
+
+import { createTestableSettings } from "../__fixtures__/fixtures"
+import { determineColumnsToHide } from "./subject_column"
+
+beforeEach(() => history.push(""))
+
+it("determines the columns to hide with one date", async () => {
+    const columnsToHide = determineColumnsToHide({}, [], [], 1, {}, createTestableSettings())
+    expect(columnsToHide).toEqual(["overrun"])
+})
+
+it("determines the columns to hide with multiple dates", async () => {
+    const columnsToHide = determineColumnsToHide({}, [], [], 2, {}, createTestableSettings())
+    expect(columnsToHide).toEqual(["measurement", "status", "target", "trend"])
+})
+
+it("determines the columns to hide when a column is explicitly hidden", async () => {
+    history.push("?hidden_columns=hidden")
+    const settings = createTestableSettings()
+    const columnsToHide = determineColumnsToHide({}, [], [], 1, {}, settings)
+    expect(columnsToHide).toEqual(["hidden", "overrun"])
+})
+
+it("determines empty columns to hide", async () => {
+    history.push("?hide_empty_columns=true")
+    const settings = createTestableSettings()
+    const columnsToHide = determineColumnsToHide({}, [], [], 1, {}, settings)
+    expect(columnsToHide).toEqual(["comment", "issues", "overrun", "tags", "time_left"])
+})

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -20,6 +20,7 @@ If your currently installed *Quality-time* version is not the latest version, pl
 
 ### Added
 
+- Allow for hiding empty columns in metric and metric detail tables via the Settings panel. Closes [#11662](https://github.com/ICTU/quality-time/issues/11662).
 - When measuring suppressed violations with SonarQube as source, also count `noqa` suppressions (using SonarQube rule S1309). Closes [#11811](https://github.com/ICTU/quality-time/issues/11811).
 - Add a parameter to Harbor sources to set the robot account prefix. Closes [#11822](https://github.com/ICTU/quality-time/issues/11822).
 


### PR DESCRIPTION
Allow for hiding empty columns in metric tables via the Settings panel.

Closes #11662.