### PR TITLE
Replace deprecated SonarQube parameters

### DIFF
--- a/components/collector/src/source_collectors/sonarqube/security_warnings.py
+++ b/components/collector/src/source_collectors/sonarqube/security_warnings.py
@@ -35,8 +35,13 @@ class SonarQubeSecurityWarnings(SonarQubeViolations):
             api_urls.append(await super()._api_url())
         if self.__security_hotspots_selected():
             base_url = await SonarQubeCollector._api_url(self)  # noqa: SLF001
+            # Note we pass both the project and the deprecated projectKey parameter because Sonarcloud.io doesn't
+            # accept the project parameter. Tested October 8, 2025.
             api_urls.append(
-                URL(f"{base_url}/api/hotspots/search?projectKey={component}&branch={branch}&ps={self.PAGE_SIZE}")
+                URL(
+                    f"{base_url}/api/hotspots/search?project={component}&projectKey={component}&branch={branch}&"
+                    f"ps={self.PAGE_SIZE}"
+                )
             )
         return await super()._get_source_responses(*api_urls)
 

--- a/components/collector/src/source_collectors/sonarqube/suppressed_violations.py
+++ b/components/collector/src/source_collectors/sonarqube/suppressed_violations.py
@@ -32,9 +32,9 @@ class SonarQubeSuppressedViolations(SonarQubeViolations):
         url = await SourceCollector._api_url(self)  # noqa: SLF001
         component = self._parameter("component")
         branch = self._parameter("branch")
-        all_issues_api_url = URL(f"{url}/api/issues/search?componentKeys={component}&branch={branch}")
+        all_issues_api_url = URL(f"{url}/api/issues/search?projects={component}&branch={branch}")
         resolved_issues_api_url = URL(
-            f"{all_issues_api_url}&statuses=RESOLVED&resolutions=WONTFIX,FALSE-POSITIVE&additionalFields=comments"
+            f"{all_issues_api_url}&resolved=yes&resolutions=WONTFIX,FALSE-POSITIVE&additionalFields=comments"
             f"{self._query_parameter('impact_severities', uppercase=True)}&ps={self.PAGE_SIZE}",
         )
         return await super()._get_source_responses(*[*urls, resolved_issues_api_url, all_issues_api_url])

--- a/components/collector/src/source_collectors/sonarqube/violations.py
+++ b/components/collector/src/source_collectors/sonarqube/violations.py
@@ -31,7 +31,7 @@ class SonarQubeViolations(SonarQubeCollector):
         # If there's more than 500 issues only the first 500 are returned. This is no problem since we limit
         # the number of "entities" sent to the server anyway (that limit is 250 currently).
         # Issue: https://github.com/ICTU/quality-time/issues/11004
-        api = f"{url}/api/issues/search?componentKeys={component}&branch={branch}&resolved=false&ps={self.PAGE_SIZE}"
+        api = f"{url}/api/issues/search?projects={component}&branch={branch}&resolved=false&ps={self.PAGE_SIZE}"
         return URL(api + self._url_parameters())
 
     def _url_parameters(self) -> str:

--- a/components/collector/tests/source_collectors/sonarqube/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_security_warnings.py
@@ -11,10 +11,10 @@ class SonarQubeSecurityWarningsTest(SonarQubeTestCase):
     API_URL = f"{SONARQUBE_URL}/api"
     BRANCH = "&branch=main"
     DASHBOARD_URL = f"{SONARQUBE_URL}/dashboard?id=id{BRANCH}"
-    HOTSPOTS_API = f"{API_URL}/hotspots/search?projectKey=id{BRANCH}&ps=500"
+    HOTSPOTS_API = f"{API_URL}/hotspots/search?project=id&projectKey=id{BRANCH}&ps=500"
     HOTSPOTS_LANDING_URL = f"{SONARQUBE_URL}/security_hotspots?id=id{BRANCH}"
     ISSUES_API = (
-        f"{API_URL}/issues/search?componentKeys=id&branch=main&resolved=false&ps=500&impactSoftwareQualities=SECURITY"
+        f"{API_URL}/issues/search?projects=id&branch=main&resolved=false&ps=500&impactSoftwareQualities=SECURITY"
     )
     ISSUES_LANDING_URL = f"{SONARQUBE_URL}/project/issues?id=id{BRANCH}&resolved=false&impactSoftwareQualities=SECURITY"
 

--- a/docs/src/versioning.md
+++ b/docs/src/versioning.md
@@ -21,8 +21,9 @@ The table below contains the *Quality-time* releases since the last minor of the
 
 | Version    | Date       | Mongo  | FC     | Migrations | Downgrade       | Upgrade         | Manual changes |
 |------------|------------|--------|--------|------------|-----------------|-----------------|----------------|
-| v5.44.0    | 2025-10-03 | v8     | v8     |            | v5.40.0-v5.43.0 | n/a             | no             |
-| v5.43.0    | 2025-09-26 | v8     | v8     |            | v5.40.0-v5.42.0 | latest          | no             |
+| v5.44.1    | 2025-10-10 | v8     | v8     |            | v5.40.0-v5.44.0 | n/a             | no             |
+| v5.44.0    | 2025-10-03 | v8     | v8     |            | v5.40.0-v5.43.0 | v5.44.1         | no             |
+| v5.43.0    | 2025-09-26 | v8     | v8     |            | v5.40.0-v5.42.0 | v5.44.0-latest  | no             |
 | v5.42.0    | 2025-09-18 | v8     | v8     |            | v5.40.0-v5.41.0 | v5.43.0-latest  | no             |
 | v5.41.0    | 2025-09-05 | v8     | v8     |            | v5.40.0         | v5.42.0-latest  | no             |
 | v5.40.0    | 2025-08-29 | v8     | v8     | added (1)  | not supported   | v5.41.0-latest  | no             |


### PR DESCRIPTION
- /api/hotspots/search Parameter 'projectKey' is deprecated since 10.2 and will be removed in a future version.
- /api/issues/search Parameter 'componentKeys' is deprecated since 10.2 and will be removed in a future version.
- /api/issues/search Parameter 'statuses' is deprecated since 10.4 and will be removed in a future version.
- No changelog item added since this is not a user facing change.

Closes #12092.