### PR TITLE
Fix failed jobs measurement details column header

### DIFF
--- a/components/shared_code/src/shared_data_model/sources/gitlab.py
+++ b/components/shared_code/src/shared_data_model/sources/gitlab.py
@@ -35,12 +35,16 @@ ALL_GITLAB_METRICS = [
     "unused_jobs",
 ]
 
+JOB_ENTITY_ATTRIBUTES = [
+    EntityAttribute(name="Job name", key="name", url="url"),
+    EntityAttribute(name="Job stage", key="stage"),
+    EntityAttribute(name="Branch or tag", key="branch"),
+]
+
 JOB_ENTITY = Entity(
     name="job",
     attributes=[
-        EntityAttribute(name="Job name", key="name", url="url"),
-        EntityAttribute(name="Job stage", key="stage"),
-        EntityAttribute(name="Branch or tag", key="branch"),
+        *JOB_ENTITY_ATTRIBUTES,
         EntityAttribute(
             name="Result of most recent build",
             key="build_result",
@@ -287,7 +291,24 @@ profile/personal_access_tokens.html) with the scope `read_repository` in the pri
                 EntityAttribute(name="Date of most recent build", key="build_date", type=EntityAttributeType.DATE),
             ],
         ),
-        "failed_jobs": JOB_ENTITY,
+        "failed_jobs": Entity(
+            name="job",
+            attributes=[
+                *JOB_ENTITY_ATTRIBUTES,
+                EntityAttribute(
+                    name="Result of most recent failed build",
+                    key="build_result",
+                    color={
+                        "canceled": Color.ACTIVE,
+                        "failed": Color.NEGATIVE,
+                        "skipped": Color.WARNING,
+                    },
+                ),
+                EntityAttribute(
+                    name="Date of most recent failed build", key="build_date", type=EntityAttributeType.DATE
+                ),
+            ],
+        ),
         "job_runs_within_time_period": JOB_ENTITY,
         "merge_requests": Entity(
             name="merge request",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Fixed
 
 - When copying a metric, also copy the status, status end date, and status rationale of the measurement entities. Fixes [#7403](https://github.com/ICTU/quality-time/issues/7403).
+- When measuring failed jobs with GitLab as source, the measurement details show the failed jobs including the date of the most recent failed build. However, the column header would read "Date of most recent build", which would be incorrect if there have been successful builds after the failed build. Column header now reads "Date of most recent failed build". Fixes [#11973](https://github.com/ICTU/quality-time/issues/11973).
 - Jira sources with only the API-version different would be considered equal in the report source overview. Fixes [#11986](https://github.com/ICTU/quality-time/issues/11986).
 - In the report source overview, don't consider sources different if one has no name (so the default name is used) and the other has a name equal to the default name. Fixes [#11987](https://github.com/ICTU/quality-time/issues/11987).
 


### PR DESCRIPTION
When measuring failed jobs with GitLab as source, the measurement details show the failed jobs including the date of the most recent failed build. However, the column header would read "Date of most recent build", which would be incorrect if there have been successful builds after the failed build. Column header now reads "Date of most recent failed build".

Fixes #11973.