### PR TITLE
Fix retrieving data from Jira Cloud

### DIFF
--- a/components/collector/src/source_collectors/jira/issues.py
+++ b/components/collector/src/source_collectors/jira/issues.py
@@ -22,18 +22,27 @@ class JiraIssues(JiraBase):
 
     async def _api_url(self) -> URL:
         """Extend to get the fields from Jira and create a field name to field id mapping."""
-        url = await super()._api_url()
-        fields_url = URL(f"{url}/rest/api/{self._rest_api_version}/field")
+        api_url = URL(f"{await super()._api_url()}/rest/api/{self._rest_api_version}")
+        await self._get_fields(api_url)
+        return await self._search_url(api_url)
+
+    async def _get_fields(self, url: URL) -> None:
+        """Retrieve the available fields."""
+        fields_url = URL(f"{url}/field")
         response = (await super()._get_source_responses(fields_url))[0]
         self._field_ids = {}
         for field in await response.json():
             field_name, field_id = field["name"].lower(), field["id"]
             self._field_ids[field_name] = field_id
             self._field_ids[field_id] = field_id  # Include ids too so we get a key error if a field doesn't exist
+
+    async def _search_url(self, url: URL) -> URL:
+        """Return the search endpoint, depending on whether Jira is the cloud deployment or not."""
+        max_results = await self._determine_max_results()
+        endpoint = "search/jql" if await self.is_cloud else "search"
         jql = str(self._parameter("jql", quote=True))
         fields = self._fields()
-        max_results = await self._determine_max_results()
-        return URL(f"{url}/rest/api/{self._rest_api_version}/search?jql={jql}&fields={fields}&maxResults={max_results}")
+        return URL(f"{url}/{endpoint}?jql={jql}&fields={fields}&maxResults={max_results}")
 
     async def _landing_url(self, responses: SourceResponses) -> URL:
         """Extend to add the JQL query to the landing URL."""
@@ -128,8 +137,8 @@ class JiraIssues(JiraBase):
         """Maximum number of issues to retrieve per page."""
         if isinstance(self.max_results, int):  # NB: using cached_property is not doable on asyncio coroutine
             return self.max_results
-        url = self._parameter("url")
-        preference_url = URL(f"{url}/rest/api/{self._rest_api_version}/mypreferences?key=jira.search.views.default.max")
+        api_url = URL(f"{await super()._api_url()}/rest/api/{self._rest_api_version}")
+        preference_url = URL(f"{api_url}/mypreferences?key=jira.search.views.default.max")
         result_value = await (await super()._get_source_responses(preference_url))[0].json()
         self.max_results = result_value if isinstance(result_value, int) else self.DEFAULT_MAX_RESULTS
         return self.max_results

--- a/components/collector/tests/metric_collectors/test_change_failure_rate.py
+++ b/components/collector/tests/metric_collectors/test_change_failure_rate.py
@@ -53,6 +53,7 @@ class ChangeFailureRateTest(unittest.IsolatedAsyncioTestCase):
         ],
     }
     JIRA_CREATED: str = ISSUE_DT.isoformat()
+    JIRA_SERVER_INFO: ClassVar[dict] = {}
 
     def setUp(self) -> None:
         """Extend to set up test fixtures."""
@@ -163,6 +164,7 @@ class ChangeFailureRateTest(unittest.IsolatedAsyncioTestCase):
         """Test metric collection, when there are no deployment sources configured."""
         self.response.json.side_effect = [
             [],
+            self.JIRA_SERVER_INFO,
             self.tickets_json,
             self.tickets_json,
         ]
@@ -179,6 +181,7 @@ class ChangeFailureRateTest(unittest.IsolatedAsyncioTestCase):
         self.response.json.side_effect = [
             self.JENKINS_JOBS_JSON,
             [],
+            self.JIRA_SERVER_INFO,
             self.tickets_json,
             self.tickets_json,
         ]
@@ -202,6 +205,7 @@ class ChangeFailureRateTest(unittest.IsolatedAsyncioTestCase):
         self.response.json.side_effect = [
             self.JENKINS_JOBS_JSON,
             [],
+            self.JIRA_SERVER_INFO,
             self.tickets_json,
             self.tickets_json,
         ]
@@ -227,6 +231,7 @@ class ChangeFailureRateTest(unittest.IsolatedAsyncioTestCase):
             self.GITLAB_JOBS_JSON,
             self.GITLAB_JOBS_JSON,
             self.GITLAB_JOBS_JSON,
+            self.JIRA_SERVER_INFO,
             self.tickets_json,
             self.tickets_json,
         ]

--- a/components/collector/tests/metric_collectors/test_test_cases.py
+++ b/components/collector/tests/metric_collectors/test_test_cases.py
@@ -1,6 +1,7 @@
 """Unit tests for the test cases metric collector."""
 
 import unittest
+from typing import ClassVar
 from unittest.mock import AsyncMock, patch
 
 from shared.model.metric import Metric
