### PR TITLE
Show Dependency-Track project version

### DIFF
--- a/components/collector/src/source_collectors/dependency_track/base.py
+++ b/components/collector/src/source_collectors/dependency_track/base.py
@@ -45,9 +45,9 @@ class DependencyTrackBase(SourceCollector):
                 page_nr += 1
         return responses
 
-    async def _get_project_uuids(self) -> dict[str, str]:
-        """Return a mapping of project UUIDs to project names."""
-        return {project["uuid"]: project["name"] async for project in self._get_projects()}
+    async def _get_projects_by_uuid(self) -> dict[str, DependencyTrackProject]:
+        """Return a mapping of project UUIDs to projects."""
+        return {project["uuid"]: project async for project in self._get_projects()}
 
     async def _get_projects(self) -> AsyncIterator[DependencyTrackProject]:
         """Return the Dependency-Track projects."""

--- a/components/collector/src/source_collectors/dependency_track/dependencies.py
+++ b/components/collector/src/source_collectors/dependency_track/dependencies.py
@@ -31,7 +31,7 @@ class DependencyTrackDependencies(DependencyTrackLatestVersionStatusBase):
     async def _get_source_responses(self, *urls: URL) -> SourceResponses:
         """Extend to get the components."""
         api_url = await self._api_url()
-        project_uuids = await self._get_project_uuids()
+        project_uuids = await self._get_projects_by_uuid()
         project_components_urls = [URL(f"{api_url}/component/project/{uuid}") for uuid in project_uuids]
         return await super()._get_source_responses(*project_components_urls)
 
@@ -57,5 +57,6 @@ class DependencyTrackDependencies(DependencyTrackLatestVersionStatusBase):
             latest_version_status=self._latest_version_status(current_version, latest_version),
             project=project["name"],
             project_landing_url=f"{landing_url}/projects/{project['uuid']}",
+            project_version=project.get("version", ""),
             version=current_version,
         )

--- a/components/collector/src/source_collectors/dependency_track/security_warnings.py
+++ b/components/collector/src/source_collectors/dependency_track/security_warnings.py
@@ -43,8 +43,8 @@ class DependencyTrackSecurityWarnings(SecurityWarningsSourceCollector, Dependenc
     async def _get_source_responses(self, *urls: URL) -> SourceResponses:
         """Extend to get the findings."""
         api_url = await self._api_url()
-        self._project_uuids = await self._get_project_uuids()
-        project_finding_urls = [URL(f"{api_url}/finding/project/{uuid}") for uuid in self._project_uuids]
+        self._projects = await self._get_projects_by_uuid()
+        project_finding_urls = [URL(f"{api_url}/finding/project/{uuid}") for uuid in self._projects]
         return await super()._get_source_responses(*project_finding_urls)
 
     async def _parse_entities(self, responses: SourceResponses) -> Entities:
@@ -71,8 +71,9 @@ class DependencyTrackSecurityWarnings(SecurityWarningsSourceCollector, Dependenc
             key=finding["matrix"],  # Matrix is a combination of project, component, and vulnerability
             latest=latest_version,
             latest_version_status=self._latest_version_status(current_version, latest_version),
-            project=self._project_uuids[project_uuid],  # Name of the project
+            project=self._projects[project_uuid]["name"],
             project_landing_url=f"{landing_url}/projects/{project_uuid}",
+            project_version=self._projects[project_uuid].get("version", ""),
             severity=vulnerability["severity"].capitalize(),
             version=current_version,
         )

--- a/components/collector/src/source_collectors/dependency_track/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/dependency_track/source_up_to_dateness.py
@@ -49,7 +49,7 @@ class DependencyTrackSourceUpToDateness(DependencyTrackBase, TimePassedCollector
                     last_bom_import="" if last_bom_import is None else last_bom_import.isoformat(),
                     project=project["name"],
                     project_landing_url=f"{landing_url}/projects/{uuid}",
-                    version=project.get("version", ""),
+                    project_version=project.get("version", ""),
                     is_latest="true" if self._is_latest(project) else "false",
                     up_to_date=self._up_to_dateness(project),
                 )

--- a/components/collector/tests/source_collectors/dependency_track/test_dependencies.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_dependencies.py
@@ -33,6 +33,7 @@ class DependencyTrackDependenciesTest(DependencyTrackTestCase):
                 "latest_version_status": latest_version_status,
                 "project": "project name",
                 "project_landing_url": "/projects/project uuid",
+                "project_version": "1.4",
                 "version": "1.0",
             },
         ]

--- a/components/collector/tests/source_collectors/dependency_track/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_security_warnings.py
@@ -50,6 +50,7 @@ class DependencyTrackSecurityWarningsTest(DependencyTrackTestCase):
                 "latest_version_status": "update possible",
                 "project": "project name",
                 "project_landing_url": "/projects/project uuid",
