### PR TITLE
Add a time remaining event parameter

### DIFF
--- a/components/shared_code/src/shared_data_model/sources/jira.py
+++ b/components/shared_code/src/shared_data_model/sources/jira.py
@@ -59,11 +59,6 @@ JIRA = Source(
     name="Jira",
     description="Jira is a proprietary issue tracker developed by Atlassian supporting bug tracking and agile project "
     "management.",
-    documentation={
-        "time_remaining": (
-            "Time remaining is the time until the end date of the active sprint of the configured Jira board."
-        )
-    },
     url=HttpUrl("https://www.atlassian.com/software/jira"),
     issue_tracker=True,
     parameters={
@@ -134,6 +129,14 @@ JIRA = Source(
         "test_result": TestResult(
             metrics=["test_cases"],
             values=["errored", "failed", "passed", "skipped", "untested"],
+        ),
+        "time_remaining_event": SingleChoiceParameter(
+            name="Time remaining until",
+            help="Time remaining measures the time remaining until the selected event. Note: the only event supported "
+            "at the moment is the end date of the active sprint of the configured Jira board.",
+            values=["end of active sprint"],
+            default_value="end of active sprint",
+            metrics=["time_remaining"],
         ),
         "velocity_sprints": IntegerParameter(
             name="Number of sprints to base velocity on",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -21,6 +21,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Added
 
 - Metrics can have an optional secondary name. Closes [#12023](https://github.com/ICTU/quality-time/issues/12023).
+- When measuring time remaining with Jira as source, add a parameter to select the event until which to measure the time remaining so it is clear what time is being measured. Only value supported at the moment is the end of the active sprint. Closes [#11893](https://github.com/ICTU/quality-time/issues/11893).
 
 ## v5.43.0 - 2025-09-26
 


### PR DESCRIPTION
When measuring time remaining with Jira as source, add a parameter to select the event until which to measure the time remaining so it is clear what time is being measured. Only value supported at the moment is the end of the active sprint.

Closes #11893.