### PR TITLE
Use Debian for the renderer instead of Alpine

### DIFF
--- a/components/renderer/Dockerfile
+++ b/components/renderer/Dockerfile
@@ -1,9 +1,12 @@
-FROM node:24.10.0-alpine3.22
+FROM node:25.0.0-trixie-slim
 
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time PDF render service"
 
-RUN apk add --no-cache chromium=141.0.7390.122-r0
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y chromium=141.0.7390.122-1~deb13u1 && \
+    rm -rf /var/lib/apt/lists/* && \
+    adduser renderer --disabled-password
 
 WORKDIR /home/renderer
 COPY package*.json /home/renderer/
@@ -11,7 +14,6 @@ RUN npm install --ignore-scripts
 
 COPY src/*js /home/renderer/
 
-RUN adduser renderer --disabled-password
 USER renderer
 
 HEALTHCHECK CMD ["node", "/home/renderer/healthcheck.cjs"]

--- a/components/renderer/src/index.js
+++ b/components/renderer/src/index.js
@@ -59,7 +59,7 @@ app.get("/api/render", async (req, res) => {
 app.listen(RENDERER_PORT, async () => {
     try {
         browser = await puppeteer.launch({
-            executablePath: "/usr/bin/chromium-browser",
+            executablePath: "/usr/bin/chromium",
             defaultViewport: { width: 1500, height: 1000 },
             args: ["--disable-dev-shm-usage", "--no-sandbox"],
             // Opt in to new Chrome headless implementation, see https://developer.chrome.com/articles/new-headless/:

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - When measuring suppressed violations with SonarQube as source, be prepared that SonarQube may add comments to violations without login. Fixes [#12136](https://github.com/ICTU/quality-time/issues/12136).
 
+### Changed
+
+- Use a Debian base image for the renderer instead of Alpine. Chromium cannot be pinned on Alpine, causing problem such as the need for updating Chromium at inconvenient moments and needing different versions of Chromium on different architectures. Fixes [#12163](https://github.com/ICTU/quality-time/issues/12163).
+
 ## v5.44.2 - 2025-10-16
 
 ### Fixed


### PR DESCRIPTION
Use a Debian base image for the renderer instead of Alpine. Chromium cannot be pinned on Alpine, causing problem such as the need for updating Chromium at inconvenient moments and needing different versions of Chromium on different architectures.

Fixes #12163.