### PR TITLE
Fix links from Quality-time to Read-the-Docs

### DIFF
--- a/components/frontend/src/metric/MetricType.jsx
+++ b/components/frontend/src/metric/MetricType.jsx
@@ -60,7 +60,7 @@ export function MetricType({ subjectType, metricType, metricUuid, reload }) {
             disabled={disabled}
             helperText={
                 <>
-                    <ReadTheDocsLink url={referenceDocumentationURL(metricType)} />
+                    <ReadTheDocsLink url={referenceDocumentationURL(dataModel.metrics[metricType].name)} />
                     {howToConfigure}
                 </>
             }

--- a/components/frontend/src/metric/MetricType.test.jsx
+++ b/components/frontend/src/metric/MetricType.test.jsx
@@ -37,6 +37,9 @@ const dataModel = {
             default_scale: "count",
             scales: ["count"],
         },
+        failed_jobs: {
+            name: "Failed CI-jobs",
+        },
     },
 }
 
@@ -80,5 +83,12 @@ it("shows the metric type read the docs URL", async () => {
 it("shows the metric type has extra documentation", async () => {
     const { container } = renderMetricType("source_version")
     expect(screen.queryAllByText(/for additional information on how to configure this metric type/).length).toBe(1)
+    await expectNoAccessibilityViolations(container)
+})
+
+it("uses the name of the metric type for the documentation link", async () => {
+    const { container } = renderMetricType("failed_jobs")
+    const readTheDocsLink = screen.getByRole("link", { name: "Read the Docs" })
+    expect(readTheDocsLink).toHaveAttribute("href", expect.stringContaining("#failed-ci-jobs"))
     await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/source/Source.jsx
+++ b/components/frontend/src/source/Source.jsx
@@ -164,11 +164,17 @@ export function Source({
             <ul>
                 <li>
                     Change the type of the metric (back) to a type that is supported by{" "}
-                    <HyperLink url={referenceDocumentationURL(sourceName)}>{sourceName}</HyperLink>.
+                    <HyperLink url={referenceDocumentationURL(dataModel.metrics[metric.type].name)}>
+                        {sourceName}
+                    </HyperLink>
+                    .
                 </li>
                 <li>
                     Change the type of this source to a type that supports{" "}
-                    <HyperLink url={referenceDocumentationURL(metricName)}>{metricName}</HyperLink>.
+                    <HyperLink url={referenceDocumentationURL(dataModel.sources[source.type].name)}>
+                        {metricName}
+                    </HyperLink>
+                    .
                 </li>
                 <li>Move this source to another metric.</li>
                 <li>Remove this source altogether.</li>

--- a/components/frontend/src/source/Source.test.jsx
+++ b/components/frontend/src/source/Source.test.jsx
@@ -19,8 +19,8 @@ afterEach(() => vi.clearAllMocks())
 
 const dataModel = {
     metrics: {
-        metric_type: { sources: ["source_type1", "source_type2"] },
-        unsupported_metric: { sources: [] },
+        metric_type: { name: "Metric type 1", sources: ["source_type1", "source_type2"] },
+        unsupported_metric: { name: "Metric type 2", sources: [] },
     },
     sources: {
         source_type1: { name: "Source type 1", parameters: {} },

--- a/components/frontend/src/source/SourceType.jsx
+++ b/components/frontend/src/source/SourceType.jsx
@@ -84,7 +84,7 @@ export function SourceType({ metricType, setSourceAttribute, sourceType }) {
             disabled={disabled}
             helperText={
                 <>
-                    <ReadTheDocsLink url={referenceDocumentationURL(sourceType)} />
+                    <ReadTheDocsLink url={referenceDocumentationURL(dataModel.sources[sourceType].name)} />
                     {howToConfigure}
                 </>
             }

--- a/components/frontend/src/source/SourceType.test.jsx
+++ b/components/frontend/src/source/SourceType.test.jsx
@@ -15,7 +15,7 @@ beforeEach(() => {
 const dataModel = {
     metrics: {
         violations: {
-            sources: ["sonarqube", "gitlab"],
+            sources: ["sonarqube", "gitlab", "source_type"],
             unit: "violations",
             direction: "<",
             name: "Violations",
@@ -36,6 +36,9 @@ const dataModel = {
         },
         unsupported: {
             name: "Unsupported",
+        },
+        source_type: {
+            name: "Name differs from key",
         },
     },
 }
@@ -100,5 +103,12 @@ it("shows that the source type has extra generic documentation", async () => {
 it("shows that the source type has extra metric-specific documentation", async () => {
     const { container } = await renderSourceType("violations", "sonarqube")
     expect(screen.getAllByText(/additional information on how to configure this source type/).length).toBe(1)
+    await expectNoAccessibilityViolations(container)
+})
+
+it("uses the name of the source type for the documentation link", async () => {
+    const { container } = await renderSourceType("violations", "source_type")
+    const readTheDocsLink = screen.getByRole("link", { name: "Read the Docs" })
+    expect(readTheDocsLink).toHaveAttribute("href", expect.stringContaining("#name-differs-from-key"))
     await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/subject/SubjectTitle.test.jsx
+++ b/components/frontend/src/subject/SubjectTitle.test.jsx
@@ -122,3 +122,10 @@ it("deletes the subject", async () => {
     expect(history.location.search).toEqual("")
     await expectNoAccessibilityViolations(container)
 })
+
+it("uses the name of the subject type for the documentation link", async () => {
+    const { container } = await renderSubjectTitle()
+    const readTheDocsLink = screen.getByRole("link", { name: "Read the Docs" })
+    expect(readTheDocsLink).toHaveAttribute("href", expect.stringContaining("#default-subject-type"))
+    await expectNoAccessibilityViolations(container)
+})

--- a/components/frontend/src/subject/SubjectType.jsx
+++ b/components/frontend/src/subject/SubjectType.jsx
@@ -49,18 +49,19 @@ subjectTypes.propTypes = {
 }
 
 export function SubjectType({ subjectType, setValue }) {
+    const dataModel = useContext(DataModel)
     const permissions = useContext(Permissions)
     const disabled = !accessGranted(permissions, [EDIT_REPORT_PERMISSION])
     return (
         <TextField
             disabled={disabled}
-            helperText={<ReadTheDocsLink url={referenceDocumentationURL(subjectType.value)} />}
+            helperText={<ReadTheDocsLink url={referenceDocumentationURL(dataModel.subjects[subjectType].name)} />}
             label="Subject type"
             onChange={(value) => setValue(value)}
             select
             value={subjectType}
         >
-            {subjectTypes(useContext(DataModel).subjects).map((subjectType) => (
+            {subjectTypes(dataModel.subjects).map((subjectType) => (
                 <MenuItem key={subjectType.key} value={subjectType.value}>
                     {subjectType.content}
                 </MenuItem>

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ### Fixed
 
+- Links from Quality-time to the documentation on Read-the-Docs would be incorrect for some sources. Fixes [#11977](https://github.com/ICTU/quality-time/issues/11977).
 - Small improvements to the documentation about importing reports. Fixes [#12013](https://github.com/ICTU/quality-time/issues/12013).
 - Make the landing URL of Dependency-Track sources mandatory, since without it Quality-time sends users to the Dependency-Track API. Fixes [#11896](https://github.com/ICTU/quality-time/issues/11896).
 


### PR DESCRIPTION
Links from Quality-time to the documentation on Read-the-Docs would be incorrect for some sources.

Fixes #11977.