### PR TITLE
Make Dependency-Track landing URL mandatory

### DIFF
--- a/components/collector/tests/source_collectors/dependency_track/base_test.py
+++ b/components/collector/tests/source_collectors/dependency_track/base_test.py
@@ -6,9 +6,15 @@ from tests.source_collectors.source_collector_test_case import SourceCollectorTe
 
 
 class DependencyTrackTestCase(SourceCollectorTestCase):
-    """Base class for Dependency-Track collector Unit tests."""
+    """Base class for Dependency-Track collector unit tests."""
 
     SOURCE_TYPE = "dependency_track"
+
+    def setUp(self) -> None:
+        """Extend to add the mandatory landing URL."""
+        super().setUp()
+        self.landing_url = f"https://{self.SOURCE_TYPE}/landing"
+        self.sources["source_id"]["parameters"]["landing_url"] = self.landing_url  # type: ignore[index]
 
     def projects(self, version: str = "1.4") -> list[DependencyTrackProject]:
         """Create the Dependency-Track projects fixture."""

--- a/components/collector/tests/source_collectors/dependency_track/test_dependencies.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_dependencies.py
@@ -27,12 +27,12 @@ class DependencyTrackDependenciesTest(DependencyTrackTestCase):
         return [
             {
                 "component": "component name",
-                "component_landing_url": "/components/component-uuid",
+                "component_landing_url": f"{self.landing_url}/components/component-uuid",
                 "key": "component-uuid",
                 "latest": latest_version,
                 "latest_version_status": latest_version_status,
                 "project": "project name",
-                "project_landing_url": "/projects/project uuid",
+                "project_landing_url": f"{self.landing_url}/projects/project uuid",
                 "project_version": "1.4",
                 "version": "1.0",
             },

--- a/components/collector/tests/source_collectors/dependency_track/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_security_warnings.py
@@ -42,14 +42,14 @@ class DependencyTrackSecurityWarningsTest(DependencyTrackTestCase):
         return [
             {
                 "component": "component name",
-                "component_landing_url": "/components/component-uuid",
+                "component_landing_url": f"{self.landing_url}/components/component-uuid",
                 "description": "vulnerability description",
                 "identifier": "CVE-123",
                 "key": "matrix",
                 "latest": "2",
                 "latest_version_status": "update possible",
                 "project": "project name",
-                "project_landing_url": "/projects/project uuid",
+                "project_landing_url": f"{self.landing_url}/projects/project uuid",
                 "project_version": "1.4",
                 "severity": "Unassigned",
                 "version": "1",

--- a/components/collector/tests/source_collectors/dependency_track/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_source_up_to_dateness.py
@@ -15,7 +15,6 @@ class DependencyTrackSourceUpToDatenessVersionTest(DependencyTrackTestCase):
 
     METRIC_ADDITION = "min"
     METRIC_TYPE = "source_up_to_dateness"
-    LANDING_URL = "https://dependency_track"
 
     def projects(self, version: str = "1.4") -> list[DependencyTrackProject]:
         """Create Dependency-Track projects fixture."""
@@ -56,7 +55,7 @@ class DependencyTrackSourceUpToDatenessVersionTest(DependencyTrackTestCase):
                 "last_bom_import": self.yesterday.isoformat(),
                 "is_latest": "true",
                 "project": "Project 1",
-                "project_landing_url": "/projects/p1",
+                "project_landing_url": f"{self.landing_url}/projects/p1",
                 "project_version": "1.1",
                 "up_to_date": "yes",
             },
@@ -66,7 +65,7 @@ class DependencyTrackSourceUpToDatenessVersionTest(DependencyTrackTestCase):
                 "last_bom_analysis": self.day_before_yesterday.isoformat(),
                 "last_bom_import": self.last_week.isoformat(),
                 "project": "Project 2",
-                "project_landing_url": "/projects/p2",
+                "project_landing_url": f"{self.landing_url}/projects/p2",
                 "project_version": "1.2",
                 "up_to_date": "nearly",
             },
@@ -75,7 +74,7 @@ class DependencyTrackSourceUpToDatenessVersionTest(DependencyTrackTestCase):
     async def test_source_up_to_dateness(self):
         """Test that the source up-to-dateness can be measured."""
         response = await self.collect(get_request_json_return_value=self.projects())
-        self.assert_measurement(response, value="7", landing_url=self.LANDING_URL, entities=self.entities())
+        self.assert_measurement(response, value="7", landing_url=self.landing_url, entities=self.entities())
 
     async def test_source_up_to_dateness_missing_bom_analysis(self):
         """Test that the source up-to-dateness can be measured even if the BOM has no last analysis datetime."""
@@ -98,13 +97,13 @@ class DependencyTrackSourceUpToDatenessVersionTest(DependencyTrackTestCase):
                 "last_bom_import": self.last_week.isoformat(),
                 "is_latest": "true",
                 "project": "Project 3",
-                "project_landing_url": "/projects/p3",
+                "project_landing_url": f"{self.landing_url}/projects/p3",
                 "project_version": "1.3",
                 "up_to_date": "nearly",
             }
         )
         response = await self.collect(get_request_json_return_value=projects)
