### PR TITLE
Fix Dependency-Track projects not found

### DIFF
--- a/components/collector/src/source_collectors/dependency_track/base.py
+++ b/components/collector/src/source_collectors/dependency_track/base.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator
 from typing import Literal, cast
 
 from base_collectors import SourceCollector
+from collector_utilities.exceptions import CollectorError
 from collector_utilities.functions import add_query, match_string_or_regular_expression
 from collector_utilities.type import URL, Response
 from model import Entity, SourceResponses
@@ -47,7 +48,10 @@ class DependencyTrackBase(SourceCollector):
 
     async def _get_projects_by_uuid(self) -> dict[str, DependencyTrackProject]:
         """Return a mapping of project UUIDs to projects."""
-        return {project["uuid"]: project async for project in self._get_projects()}
+        if projects := {project["uuid"]: project async for project in self._get_projects()}:
+            return projects
+        error_message = "No projects found"
+        raise CollectorError(error_message)
 
     async def _get_projects(self) -> AsyncIterator[DependencyTrackProject]:
         """Return the Dependency-Track projects."""

--- a/components/collector/tests/source_collectors/dependency_track/base_test.py
+++ b/components/collector/tests/source_collectors/dependency_track/base_test.py
@@ -1,5 +1,6 @@
 """Base classes for Dependency-Track collector unit tests."""
 
+from model.measurement import MetricMeasurement
 from source_collectors.dependency_track.json_types import DependencyTrackMetrics, DependencyTrackProject
 
 from tests.source_collectors.source_collector_test_case import SourceCollectorTestCase
@@ -16,10 +17,10 @@ class DependencyTrackTestCase(SourceCollectorTestCase):
         self.landing_url = f"https://{self.SOURCE_TYPE}/landing"
         self.sources["source_id"]["parameters"]["landing_url"] = self.landing_url  # type: ignore[index]
 
-    def projects(self, version: str = "1.4") -> list[DependencyTrackProject]:
+    def projects(self, version: str = "1.4", *, is_latest: bool = False) -> list[DependencyTrackProject]:
         """Create the Dependency-Track projects fixture."""
         project = DependencyTrackProject(
-            isLatest=False,
+            isLatest=is_latest,
             name="project name",
             uuid="project uuid",
             lastBomImport=0,
@@ -28,3 +29,7 @@ class DependencyTrackTestCase(SourceCollectorTestCase):
         if version:
             project["version"] = version
         return [project]
+
+    def assert_no_projects_found(self, measurement: MetricMeasurement) -> None:
+        """Assert that no projects have been found."""
+        self.assert_measurement(measurement, connection_error="No projects found")

--- a/components/collector/tests/source_collectors/dependency_track/test_dependencies.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_dependencies.py
@@ -41,7 +41,7 @@ class DependencyTrackDependenciesTest(DependencyTrackTestCase):
     async def test_no_projects(self):
         """Test that there are no dependencies if there are no projects."""
         response = await self.collect(get_request_json_return_value=[])
-        self.assert_measurement(response, value="0", entities=[])
+        self.assert_no_projects_found(response)
 
     async def test_no_vulnerabilities(self):
         """Test one project without dependencies."""
@@ -85,7 +85,7 @@ class DependencyTrackDependenciesTest(DependencyTrackTestCase):
         """Test filtering projects by name without match."""
         self.set_source_parameter("project_names", ["other project"])
         response = await self.collect(get_request_json_return_value=self.projects())
-        self.assert_measurement(response, value="0", entities=[])
+        self.assert_no_projects_found(response)
 
     async def test_filter_by_project_regular_expression(self):
         """Test filtering projects by regular expression."""
@@ -103,7 +103,7 @@ class DependencyTrackDependenciesTest(DependencyTrackTestCase):
         """Test filtering projects by version without a match."""
         self.set_source_parameter("project_versions", ["1.2", "1.3"])
         response = await self.collect(get_request_json_return_value=self.projects())
-        self.assert_measurement(response, value="0", entities=[])
+        self.assert_no_projects_found(response)
 
     async def test_filter_by_project_name_and_version(self):
         """Test filtering projects by name and version."""
@@ -116,10 +116,10 @@ class DependencyTrackDependenciesTest(DependencyTrackTestCase):
         """Test filtering projects by version."""
         self.set_source_parameter("project_versions", ["1.2", "1.3"])
         response = await self.collect(get_request_json_return_value=self.projects(version=""))
-        self.assert_measurement(response, value="0", entities=[])
+        self.assert_no_projects_found(response)
 
     async def test_filter_by_latest_project(self):
         """Test that projects can be filtered by being the latest project version."""
         self.set_source_parameter("only_include_latest_project_versions", "yes")
         response = await self.collect(get_request_json_side_effect=[self.projects()])
-        self.assert_measurement(response, value="0", entities=[])
+        self.assert_no_projects_found(response)

--- a/components/collector/tests/source_collectors/dependency_track/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_source_up_to_dateness.py
@@ -16,7 +16,7 @@ class DependencyTrackSourceUpToDatenessVersionTest(DependencyTrackTestCase):
     METRIC_ADDITION = "min"
     METRIC_TYPE = "source_up_to_dateness"
 
-    def projects(self, version: str = "1.4") -> list[DependencyTrackProject]:
+    def projects(self, version: str = "1.4", *, is_latest: bool = False) -> list[DependencyTrackProject]:
         """Create Dependency-Track projects fixture."""
         now = datetime.now(tz=tzlocal()).replace(microsecond=0)
         self.yesterday = now - timedelta(days=1)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ### Fixed
 
+- When measuring security warnings or dependencies with Dependency-Track as source, throw an error if no projects match instead of reporting zero warnings or dependencies. Fixes [#11898](https://github.com/ICTU/quality-time/issues/11898).
 - Fix landing URL for SonarQube security hotspots. Fixes [#12059](https://github.com/ICTU/quality-time/issues/12059).
 
 ## v5.44.0 - 2025-10-03


### PR DESCRIPTION
When measuring security warnings or dependencies with Dependency-Track as source, throw an error if no projects match instead of reporting zero warnings or dependencies.

Fixes #11898.