### PR TITLE
Fix sources with default name in report sources

### DIFF
--- a/components/frontend/src/report/ReportSources.jsx
+++ b/components/frontend/src/report/ReportSources.jsx
@@ -54,7 +54,7 @@ SourceParameters.propTypes = {
 
 export function ReportSources({ reload, report, settings }) {
     const dataModel = useContext(DataModel)
-    const sources = reportSources(report)
+    const sources = reportSources(dataModel, report)
     if (sources.length === 0) {
         return <InfoMessage title="No sources">No sources have been configured yet.</InfoMessage>
     }

--- a/components/frontend/src/report/ReportSources.test.jsx
+++ b/components/frontend/src/report/ReportSources.test.jsx
@@ -135,6 +135,33 @@ it("shows the default source name if the source doesn't have an own name", async
     await expectNoAccessibilityViolations(container)
 })
 
+it("considers a source without name the same as a source that has a name equal to the default name", async () => {
+    const { container } = renderReportSources({
+        subjects: {
+            subject_uuid: {
+                metrics: {
+                    metric_uuid1: {
+                        sources: {
+                            source_uuid1: { type: "source_type", parameters: { url: "https://sonarqube.org" } },
+                        },
+                    },
+                    metric_uuid2: {
+                        sources: {
+                            source_uuid2: {
+                                type: "source_type",
+                                name: "Source type name",
+                                parameters: { url: "https://sonarqube.org" },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    })
+    expect(screen.getAllByText("Source type name").length).toBe(2) // Source type and source name are equal
+    await expectNoAccessibilityViolations(container)
+})
+
 it("changes the value of a parameter of a source without parameter layout", async () => {
     const { container } = renderReportSources(
         {

--- a/components/frontend/src/report/report_utils.jsx
+++ b/components/frontend/src/report/report_utils.jsx
@@ -11,7 +11,7 @@ import {
     reportsPropType,
     settingsPropType,
 } from "../sharedPropTypes"
-import { addCounts, getMetricScale, getMetricTags, visibleMetrics } from "../utils"
+import { addCounts, getMetricScale, getMetricTags, getSourceName, visibleMetrics } from "../utils"
 
 export function measurementOnDate(date, measurements, metricUuid) {
     const isoDateString = date.toISOString().split("T")[0]
@@ -97,14 +97,14 @@ summarizeReportsOnDate.propTypes = {
     tag: string,
 }
 
-export function reportSources(report) {
+export function reportSources(dataModel, report) {
     const sourceIds = new Set()
     const sources = {}
     Object.values(report.subjects ?? {}).forEach((subject) => {
         Object.values(subject.metrics ?? {}).forEach((metric) => {
             Object.entries(metric.sources ?? {}).forEach(([sourceUuid, source]) => {
                 const reportSource = {
-                    name: source.name ?? "",
+                    name: getSourceName(source, dataModel),
                     type: source.type,
                     url: source.parameters?.url ?? "",
                     landing_url: source.parameters?.landing_url ?? "",
@@ -130,5 +130,6 @@ export function reportSources(report) {
     return sortedSources
 }
 reportSources.propTypes = {
+    dataModel: dataModelPropType,
     report: reportPropType,
 }

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - When copying a metric, also copy the status, status end date, and status rationale of the measurement entities. Fixes [#7403](https://github.com/ICTU/quality-time/issues/7403).
 - Jira sources with only the API-version different would be considered equal in the report source overview. Fixes [#11986](https://github.com/ICTU/quality-time/issues/11986).
+- In the report source overview, don't consider sources different if one has no name (so the default name is used) and the other has a name equal to the default name. Fixes [#11987](https://github.com/ICTU/quality-time/issues/11987).
 
 ### Added
 


### PR DESCRIPTION
In the report source overview, don't consider sources different if one has no name (so the default name is used) and the other has a name equal to the default name.

Fixes #11987.