+                "project_version": "1.4",
                 "severity": "Unassigned",
                 "version": "1",
             },

--- a/components/collector/tests/source_collectors/dependency_track/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_source_up_to_dateness.py
@@ -57,8 +57,8 @@ class DependencyTrackSourceUpToDatenessVersionTest(DependencyTrackTestCase):
                 "is_latest": "true",
                 "project": "Project 1",
                 "project_landing_url": "/projects/p1",
+                "project_version": "1.1",
                 "up_to_date": "yes",
-                "version": "1.1",
             },
             {
                 "key": "p2",
@@ -67,8 +67,8 @@ class DependencyTrackSourceUpToDatenessVersionTest(DependencyTrackTestCase):
                 "last_bom_import": self.last_week.isoformat(),
                 "project": "Project 2",
                 "project_landing_url": "/projects/p2",
+                "project_version": "1.2",
                 "up_to_date": "nearly",
-                "version": "1.2",
             },
         ]
 
@@ -99,8 +99,8 @@ class DependencyTrackSourceUpToDatenessVersionTest(DependencyTrackTestCase):
                 "is_latest": "true",
                 "project": "Project 3",
                 "project_landing_url": "/projects/p3",
+                "project_version": "1.3",
                 "up_to_date": "nearly",
-                "version": "1.3",
             }
         )
         response = await self.collect(get_request_json_return_value=projects)
@@ -125,8 +125,8 @@ class DependencyTrackSourceUpToDatenessVersionTest(DependencyTrackTestCase):
                 "is_latest": "false",
                 "project": "Project 3",
                 "project_landing_url": "/projects/p3",
+                "project_version": "1.3",
                 "up_to_date": "unknown",
-                "version": "1.3",
             }
         )
         response = await self.collect(get_request_json_return_value=projects)

--- a/components/shared_code/src/shared_data_model/sources/dependency_track.py
+++ b/components/shared_code/src/shared_data_model/sources/dependency_track.py
@@ -20,6 +20,10 @@ DEPENDENCY_TRACK_DESCRIPTION = (
     "Dependency-Track is a component analysis platform that allows organizations to identify and "
     "reduce risk in the software supply chain."
 )
+PROJECT_ATTRIBUTES = [
+    EntityAttribute(name="Project", url="project_landing_url"),
+    EntityAttribute(name="Project version"),
+]
 VERSION_ATTRIBUTES = [
     EntityAttribute(name="Current version", key="version"),
     EntityAttribute(name="Latest version", key="latest"),
@@ -107,7 +111,7 @@ DEPENDENCY_TRACK = Source(
             name="dependency",
             name_plural="dependencies",
             attributes=[
-                EntityAttribute(name="Project", url="project_landing_url"),
+                *PROJECT_ATTRIBUTES,
                 EntityAttribute(name="Component", url="component_landing_url"),
                 *VERSION_ATTRIBUTES,
             ],
@@ -115,7 +119,7 @@ DEPENDENCY_TRACK = Source(
         "security_warnings": Entity(
             name="security warning",
             attributes=[
-                EntityAttribute(name="Project", url="project_landing_url"),
+                *PROJECT_ATTRIBUTES,
                 EntityAttribute(name="Component", url="component_landing_url"),
                 EntityAttribute(name="Identifier"),
                 EntityAttribute(name="Description"),
@@ -126,8 +130,7 @@ DEPENDENCY_TRACK = Source(
         "source_up_to_dateness": Entity(
             name="project",
             attributes=[
-                EntityAttribute(name="Project", url="project_landing_url"),
-                EntityAttribute(name="Version"),
+                *PROJECT_ATTRIBUTES,
                 EntityAttribute(name="Latest", key="is_latest", type=EntityAttributeType.BOOLEAN),
                 EntityAttribute(name="Last BOM import", type=EntityAttributeType.DATETIME),
                 EntityAttribute(name="Last BOM analysis", type=EntityAttributeType.DATETIME),

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -21,6 +21,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Added
 
 - When measuring pipeline duration with GitLab as source, allow for measuring the latest pipeline in the set of pipelines that match the filter criteria instead of the slowest. Closes [#11860](https://github.com/ICTU/quality-time/issues/11860).
+- When measuring dependencies or security warnings with Dependency-Track as source, also show the project version in the measurement details. Closes [#11895](https://github.com/ICTU/quality-time/issues/11895).
 
 ### Changed
 


### PR DESCRIPTION
When measuring dependencies or security warnings with Dependency-Track as source, also show the project version in the measurement details.

Closes #11895.