-        self.assert_measurement(response, value="7", landing_url=self.LANDING_URL, entities=entities)
+        self.assert_measurement(response, value="7", landing_url=self.landing_url, entities=entities)
 
     async def test_source_up_to_dateness_missing_bom_import(self):
         """Test that the source up-to-dateness can be measured even if the BOM has no import datetime."""
@@ -124,13 +123,13 @@ class DependencyTrackSourceUpToDatenessVersionTest(DependencyTrackTestCase):
                 "last_bom_import": "",
                 "is_latest": "false",
                 "project": "Project 3",
-                "project_landing_url": "/projects/p3",
+                "project_landing_url": f"{self.landing_url}/projects/p3",
                 "project_version": "1.3",
                 "up_to_date": "unknown",
             }
         )
         response = await self.collect(get_request_json_return_value=projects)
-        self.assert_measurement(response, value="7", landing_url=self.LANDING_URL, entities=entities)
+        self.assert_measurement(response, value="7", landing_url=self.landing_url, entities=entities)
 
     async def test_filter_by_project_name(self):
         """Test that projects can be filtered by name."""
@@ -142,13 +141,13 @@ class DependencyTrackSourceUpToDatenessVersionTest(DependencyTrackTestCase):
         """Test that projects can be filtered by regular expression."""
         self.set_source_parameter("project_names", ["Project .*"])
         response = await self.collect(get_request_json_return_value=self.projects())
-        self.assert_measurement(response, value="7", landing_url=self.LANDING_URL, entities=self.entities())
+        self.assert_measurement(response, value="7", landing_url=self.landing_url, entities=self.entities())
 
     async def test_filter_by_project_version(self):
         """Test filtering projects by version."""
         self.set_source_parameter("project_versions", ["1.2", "1.3"])
         response = await self.collect(get_request_json_return_value=self.projects())
-        self.assert_measurement(response, value="7", landing_url=self.LANDING_URL, entities=self.entities()[1:])
+        self.assert_measurement(response, value="7", landing_url=self.landing_url, entities=self.entities()[1:])
 
     async def test_filter_by_project_name_and_version(self):
         """Test filtering projects by name and version."""
@@ -161,7 +160,7 @@ class DependencyTrackSourceUpToDatenessVersionTest(DependencyTrackTestCase):
         """Test that projects can be filtered by event type."""
         self.set_source_parameter("project_event_types", ["last BOM import"])
         response = await self.collect(get_request_json_return_value=self.projects())
-        self.assert_measurement(response, value="7", landing_url=self.LANDING_URL, entities=self.entities())
+        self.assert_measurement(response, value="7", landing_url=self.landing_url, entities=self.entities())
 
     async def test_filter_by_event_type_last_bom_analysis(self):
         """Test that projects can be filtered by event type."""
@@ -170,20 +169,20 @@ class DependencyTrackSourceUpToDatenessVersionTest(DependencyTrackTestCase):
         entities = self.entities()
         entities[0]["up_to_date"] = "nearly"
         entities[1]["up_to_date"] = "yes"
-        self.assert_measurement(response, value="4", landing_url=self.LANDING_URL, entities=entities)
+        self.assert_measurement(response, value="4", landing_url=self.landing_url, entities=entities)
 
     async def test_filter_by_latest_project(self):
         """Test that projects can be filtered by being the latest project version."""
         self.set_source_parameter("only_include_latest_project_versions", "yes")
         response = await self.collect(get_request_json_return_value=self.projects())
-        self.assert_measurement(response, value="1", landing_url=self.LANDING_URL, entities=self.entities()[:1])
+        self.assert_measurement(response, value="1", landing_url=self.landing_url, entities=self.entities()[:1])
 
     async def test_source_up_to_dateness_with_pagination(self):
         """Test that the source up-to-dateness can be measured when pagination is needed."""
         default_size = DependencyTrackBase.PAGE_SIZE
         DependencyTrackBase.PAGE_SIZE = 1
         response = await self.collect(get_request_json_return_value=self.projects())
-        self.assert_measurement(response, value="7", landing_url=self.LANDING_URL, entities=self.entities())
+        self.assert_measurement(response, value="7", landing_url=self.landing_url, entities=self.entities())
         DependencyTrackBase.PAGE_SIZE = default_size
 
     async def test_source_up_to_dateness_with_reversed_direction(self):
@@ -193,4 +192,4 @@ class DependencyTrackSourceUpToDatenessVersionTest(DependencyTrackTestCase):
         entities = self.entities()
         entities[0]["up_to_date"] = "no"
         entities[1]["up_to_date"] = "yes"
