### PR TITLE
Average GitLab pipeline duration

### DIFF
--- a/components/collector/src/source_collectors/gitlab/pipeline_duration.py
+++ b/components/collector/src/source_collectors/gitlab/pipeline_duration.py
@@ -12,10 +12,21 @@ class GitLabPipelineDuration(GitLabPipelineBase):
 
     async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Parse the value from the responses."""
-        if durations := [int(entity["duration"]) for entity in included_entities]:
-            if self._parameter("pipeline_selection") == "slowest":
-                return str(max(durations))
-            included_entities.sort(key=lambda entity: entity["updated"] or entity["created"])
-            return str(included_entities[-1]["duration"])
-        error_message = "No pipelines found within the lookback period"
-        raise CollectorError(error_message)
+        if not included_entities:
+            error_message = "No pipelines found within the lookback period"
+            raise CollectorError(error_message)
+        match self._parameter("pipeline_selection"):
+            case "slowest":
+                return str(max(self._durations(included_entities)))
+            case "latest":
+                included_entities.sort(key=lambda entity: entity["updated"] or entity["created"])
+                return str(included_entities[-1]["duration"])
+            case "average":
+                return str(round(sum(self._durations(included_entities)) / len(included_entities)))
+            case _:  # pragma: no cover
+                error_message = "Invalid value for the pipeline selection parameter"
+                raise CollectorError(error_message)
+
+    def _durations(self, entities: Entities) -> list[int]:
+        """Return the pipeline durations of the entities."""
+        return [int(entity["duration"]) for entity in entities]

--- a/components/shared_code/src/shared_data_model/sources/gitlab.py
+++ b/components/shared_code/src/shared_data_model/sources/gitlab.py
@@ -267,9 +267,9 @@ profile/personal_access_tokens.html) with the scope `read_repository` in the pri
             metrics=["pipeline_duration", "source_up_to_dateness"],
         ),
         "pipeline_selection": SingleChoiceParameter(
-            name="Pipeline to select",
-            help="Which pipeline to select from the set of pipelines that match the filter criteria?",
-            values=["latest", "slowest"],
+            name="Pipeline selection",
+            help="Which pipeline(s) to select from the set of pipelines that match the filter criteria?",
+            values=["average", "latest", "slowest"],
             default_value="slowest",
             metrics=["pipeline_duration"],
         ),

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -20,7 +20,8 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ### Added
 
-- When measuring pipeline duration with GitLab as source, allow for measuring the latest pipeline in the set of pipelines that match the filter criteria instead of the slowest. Closes [#11860](https://github.com/ICTU/quality-time/issues/11860).
+- When measuring pipeline duration with GitLab as source, in addition to the duration of the slowest pipeline, allow for reporting the duration of the latest pipeline. Closes [#11860](https://github.com/ICTU/quality-time/issues/11860).
+- When measuring pipeline duration with GitLab as source, in addition to the duration of the slowest pipeline, allow for reporting the average duration of the selected pipelines. Closes [#11894](https://github.com/ICTU/quality-time/issues/11894).
 - When measuring dependencies or security warnings with Dependency-Track as source, also show the project version in the measurement details. Closes [#11895](https://github.com/ICTU/quality-time/issues/11895).
 
 ### Changed


### PR DESCRIPTION
When measuring pipeline duration with GitLab as source, allow for reporting the average duration of the selected pipelines.

Closes #11894.