### PR TITLE
When copying a metric also copy entity status

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,12 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- When copying a metric, also copy the status of the metric's measurement details. Fixes [#7403](https://github.com/ICTU/quality-time/issues/7403).
+
 ## v5.41.0 - 2025-09-05
 
 ### Fixed

--- a/tests/feature_tests/src/features/measurement_entities.feature
+++ b/tests/feature_tests/src/features/measurement_entities.feature
@@ -94,3 +94,14 @@ Feature: measurement entities
     When the client sets the status of entity 1 to "confirmed"
     And the client waits a second
     Then the metric status is "target_met"
+
+  Scenario: copy a metric with an entity that is false positive
+    Given an existing metric with type "user_story_points"
+    And an existing source with type "azure_devops"
+    When the collector measures "120"
+      | key | story_points |
+      | 1   | 100          |
+      | 2   | 20           |
+    And the client sets the status of entity 1 to "false_positive"
+    And the client copies the metric
+    Then the metric status is "target_not_met"


### PR DESCRIPTION
When copying a metric also copy the status of measurement entities.

Fixes #7403.