-        self.assert_measurement(response, value="1", landing_url=self.LANDING_URL, entities=entities)
+        self.assert_measurement(response, value="1", landing_url=self.landing_url, entities=entities)

--- a/components/collector/tests/source_collectors/dependency_track/test_source_version.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_source_version.py
@@ -12,4 +12,4 @@ class DependencyTrackSourceVersionTest(DependencyTrackTestCase):
     async def test_source_version(self):
         """Test that the source version can be measured."""
         response = await self.collect(get_request_json_return_value={"version": "4.8.2"})
-        self.assert_measurement(response, value="4.8.2", landing_url="https://dependency_track")
+        self.assert_measurement(response, value="4.8.2", landing_url=self.landing_url)

--- a/components/frontend/src/fields/TextField.jsx
+++ b/components/frontend/src/fields/TextField.jsx
@@ -54,7 +54,7 @@ export function TextField({
         <MUITextField
             defaultValue={textValue ?? ""}
             disabled={disabled || (select && children.length === 0)}
-            error={error}
+            error={error || (required && !textValue)}
             fullWidth
             helperText={helperText}
             id={id}

--- a/components/frontend/src/source/SourceParameters.test.jsx
+++ b/components/frontend/src/source/SourceParameters.test.jsx
@@ -5,10 +5,12 @@ import { expectNoAccessibilityViolations } from "../testUtils"
 import { SourceParameters } from "./SourceParameters"
 
 function renderSourceParameters({
+    changedParamKeys = [],
+    defaultValue = "Default value",
+    mandatory = false,
     placeholder = "",
     type = "string",
     sourceParameterValue = null,
-    changedParamKeys = [],
 }) {
     return render(
         <DataModel.Provider
@@ -18,18 +20,19 @@ function renderSourceParameters({
                     source_type: {
                         parameters: {
                             parameter_key: {
-                                default_value: "Default value",
+                                default_value: defaultValue,
+                                mandatory: mandatory,
+                                metrics: ["violations"],
+                                name: "Parameter",
                                 placeholder: placeholder,
                                 type: type,
-                                name: "Parameter",
-                                metrics: ["violations"],
                             },
                             other_parameter_key: {
                                 default_value: "Other parameter default",
+                                metrics: ["violations"],
+                                name: "Other parameter",
                                 placeholder: "Other parameter placeholder",
                                 type: type,
-                                name: "Other parameter",
-                                metrics: ["violations"],
                             },
                         },
                         parameter_layout: {
@@ -80,6 +83,18 @@ it("renders a default value if the source parameter has no value", async () => {
 it("renders the source parameter value", async () => {
     const { container } = renderSourceParameters({ sourceParameterValue: "Value" })
     expect(screen.queryAllByDisplayValue(/Value/).length).toBe(1)
+    await expectNoAccessibilityViolations(container)
+})
+
+it("does not render a warning if a mandatory parameter has a value", async () => {
+    const { container } = renderSourceParameters({ defaultValue: "Value", mandatory: true })
+    expect(screen.getByDisplayValue(/Value/)).toBeValid()
+    await expectNoAccessibilityViolations(container)
+})
+
+it("renders a warning if a mandatory parameter has no value", async () => {
+    const { container } = renderSourceParameters({ defaultValue: "", placeholder: "Placeholder", mandatory: true })
+    expect(screen.getByPlaceholderText(/Placeholder/)).toBeInvalid()
     await expectNoAccessibilityViolations(container)
 })
 

--- a/components/shared_code/src/shared_data_model/sources/dependency_track.py
+++ b/components/shared_code/src/shared_data_model/sources/dependency_track.py
@@ -53,8 +53,8 @@ DEPENDENCY_TRACK = Source(
         "landing_url": LandingURL(
             name="URL of the Dependency-Track instance",
             help="URL of the Dependency-Track instance, with port if necessary, but without path. For example, "
-            "'https://www.dependencytrack.example.org'. If provided, users clicking the source URL will visit this URL "
-            "instead of the Dependency-Track API.",
+            "'https://www.dependencytrack.example.org'.",
+            mandatory=True,
             metrics=ALL_DEPENDENCY_TRACK_METRICS,
         ),
         "private_token": PrivateToken(

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Fixed
 
 - Small improvements to the documentation about importing reports. Fixes [#12013](https://github.com/ICTU/quality-time/issues/12013).
+- Make the landing URL of Dependency-Track sources mandatory, since without it Quality-time sends users to the Dependency-Track API. Fixes [#11896](https://github.com/ICTU/quality-time/issues/11896).
 
 ## v5.42.0 - 2025-09-18
 


### PR DESCRIPTION
Make the landing URL of Dependency-Track sources mandatory, since without it Quality-time sends users to the Dependency-Track API.

Fixes #11896.