### PR TITLE
Prefer landing URLs in Jira issues

### DIFF
--- a/components/api_server/src/routes/metric.py
+++ b/components/api_server/src/routes/metric.py
@@ -209,7 +209,7 @@ def create_issue_text(metric: Metric, measured_value: Value) -> tuple[str, str]:
     """Create an issue description for the metric."""
     metric_url = dict(bottle.request.json)["metric_url"]
     source_names = ", ".join([source.name or DATA_MODEL.sources[str(source.type)].name for source in metric.sources])
-    source_urls = [url for url in [source.get("parameters", {}).get("url") for source in metric.sources] if url]
+    source_urls = [url for url in [get_source_url(source) for source in metric.sources] if url]
     percentage = "%" if metric.scale() == "percentage" else ""
     issue_summary = f"Fix {measured_value}{percentage} {metric.unit} from {source_names}"
     source_url_str = f"\nPlease go to {', '.join(source_urls)} for more details." if source_urls else ""
@@ -218,3 +218,9 @@ def create_issue_text(metric: Metric, measured_value: Value) -> tuple[str, str]:
         f"{measured_value}{percentage} {metric.unit} from {source_names}.{source_url_str}\n"
     )
     return issue_summary, issue_description
+
+
+def get_source_url(source: dict[str, dict[str, str]]) -> str:
+    """Get the URL from the source. Prefer landing URL over API URL."""
+    parameters = source.get("parameters", {})
+    return parameters.get("landing_url", "") or parameters.get("url", "")

--- a/components/api_server/tests/routes/test_metric.py
+++ b/components/api_server/tests/routes/test_metric.py
@@ -613,6 +613,19 @@ class MetricIssueTest(DataModelTestCase):
         self.assert_issue_inserted()
 
     @patch("bottle.request", Mock(json={"metric_url": METRIC_URL}))
+    def test_add_metric_issue_with_landing_url(self, requests_post):
+        """Test that the metric landing URL is used if available."""
+        self.sources[SOURCE_ID]["parameters"]["landing_url"] = "https://zap/landing"
+        description = self.expected_json["fields"]["description"]
+        self.expected_json["fields"]["description"] = description.replace("https://zap", "https://zap/landing")
+        response = Mock()
+        response.json.return_value = {"key": "FOO-42"}
+        requests_post.return_value = response
+        self.assertEqual({"ok": True, "issue_url": self.ISSUE_URL}, add_metric_issue(METRIC_ID, self.database))
+        self.assert_issue_posted(requests_post)
+        self.assert_issue_inserted()
+
+    @patch("bottle.request", Mock(json={"metric_url": METRIC_URL}))
     def test_add_metric_issue_with_percentage_scale(self, requests_post):
         """Test that an issue with the percentage scale can be added to the issue tracker."""
         self.measurement["percentage"] = {"status": "target_not_met", "value": "21"}

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ### Added
 
+- When creating a Jira issue from Quality-time, include source landing URLs in the issue instead of source API URLs if possible. Closes [#8283](https://github.com/ICTU/quality-time/issues/8283).
 - Add support for OWASP Dependency-Check JSON reports as source for the 'dependencies', 'security warnings', 'source up-to-dateness', and 'source version' metrics. Closes [#11851](https://github.com/ICTU/quality-time/issues/11851).
 
 ## v5.39.0 - 2025-08-21


### PR DESCRIPTION
When creating a Jira issue from Quality-time, include source landing URLs in the issue instead of source API URLs if possible.

Closes #8283.