### PR TITLE
Add a 'compliance' metric

### DIFF
--- a/components/frontend/src/fields/TextField.jsx
+++ b/components/frontend/src/fields/TextField.jsx
@@ -42,7 +42,14 @@ export function TextField({
     const startInputAdornment = startAdornment ? (
         <InputAdornment position="start">{startAdornment}</InputAdornment>
     ) : null
-    const endInputAdornment = endAdornment ? <InputAdornment position="end">{endAdornment}</InputAdornment> : null
+    const endInputAdornment = endAdornment ? (
+        <InputAdornment
+            position="end"
+            sx={{ marginTop: "16px" }} // Adjust margin to vertically align the unit with the input field
+        >
+            {endAdornment}
+        </InputAdornment>
+    ) : null
     return (
         <MUITextField
             defaultValue={textValue ?? ""}

--- a/components/shared_code/src/shared_data_model/meta/unit.py
+++ b/components/shared_code/src/shared_data_model/meta/unit.py
@@ -11,6 +11,7 @@ class Unit(StrEnum):
     CI_JOBS = "CI-jobs"
     CI_JOB_RUNS = "CI-job runs"
     COMPLEX_UNITS = "complex units"
+    COMPLIANCE = "compliance"
     DAYS = "days"
     DEPENDENCIES = "dependencies"
     DOWNVOTES = "downvotes"

--- a/components/shared_code/src/shared_data_model/metrics.py
+++ b/components/shared_code/src/shared_data_model/metrics.py
@@ -79,6 +79,17 @@ number of deployments (denominator). Azure DevOps needs to be added as source on
         sources=["manual_number", "sonarqube"],
         tags=[Tag.MAINTAINABILITY, Tag.TESTABILITY],
     ),
+    "compliance": Metric(
+        name="Compliance",
+        description="Keep track of compliance against standards or regulations.",
+        rationale="Measure compliance to report progress and keep track of improvement actions.",
+        direction=Direction.MORE_IS_BETTER,
+        scales=["percentage"],
+        unit=Unit.COMPLIANCE,
+        sources=["manual_number"],
+        target="100",
+        near_target="80",
+    ),
     "dependencies": Metric(
         name="Dependencies",
         description="The number of (outdated) dependencies.",

--- a/components/shared_code/src/shared_data_model/sources/manual_number.py
+++ b/components/shared_code/src/shared_data_model/sources/manual_number.py
@@ -23,6 +23,7 @@ source.""",
             metrics=[
                 "commented_out_code",
                 "complex_units",
+                "compliance",
                 "dependencies",
                 "duplicated_lines",
                 "failed_jobs",

--- a/components/shared_code/src/shared_data_model/sources/quality_time.py
+++ b/components/shared_code/src/shared_data_model/sources/quality_time.py
@@ -26,6 +26,7 @@ ALL_METRICS = {
     "CI-pipeline duration": "pipeline_duration",
     "Commented out code": "commented_out_code",
     "Complex units": "complex_units",
+    "Compliance": "compliance",
     "Dependencies": "dependencies",
     "Duplicated lines": "duplicated_lines",
     "Failed CI-jobs": "failed_jobs",

--- a/components/shared_code/src/shared_data_model/subjects.py
+++ b/components/shared_code/src/shared_data_model/subjects.py
@@ -28,6 +28,7 @@ SUBJECTS = {
                 ],
             ),
         },
+        metrics=["compliance"],
     ),
     "process": Subject(
         name="Process",
@@ -75,14 +76,12 @@ SUBJECTS = {
                 ],
             ),
         },
-        metrics=[
-            "time_remaining",
-        ],
+        metrics=["compliance", "time_remaining"],
     ),
     "report": Subject(
         name="Quality report",
         description="A software quality report.",
-        metrics=["metrics", "missing_metrics"],
+        metrics=["compliance", "metrics", "missing_metrics"],
     ),
     "software": Subject(
         name="Software",
@@ -130,14 +129,11 @@ SUBJECTS = {
                 ],
             ),
         },
-        metrics=[
-            "slow_transactions",
-            "performancetest_stability",
-        ],
+        metrics=["compliance", "slow_transactions", "performancetest_stability"],
     ),
     "team": Subject(
         name="Team",
         description="A team developing, maintaining and/or operating custom software.",
-        metrics=["sentiment", "velocity"],
+        metrics=["compliance", "sentiment", "velocity"],
     ),
 }

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - When copying a metric, also copy the status, status end date, and status rationale of the measurement entities. Fixes [#7403](https://github.com/ICTU/quality-time/issues/7403).
 
+### Added
+
+- Add a 'compliance' metric to track compliance to standards or regulations. Manual number is the only supported source at the moment. Closes [#11824](https://github.com/ICTU/quality-time/issues/11824).
+
 ## v5.41.0 - 2025-09-05
 
 ### Fixed


### PR DESCRIPTION
Add a 'compliance' metric to track compliance to standards or regulations. Manual number is the only supported source at the moment.

Closes #11824.