### PR TITLE
Metrics can have an optional secondary name

### DIFF
--- a/components/api_server/tests/routes/test_metric.py
+++ b/components/api_server/tests/routes/test_metric.py
@@ -138,6 +138,20 @@ class PostMetricAttributeTest(PostMetricAttributeTestCase):
             report=updated_report,
         )
 
+    def test_post_metric_secondary_name(self, request):
+        """Test that the metric secondary name can be changed."""
+        request.json = {"secondary_name": "Secondary name"}
+        self.assertEqual({"ok": True}, post_metric_attribute(METRIC_ID, "secondary_name", self.database))
+        updated_report = self.updated_report()
+        self.assertEqual(
+            "Secondary name",
+            updated_report["subjects"][SUBJECT_ID]["metrics"][METRIC_ID]["secondary_name"],
+        )
+        self.assert_delta(
+            "secondary_name of metric 'name' of subject 'Subject' in report 'Report' from '' to 'Secondary name'",
+            report=updated_report,
+        )
+
     @patch("shared.model.measurement.iso_timestamp", new=Mock(return_value="2019-01-01"))
     def test_post_metric_type(self, request):
         """Test that the metric type can be changed and that sources are not removed."""

--- a/components/frontend/src/metric/MetricConfigurationParameters.jsx
+++ b/components/frontend/src/metric/MetricConfigurationParameters.jsx
@@ -55,6 +55,24 @@ MetricName.propTypes = {
     reload: func,
 }
 