@@ -58,6 +59,7 @@ class TestCasesTest(unittest.IsolatedAsyncioTestCase):
             </statistics>
         </robot>"""
     CREATED = "2020-08-06T16:36:48.000+0200"
+    JIRA_SERVER_INFO: ClassVar[dict] = {}
 
     def setUp(self) -> None:
         """Extend to set up test fixtures."""
@@ -66,7 +68,9 @@ class TestCasesTest(unittest.IsolatedAsyncioTestCase):
         self.session.timeout.total = config.MEASUREMENT_TIMEOUT
         self.response = self.session.get.return_value = AsyncMock()
         self.test_cases_json = {"total": 2, "issues": [self.jira_issue(), self.jira_issue("key-2")]}
-        self.response.json = AsyncMock(side_effect=[[], self.test_cases_json, self.test_cases_json])
+        self.response.json = AsyncMock(
+            side_effect=[[], self.JIRA_SERVER_INFO, self.test_cases_json, self.test_cases_json]
+        )
         self.jira_url = "https://jira"
         self.test_report_url = "https://report_xml"
 
@@ -174,7 +178,9 @@ class TestCasesTest(unittest.IsolatedAsyncioTestCase):
                 },
             ],
         }
-        self.response.json = AsyncMock(side_effect=[[], jenkins_json, self.test_cases_json, self.test_cases_json])
+        self.response.json = AsyncMock(
+            side_effect=[[], jenkins_json, self.JIRA_SERVER_INFO, self.test_cases_json, self.test_cases_json]
+        )
         jira = {"type": "jira", "parameters": {"url": self.jira_url, "jql": "jql"}}
         jenkins_test_report = {"type": "jenkins_test_report", "parameters": {"url": self.test_report_url}}
         measurement = await self.collect({"jira": jira, "jenkins_test_report": jenkins_test_report})

--- a/components/collector/tests/source_collectors/jira/base.py
+++ b/components/collector/tests/source_collectors/jira/base.py
@@ -1,5 +1,6 @@
 """Unit tests for the Jira metric source."""
 
+from typing import ClassVar
 from unittest.mock import patch
 
 from model import MetricMeasurement
@@ -12,6 +13,7 @@ class JiraTestCase(SourceCollectorTestCase):
     """Base class for Jira unit tests."""
 
     SOURCE_TYPE = "jira"
+    JIRA_SERVER_INFO: ClassVar[dict] = {}
 
     def setUp(self):
         """Extend to create sources and a metric of type METRIC_TYPE."""
@@ -55,6 +57,7 @@ class JiraTestCase(SourceCollectorTestCase):
             return await self.collect(
                 get_request_json_side_effect=[
                     fields_json or [{"id": "field", "name": "Field"}],
+                    self.JIRA_SERVER_INFO,
                     issues_json,
                     issues_json,
                 ],

--- a/components/collector/tests/source_collectors/jira/test_issues.py
+++ b/components/collector/tests/source_collectors/jira/test_issues.py
@@ -1,5 +1,7 @@
 """Unit tests for the Jira issues collector."""
 
+import aiohttp
+
 from source_collectors.jira.issues import JiraIssues
 
 from .base import JiraTestCase
@@ -23,9 +25,8 @@ class JiraIssuesTest(JiraTestCase):
         issues_json1 = {"total": 2, "issues": [self.issue()]}
         issues_json2 = {"total": 2, "issues": [self.issue(key="2")]}
         issues_json3 = {"total": 2, "issues": []}
-        response = await self.collect(
-            get_request_json_side_effect=[[], issues_json1, issues_json2, issues_json3, issues_json1, issues_json2],
-        )
+        side_effect = [[], self.JIRA_SERVER_INFO, issues_json1, issues_json2, issues_json3, issues_json1, issues_json2]
+        response = await self.collect(get_request_json_side_effect=side_effect)
         JiraIssues.max_results = previous_max_results
         self.assert_measurement(response, value="2", entities=[self.entity(), self.entity(key="2")])
 
@@ -39,38 +40,58 @@ class JiraIssuesTest(JiraTestCase):
     async def test_determine_max_results_from_api(self):
         """Test that the maxResults param is determined via API call value."""
         issues_json = {"total": 1, "issues": [self.issue()]}
-        response, get_mock, _ = await self.collect(
-            get_request_json_side_effect=[[{"id": "field", "name": "Field"}], 50, issues_json, issues_json],
-            return_mocks=True,
-        )
+        side_effect = [[{"id": "field", "name": "Field"}], 51, self.JIRA_SERVER_INFO, issues_json, issues_json]
+        response, get_mock, _ = await self.collect(get_request_json_side_effect=side_effect, return_mocks=True)
         self.assert_measurement(response, value="1", entities=[self.entity()])
-        self.assertIn("&maxResults=50&", get_mock.mock_calls[2].args[0])
+        self.assertIn("&maxResults=51&", get_mock.mock_calls[3].args[0])
 
     async def test_determine_max_results_from_default(self):
         """Test that the maxResults param is determined through fallback."""
         issues_json = {"total": 1, "issues": [self.issue()]}
-        result, get_mock, _ = await self.collect(
-            get_request_json_side_effect=[[{"id": "field", "name": "Field"}], "error", issues_json, issues_json],
-            return_mocks=True,
-        )
+        side_effect = [[{"id": "field", "name": "Field"}], "error", self.JIRA_SERVER_INFO, issues_json, issues_json]
+        result, get_mock, _ = await self.collect(get_request_json_side_effect=side_effect, return_mocks=True)
         self.assert_measurement(result, value="1", entities=[self.entity()])
-        self.assertIn(f"&maxResults={JiraIssues.DEFAULT_MAX_RESULTS}&", get_mock.mock_calls[2].args[0])
+        self.assertIn(f"&maxResults={JiraIssues.DEFAULT_MAX_RESULTS}&", get_mock.mock_calls[3].args[0])
 
     async def test_api_v2(self):
         """Test that the Jira API version used is v2 by default."""
         issues_json = {"total": 1, "issues": [self.issue()]}
-        _, get_mock, _ = await self.collect(
-            get_request_json_side_effect=[[{"id": "field", "name": "Field"}], 50, issues_json, issues_json],
-            return_mocks=True,
-        )
+        side_effect = [[{"id": "field", "name": "Field"}], 50, self.JIRA_SERVER_INFO, issues_json, issues_json]
+        _, get_mock, _ = await self.collect(get_request_json_side_effect=side_effect, return_mocks=True)
         self.assertTrue(get_mock.mock_calls[2].startswith("https://jira/rest/api/2"))
 
     async def test_api_v3(self):
         """Test that the Jira API version can be set to v3."""
         self.set_source_parameter("api_version", "v3")
         issues_json = {"total": 1, "issues": [self.issue()]}
-        _, get_mock, _ = await self.collect(
-            get_request_json_side_effect=[[{"id": "field", "name": "Field"}], 50, issues_json, issues_json],
-            return_mocks=True,
-        )
+        side_effect = [[{"id": "field", "name": "Field"}], 50, self.JIRA_SERVER_INFO, issues_json, issues_json]
+        _, get_mock, _ = await self.collect(get_request_json_side_effect=side_effect, return_mocks=True)
         self.assertTrue(get_mock.mock_calls[2].startswith("https://jira/rest/api/3"))
+
+    async def test_deployment_type_cloud(self):
+        """Test that the Jira Cloud API is used if the Jira URL points to Jira Cloud."""
+        issues_json = {"total": 1, "issues": [self.issue()]}
+        side_effect = [[{"id": "field", "name": "Field"}], 50, {"deploymentType": "Cloud"}, issues_json, issues_json]
+        _, get_mock, _ = await self.collect(get_request_json_side_effect=side_effect, return_mocks=True)
+        self.assertTrue(get_mock.mock_calls[3].startswith("https://jira/rest/api/3/search/jql?jql="))
+
+    async def test_deployment_type_data_center(self):
+        """Test that the Jira Data Center API is used if the Jira URL points to Jira Data Center."""
+        issues_json = {"total": 1, "issues": [self.issue()]}
+        side_effect = [[{"id": "field", "name": "Field"}], 50, self.JIRA_SERVER_INFO, issues_json, issues_json]
+        _, get_mock, _ = await self.collect(get_request_json_side_effect=side_effect, return_mocks=True)
+        self.assertTrue(get_mock.mock_calls[3].startswith("https://jira/rest/api/3/search?jql="))
+
+    async def test_assume_deployment_type_data_center_on_connection_error(self):
+        """Test that the Jira Data Center API is used if the server info results in an error."""
+        issues_json = {"total": 1, "issues": [self.issue()]}
+        side_effect = [[{"id": "field", "name": "Field"}], 50, aiohttp.ClientError, issues_json, issues_json]
+        _, get_mock, _ = await self.collect(get_request_json_side_effect=side_effect, return_mocks=True)
+        self.assertTrue(get_mock.mock_calls[3].startswith("https://jira/rest/api/3/search?jql="))
+
+    async def test_assume_deployment_type_data_center_on_parse_error(self):
+        """Test that the Jira Data Center API is used if the server info results in an error."""
+        issues_json = {"total": 1, "issues": [self.issue()]}
+        side_effect = [[{"id": "field", "name": "Field"}], 50, "not a dict", issues_json, issues_json]
+        _, get_mock, _ = await self.collect(get_request_json_side_effect=side_effect, return_mocks=True)
+        self.assertTrue(get_mock.mock_calls[3].startswith("https://jira/rest/api/3/search?jql="))

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,12 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- When the Jira source is a Jira Cloud instance, use the Jira Cloud endpoints. Fixes [#12093](https://github.com/ICTU/quality-time/issues/12093).
+
 ## v5.44.1 - 2025-10-10
 
 ### Fixed


### PR DESCRIPTION
When the Jira source is a Jira Cloud instance, use the Jira Cloud endpoints.

Fixes #12093.