### PR TITLE
Make the "Issues" dashboard card consistent

### DIFF
--- a/components/frontend/src/dashboard/FilterCardWithTable.jsx
+++ b/components/frontend/src/dashboard/FilterCardWithTable.jsx
@@ -1,14 +1,17 @@
 import { Chip, Table, TableBody, TableCell, TableRow } from "@mui/material"
-import { bool, func, string } from "prop-types"
+import { bool, func, number, string } from "prop-types"
 
 import { childrenPropType } from "../sharedPropTypes"
 import { DashboardCard } from "./DashboardCard"
 
-export function FilterCardWithTable({ children, onClick, selected, title }) {
+export function FilterCardWithTable({ children, onClick, selected, title, total }) {
     return (
         <DashboardCard onClick={onClick} selected={selected} title={title} titleFirst={true}>
-            <Table size="small">
-                <TableBody>{children}</TableBody>
+            <Table size="small" padding="none" height="75%">
+                <TableBody>
+                    {children}
+                    <Row key="total" color="total" label={<b>Total</b>} value={total} />
+                </TableBody>
             </Table>
         </DashboardCard>
     )
@@ -18,15 +21,21 @@ FilterCardWithTable.propTypes = {
     onClick: func,
     selected: bool,
     title: string,
+    total: number,
 }
 
 function Row({ color, label, value }) {
     return (
-        <TableRow>
+        <TableRow
+            sx={{
+                "&:last-child th, &:last-child td": {
+                    borderBottom: 0,
+                },
+            }}
+        >
             <TableCell
                 sx={{
-                    fontSize: "12px",
-                    paddingLeft: "0px",
+                    fontSize: "1.3em",
                     whiteSpace: "nowrap",
                     width: "100%",
                     maxWidth: 0,

--- a/components/frontend/src/dashboard/IssuesCard.jsx
+++ b/components/frontend/src/dashboard/IssuesCard.jsx
@@ -1,13 +1,13 @@
 import { bool, func } from "prop-types"
 
 import { reportPropType } from "../sharedPropTypes"
-import { capitalize } from "../utils"
+import { capitalize, sum } from "../utils"
 import { FilterCardWithTable } from "./FilterCardWithTable"
 
 function issueStatuses(report) {
     // The issue status is unknown when the issue was added recently and the status hasn't been collected yet
     // or when collecting the issue status from the issue tracker failed
-    const statuses = { todo: 0, doing: 0, done: 0, unknown: 0 }
+    const statuses = { unknown: 0, todo: 0, doing: 0, done: 0 }
     Object.values(report.subjects).forEach((subject) => {
         Object.values(subject.metrics).forEach((metric) => {
             let nrIssuesWithKnownStatus = 0
@@ -30,8 +30,9 @@ issueStatuses.propTypes = {
 
 export function IssuesCard({ onClick, report, selected }) {
     const statuses = issueStatuses(report)
+    const total = sum(Object.values(statuses))
     return (
-        <FilterCardWithTable onClick={onClick} selected={selected} title="Issues">
+        <FilterCardWithTable onClick={onClick} selected={selected} title="Issues" total={total}>
             {Object.entries(statuses).map(([status, count]) => (
                 <FilterCardWithTable.Row key={status} color={status} label={capitalize(status)} value={count} />
             ))}

--- a/components/frontend/src/dashboard/LegendCard.jsx
+++ b/components/frontend/src/dashboard/LegendCard.jsx
@@ -10,7 +10,7 @@ export function LegendCard() {
             <StatusIcon status={status} />
             <ListItemText
                 primary={STATUS_SHORT_NAME[status]}
-                slotProps={{ primary: { typography: { fontSize: "12px" } } }}
+                slotProps={{ primary: { typography: { fontSize: "1.1em" } } }}
                 sx={{ marginLeft: "10px" }}
             />
         </ListItem>
@@ -18,7 +18,7 @@ export function LegendCard() {
 
     return (
         <DashboardCard title="Legend" titleFirst={true}>
-            <List sx={{ padding: "0px", paddingLeft: "0px", whiteSpace: "nowrap" }}>{listItems}</List>
+            <List sx={{ padding: "0px", whiteSpace: "nowrap" }}>{listItems}</List>
         </DashboardCard>
     )
 }

--- a/components/frontend/src/dashboard/MetricsRequiringActionCard.jsx
+++ b/components/frontend/src/dashboard/MetricsRequiringActionCard.jsx
@@ -30,11 +30,10 @@ export function MetricsRequiringActionCard({ onClick, reports, selected }) {
     const statuses = metricStatuses(reports)
     const total = sum(Object.values(statuses))
     return (
-        <FilterCardWithTable onClick={onClick} selected={selected} title="Action required">
+        <FilterCardWithTable onClick={onClick} selected={selected} title="Action required" total={total}>
             {Object.entries(statuses).map(([status, count]) => (
                 <FilterCardWithTable.Row key={status} color={status} label={STATUS_NAME[status]} value={count} />
             ))}
-            <FilterCardWithTable.Row key="total" color="total" label={<b>Total</b>} value={total} />
         </FilterCardWithTable>
     )
 }

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - When measuring security warnings or dependencies with Dependency-Track as source, throw an error if no projects match instead of reporting zero warnings or dependencies. Fixes [#11898](https://github.com/ICTU/quality-time/issues/11898).
 - Fix landing URL for SonarQube security hotspots. Fixes [#12059](https://github.com/ICTU/quality-time/issues/12059).
+- Make the "Issues" dashboard card consistent with other dashboard cards by putting the number of unknown issues on the first line and giving it a total number of issues. Fixes [#12080](https://github.com/ICTU/quality-time/issues/12080).
 
 ## v5.44.0 - 2025-10-03
 


### PR DESCRIPTION
Make the "Issues" dashboard card consistent with other dashboard cards: put the number of unknown issues on the first line and give it a total number of issues.

Fixes #12080.