### PR TITLE
Fix UI crash when expanding the title of a subject

### DIFF
--- a/components/frontend/src/subject/SubjectTitle.test.jsx
+++ b/components/frontend/src/subject/SubjectTitle.test.jsx
@@ -26,7 +26,10 @@ afterEach(() => vi.restoreAllMocks())
 
 const dataModel = {
     subjects: {
-        subject_type: { name: "Default subject type" },
+        subject_type: {
+            name: "Default subject type",
+            subjects: { nested_subject_type: { name: "Nested subject type" } },
+        },
         subject_type2: { name: "Other subject type" },
     },
     metrics: {
@@ -66,6 +69,22 @@ async function renderSubjectTitle(subjectType = "subject_type") {
 
 it("changes the subject type", async () => {
     const { container } = await renderSubjectTitle()
+    fireEvent.mouseDown(screen.getByLabelText(/Subject type/))
+    clickText(/Other subject type/)
+    expectFetch("post", "subject/subject_uuid/attribute/type", { type: "subject_type2" })
+    await expectNoAccessibilityViolations(container)
+})
+
+it("changes the subject type to a nested type", async () => {
+    const { container } = await renderSubjectTitle()
+    fireEvent.mouseDown(screen.getByLabelText(/Subject type/))
+    clickText(/Nested subject type/)
+    expectFetch("post", "subject/subject_uuid/attribute/type", { type: "nested_subject_type" })
+    await expectNoAccessibilityViolations(container)
+})
+
+it("changes the subject type from a nested type", async () => {
+    const { container } = await renderSubjectTitle("nested_subject_type")
     fireEvent.mouseDown(screen.getByLabelText(/Subject type/))
     clickText(/Other subject type/)
     expectFetch("post", "subject/subject_uuid/attribute/type", { type: "subject_type2" })

--- a/components/frontend/src/subject/SubjectType.jsx
+++ b/components/frontend/src/subject/SubjectType.jsx
@@ -7,7 +7,7 @@ import { DataModel } from "../context/DataModel"
 import { accessGranted, EDIT_REPORT_PERMISSION, Permissions } from "../context/Permissions"
 import { TextField } from "../fields/TextField"
 import { subjectPropType } from "../sharedPropTypes"
-import { referenceDocumentationURL } from "../utils"
+import { getSubjectType, referenceDocumentationURL } from "../utils"
 import { ReadTheDocsLink } from "../widgets/ReadTheDocsLink"
 
 export function subjectTypes(subjectTypesMapping, level = 0) {
@@ -52,10 +52,11 @@ export function SubjectType({ subjectType, setValue }) {
     const dataModel = useContext(DataModel)
     const permissions = useContext(Permissions)
     const disabled = !accessGranted(permissions, [EDIT_REPORT_PERMISSION])
+    const subjectTypeName = getSubjectType(subjectType, dataModel.subjects).name
     return (
         <TextField
             disabled={disabled}
-            helperText={<ReadTheDocsLink url={referenceDocumentationURL(dataModel.subjects[subjectType].name)} />}
+            helperText={<ReadTheDocsLink url={referenceDocumentationURL(subjectTypeName)} />}
             label="Subject type"
             onChange={(value) => setValue(value)}
             select

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,6 +19,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 - When measuring security warnings or dependencies with Dependency-Track as source, throw an error if no projects match instead of reporting zero warnings or dependencies. Fixes [#11898](https://github.com/ICTU/quality-time/issues/11898).
 - Fix landing URL for SonarQube security hotspots. Fixes [#12059](https://github.com/ICTU/quality-time/issues/12059).
 - Make the "Issues" dashboard card consistent with other dashboard cards by putting the number of unknown issues on the first line and giving it a total number of issues. Fixes [#12080](https://github.com/ICTU/quality-time/issues/12080).
+- Don't crash the UI when expanding the title of a subject with a nested subject type. Fixes [#12105](https://github.com/ICTU/quality-time/issues/12105).
 
 ## v5.44.0 - 2025-10-03
 


### PR DESCRIPTION
Don't crash the UI when expanding the title of a subject with a nested subject type.

Fixes #12105.