### PR TITLE
Fix visible tags menu in settings

### DIFF
--- a/components/frontend/src/AppUI.jsx
+++ b/components/frontend/src/AppUI.jsx
@@ -21,7 +21,7 @@ import {
     reportsPropType,
     stringsPropType,
 } from "./sharedPropTypes"
-import { getReportsTags, getUserPermissions } from "./utils"
+import { getReportsTags, getReportTags, getUserPermissions } from "./utils"
 
 export function AppUI({
     changedFields,
@@ -78,7 +78,7 @@ export function AppUI({
                         atReportsOverview={atReportsOverview}
                         handleSort={handleSort}
                         settings={settings}
-                        tags={getReportsTags(reports)}
+                        tags={atReportsOverview ? getReportsTags(reports) : getReportTags(currentReport)}
                     />
                 }
                 settings={settings}

--- a/components/frontend/src/utils.jsx
+++ b/components/frontend/src/utils.jsx
@@ -299,6 +299,9 @@ visibleMetrics.propTypes = {
 }
 
 export function getReportTags(report, hiddenTags) {
+    if (!report) {
+        return []
+    }
     const tags = new Set()
     Object.values(report.subjects).forEach((subject) => {
         Object.values(subject.metrics).forEach((metric) => {

--- a/components/frontend/src/utils.test.jsx
+++ b/components/frontend/src/utils.test.jsx
@@ -356,29 +356,35 @@ it("returns the metric response overrun when there are two measurements with dif
     })
 })
 
-it("returns the tags of an empty report", () => {
-    expect(getReportTags({ subjects: {} })).toStrictEqual([])
-})
+describe("getReportsTags", () => {
+    it("returns an empty list of tags if the report is null", () => {
+        expect(getReportTags(null)).toStrictEqual([])
+    })
 
-it("returns the tags of a report with one tag", () => {
-    expect(
-        getReportTags({
-            subjects: { subject_uud: { metrics: { metric_uuid: { tags: ["tag"] } } } },
-        }),
-    ).toStrictEqual(["tag"])
-})
+    it("returns the tags of an empty report", () => {
+        expect(getReportTags({ subjects: {} })).toStrictEqual([])
+    })
 
-it("does not return hidden tags", () => {
-    expect(
-        getReportTags(
-            {
-                subjects: {
-                    subject_uud: { metrics: { metric_uuid: { tags: ["tag", "hidden"] } } },
+    it("returns the tags of a report with one tag", () => {
+        expect(
+            getReportTags({
+                subjects: { subject_uud: { metrics: { metric_uuid: { tags: ["tag"] } } } },
+            }),
+        ).toStrictEqual(["tag"])
+    })
+
+    it("does not return hidden tags", () => {
+        expect(
+            getReportTags(
+                {
+                    subjects: {
+                        subject_uud: { metrics: { metric_uuid: { tags: ["tag", "hidden"] } } },
+                    },
                 },
-            },
-            ["hidden"],
-        ),
-    ).toStrictEqual(["tag"])
+                ["hidden"],
+            ),
+        ).toStrictEqual(["tag"])
+    })
 })
 
 it("hides metrics not requiring action or without issues", () => {

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - Fix broken links in the documentation. Fixes [#12033](https://github.com/ICTU/quality-time/issues/12033).
 - Disable issue tracker fields until the user picks an issue tracker type. Fixes [#12039](https://github.com/ICTU/quality-time/issues/12039).
+- The "Visible tags" menu in the settings panel of a report would show tags not used in the current report. Fixes [#12061](https://github.com/ICTU/quality-time/issues/12061).
 
 ### Changed
 
@@ -25,8 +26,8 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ### Added
 
-- Metrics can have an optional secondary name. Closes [#12023](https://github.com/ICTU/quality-time/issues/12023).
 - When measuring time remaining with Jira as source, add a parameter to select the event until which to measure the time remaining so it is clear what time is being measured. Only value supported at the moment is the end of the active sprint. Closes [#11893](https://github.com/ICTU/quality-time/issues/11893).
+- Metrics can have an optional secondary name. Closes [#12023](https://github.com/ICTU/quality-time/issues/12023).
 
 ## v5.43.0 - 2025-09-26
 


### PR DESCRIPTION
The "Visible tags" menu in the settings panel of a report would show tags not used in the current report.

Fixes #12061.