### PR TITLE
Add warning to documentaton about GitLab artifacts

### DIFF
--- a/components/shared_code/src/shared_data_model/sources/gitlab.py
+++ b/components/shared_code/src/shared_data_model/sources/gitlab.py
@@ -89,8 +89,7 @@ GitLab. In that case, you still use the JUnit (or JaCoCo, or Axe...) source, but
 Depending on where the document is stored in GitLab, there are two scenarios; the source is a build artifact of a GitLab
 CI pipeline, or the source is stored in a GitLab repository:
 
-1. When the metric source is a build artifact of a GitLab CI pipeline, use [URLs of the following format](https://docs.\
-gitlab.com/ee/api/job_artifacts.html#download-a-single-artifact-file-from-specific-tag-or-branch):
+1. When the metric source is a build artifact of a GitLab CI pipeline, use [URLs of the following format](https://docs.gitlab.com/api/job_artifacts/#download-a-single-artifact-file-by-reference-name):
 
     `https://<gitlab-server>/api/v4/projects/<project-id>/jobs/artifacts/<branch>/raw/<path>/<to>/<file-name>?\
 job=<job-name>`
@@ -100,6 +99,13 @@ job=<job-name>`
 
     If the repository is private, you also need to enter an [personal access token](https://docs.gitlab.com/ee/user/\
 profile/personal_access_tokens.html) with the scope `read_api` in the private token field.
+
+    ```{warning}
+    Artifacts can only be downloaded from a
+    [completed pipeline with status `success`](https://docs.gitlab.com/api/job_artifacts/#download-a-single-artifact-file-by-reference-name).
+    Consider setting `allow_failure: true` on
+    [test jobs](https://docs.gitlab.com/ci/quick_start/tutorial/#add-test-jobs) in the pipeline.
+    ```
 
 2.  When the metric source is a file stored in a GitLab repository, use [URLs of the following format](https://docs.\
 gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository):

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - When copying a metric, also copy the status, status end date, and status rationale of the measurement entities. Fixes [#7403](https://github.com/ICTU/quality-time/issues/7403).
 - When measuring failed jobs with GitLab as source, the measurement details show the failed jobs including the date of the most recent failed build. However, the column header would read "Date of most recent build", which would be incorrect if there have been successful builds after the failed build. Column header now reads "Date of most recent failed build". Fixes [#11973](https://github.com/ICTU/quality-time/issues/11973).
+- Add a warning to the reference manual about GitLab not downloading artifacts from unsuccessful pipelines. Fixes [#11976](https://github.com/ICTU/quality-time/issues/11976).
 - Jira sources with only the API-version different would be considered equal in the report source overview. Fixes [#11986](https://github.com/ICTU/quality-time/issues/11986).
 - In the report source overview, don't consider sources different if one has no name (so the default name is used) and the other has a name equal to the default name. Fixes [#11987](https://github.com/ICTU/quality-time/issues/11987).
 


### PR DESCRIPTION
Add a warning to the reference manual about GitLab not downloading artifacts from unsuccessful pipelines.

Fixes #11976.