+function MetricSecondaryName({ metric, metricUuid, reload }) {
+    const permissions = useContext(Permissions)
+    const disabled = !accessGranted(permissions, [EDIT_REPORT_PERMISSION])
+    return (
+        <TextField
+            disabled={disabled}
+            label="Metric secondary name"
+            onChange={(value) => setMetricAttribute(metricUuid, "secondary_name", value, reload)}
+            value={metric.secondary_name}
+        />
+    )
+}
+MetricSecondaryName.propTypes = {
+    metric: metricPropType,
+    metricUuid: string,
+    reload: func,
+}
+
 function Tags({ metric, metricUuid, reload, report }) {
     const permissions = useContext(Permissions)
     const disabled = !accessGranted(permissions, [EDIT_REPORT_PERMISSION])
@@ -214,7 +232,10 @@ export function MetricConfigurationParameters({ metric, metricUuid, reload, repo
                 />
             </Grid>
             <Grid size={1}>
-                <MetricName {...commonParameterProps} />
+                <Stack spacing={{ xs: 1, sm: 1, md: 1 }}>
+                    <MetricName {...commonParameterProps} />
+                    <MetricSecondaryName {...commonParameterProps} />
+                </Stack>
             </Grid>
             <Grid size={1}>
                 <Tags report={report} {...commonParameterProps} />

--- a/components/frontend/src/metric/MetricConfigurationParameters.test.jsx
+++ b/components/frontend/src/metric/MetricConfigurationParameters.test.jsx
@@ -83,6 +83,13 @@ it("sets the metric name", async () => {
     await expectNoAccessibilityViolations(container)
 })
 
+it("sets the metric secondary name", async () => {
+    const { container } = await renderMetricParameters()
+    await typeInField(/Metric secondary name/, "New metric secondary name")
+    expectMetricAttributePost("secondary_name", "New metric secondary name")
+    await expectNoAccessibilityViolations(container)
+})
+
 it("adds a tag on enter", async () => {
     const { container } = await renderMetricParameters()
     await typeInField(/Metric tags/, "New tag", "Enter")

--- a/components/frontend/src/subject/SubjectTableRow.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.jsx
@@ -1,5 +1,5 @@
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator"
-import { Chip, TableCell, Tooltip, Typography } from "@mui/material"
+import { Chip, Stack, TableCell, Tooltip, Typography } from "@mui/material"
 import { bool, func, number, object, string } from "prop-types"
 import React, { useContext, useRef } from "react"
 
@@ -211,6 +211,23 @@ MeasurementCells.propTypes = {
     settings: settingsPropType,
 }
 
+function MetricName({ metric }) {
+    const dataModel = useContext(DataModel)
+    const name = getMetricName(metric, dataModel)
+    if (metric.secondary_name) {
+        return (
+            <Stack>
+                {name}
+                <Typography sx={{ fontSize: "90%" }}>{metric.secondary_name}</Typography>
+            </Stack>
+        )
+    }
+    return name
+}
+MetricName.propTypes = {
+    metric: metricPropType,
+}
+
 const DragHandleButton = React.forwardRef(function DragHandleButton({ label, ...props }, ref) {
     return (
         <button
@@ -255,7 +272,6 @@ export function SubjectTableRow({
     onDrop,
 }) {
     const dataModel = useContext(DataModel)
-    const metricName = getMetricName(metric, dataModel)
     const scale = getMetricScale(metric, dataModel)
     const unit = getMetricUnit(metric, dataModel)
     const nrDates = dates.length
@@ -302,7 +318,9 @@ export function SubjectTableRow({
             id={metricUuid}
             onExpand={() => settings.expandedItems.toggle(metricUuid)}
         >
-            <TableCell>{metricName}</TableCell>
+            <TableCell>
+                <MetricName metric={metric} />
+            </TableCell>
             {nrDates > 1 && (
                 <MeasurementCells
                     dates={dates}

--- a/components/frontend/src/subject/SubjectTableRow.test.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.test.jsx
@@ -19,6 +19,8 @@ function renderSubjectTableRow({
     evaluateTargets = undefined,
     expanded = false,
     permissions = "",
+    name = "",
+    secondaryName = "",
 } = {}) {
     const dates = [new Date("2024-01-03"), new Date("2024-01-02"), new Date("2024-01-01")]
     const reverseMeasurements = [
@@ -60,8 +62,10 @@ function renderSubjectTableRow({
                                 comment: comment,
                                 direction: direction,
                                 evaluate_targets: evaluateTargets,
+                                name: name,
                                 recent_measurements: [],
                                 scale: scale,
+                                secondary_name: secondaryName,
                                 type: "metric_type",
                                 unit: "things",
                             }}
@@ -181,4 +185,22 @@ it("shows no drag handle when rows are sorted", () => {
         </Permissions.Provider>,
     )
     expect(screen.queryByLabelText("Drag to reorder")).not.toBeInTheDocument()
+})
+
+it("shows the metric type as name if the metric has no name", async () => {
+    const { container } = renderSubjectTableRow()
+    expect(screen.getAllByText("Metric type").length).toBe(1)
+    await expectNoAccessibilityViolations(container)
+})
+
+it("shows the metric name", async () => {
+    const { container } = renderSubjectTableRow({ name: "Metric name" })
+    expect(screen.getAllByText("Metric name").length).toBe(1)
+    await expectNoAccessibilityViolations(container)
+})
+
+it("shows the metric secondary name", async () => {
+    const { container } = renderSubjectTableRow({ secondaryName: "Secondary name" })
+    expect(screen.getAllByText("Secondary name").length).toBe(1)
+    await expectNoAccessibilityViolations(container)
 })

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - When using Gatling performance reports as source, Quality-time now parses the Gatling HTML file instead of the JSON and log files that Gatling no longer exposes as part of the report. Fixes [#11955](https://github.com/ICTU/quality-time/issues/11955).
 
+### Added
+
+- Metrics can have an optional secondary name. Closes [#12023](https://github.com/ICTU/quality-time/issues/12023).
+
 ## v5.43.0 - 2025-09-26
 
 ### Fixed

--- a/tests/feature_tests/src/features/metric.feature
+++ b/tests/feature_tests/src/features/metric.feature
@@ -123,6 +123,11 @@ Feature: metric
     When the client changes the metric name to "Metric"
     Then the metric name is "Metric"
 
+  Scenario: change metric secondary name
+    Given an existing metric
+    When the client changes the metric secondary_name to "Secondary name"
+    Then the metric secondary_name is "Secondary name"
+
   Scenario: change metric position
     Given an existing metric with name "A"
     And an existing metric with name "B"


### PR DESCRIPTION
Metrics can take an optional secondary name that is displayed in a slightly smaller font in the metrics table. This allows for grouping related metrics by giving them a common secondary name, or add other information to the metrics table.

Closes #12023.