### PR TITLE
Add used/unused metrics to source overview

### DIFF
--- a/components/frontend/src/__fixtures__/fixtures.js
+++ b/components/frontend/src/__fixtures__/fixtures.js
@@ -28,17 +28,26 @@ export const dataModel = {
         subject_type: { name: "Subject type", metrics: ["metric_type"] },
     },
     metrics: {
-        metric_type: { name: "Metric type", tags: [] },
+        metric_type: {
+            name: "Metric type",
+            tags: [],
+            sources: ["source_type", "source_type_without_location_parameters"],
+        },
+        metric_type2: {
+            name: "Metric type 2",
+            description: "Metric type description",
+            rationale: "Metric type rationale",
+            tags: [],
+            sources: ["source_type_without_location_parameters"],
+        },
     },
     sources: {
         source_type: {
             name: "Source type name",
-            metrics: ["metric_type"],
             parameters: { url: { type: "url", name: "URL" } },
         },
         source_type_without_location_parameters: {
             name: "Source type without location parameters",
-            metrics: ["metric_type"],
             parameters: {},
         },
     },
@@ -78,7 +87,7 @@ export const report = {
                         source_uuid2: {
                             name: "Source 2",
                             type: "source_type",
-                            parameters: { url: "https://sourc2.org" },
+                            parameters: { url: "https://source2.org" },
                         },
                     },
                     status: "informative",

--- a/components/frontend/src/report/report_utils.jsx
+++ b/components/frontend/src/report/report_utils.jsx
@@ -10,8 +10,18 @@ import {
     reportPropType,
     reportsPropType,
     settingsPropType,
+    sourcePropType,
+    sourceTypePropType,
 } from "../sharedPropTypes"
-import { addCounts, getMetricScale, getMetricTags, getSourceName, visibleMetrics } from "../utils"
+import {
+    addCounts,
+    getMetricName,
+    getMetricScale,
+    getMetricTags,
+    getSourceName,
+    getSubjectName,
+    visibleMetrics,
+} from "../utils"
 
 export function measurementOnDate(date, measurements, metricUuid) {
     const isoDateString = date.toISOString().split("T")[0]
@@ -100,29 +110,15 @@ summarizeReportsOnDate.propTypes = {
 export function reportSources(dataModel, report) {
     const sourceIds = new Set()
     const sources = {}
-    for (const subject of Object.values(report.subjects ?? {})) {
-        for (const metric of Object.values(subject.metrics ?? {})) {
-            for (const [sourceUuid, source] of Object.entries(metric.sources ?? {})) {
-                const reportSource = {
-                    name: getSourceName(source, dataModel),
-                    type: source.type,
-                    url: source.parameters?.url ?? "",
-                    landing_url: source.parameters?.landing_url ?? "",
-                    username: source.parameters?.username ?? "",
-                    password: source.parameters?.password ?? "",
-                    private_token: source.parameters?.private_token ?? "",
-                    api_version: source.parameters?.api_version ?? "",
-                }
-                const sourceId = JSON.stringify(reportSource)
-                if (sourceIds.has(sourceId)) {
-                    sources[sourceId].nrMetrics += 1
-                } else {
-                    reportSource["uuid"] = sourceUuid
-                    sources[sourceId] = reportSource
-                    sources[sourceId].nrMetrics = 1
-                    sourceIds.add(sourceId)
-                }
-            }
+    for (const { source, sourceUuid } of iterateSources(report)) {
+        const sourceId = createSourceId(dataModel, source)
+        if (sourceIds.has(sourceId)) {
+            sources[sourceId].nrMetrics += 1
+        } else {
+            source["uuid"] = sourceUuid
+            source["nrMetrics"] = 1
+            sources[sourceId] = source
+            sourceIds.add(sourceId)
         }
     }
     const sortedSources = Object.values(sources)
@@ -132,4 +128,90 @@ export function reportSources(dataModel, report) {
 reportSources.propTypes = {
     dataModel: dataModelPropType,
     report: reportPropType,
+}
+
+export function metricsUsingSource(dataModel, report, source) {
+    // Return the metrics in the report that use the source with the given sourceUuid or a source with the same
+    // parameters
+    const metrics = {}
+    const sourceId = createSourceId(dataModel, source)
+    for (const { subject, subjectUuid, metric, metricUuid, source } of iterateSources(report)) {
+        if (createSourceId(dataModel, source) === sourceId) {
+            metrics[metricUuid] = {
+                name: getMetricName(metric, dataModel),
+                secondary_name: metric.secondary_name ?? "",
+                subjectName: getSubjectName(subject, dataModel),
+                subjectUuid: subjectUuid,
+            }
+        }
+    }
+    return metrics
+}
+metricsUsingSource.propTypes = {
+    dataModel: dataModelPropType,
+    report: reportPropType,
+    source: sourcePropType,
+}
+
+export function unusedMetricTypesSupportedBySource(dataModel, report, source) {
+    // Return the metric types that can be measured with the source but aren't currently measured in the report
+    const supportedMetricTypes = new Set()
+    for (const [metricType, metric] of Object.entries(dataModel.metrics)) {
+        if (metric.sources.includes(source.type)) {
+            supportedMetricTypes.add(metricType)
+        }
+    }
+    const usedMetricTypes = new Set()
+    const sourceId = createSourceId(dataModel, source)
+    for (const { metric, source } of iterateSources(report)) {
+        if (createSourceId(dataModel, source) === sourceId) {
+            usedMetricTypes.add(metric.type)
+        }
+    }
+    return supportedMetricTypes.difference(usedMetricTypes)
+}
+unusedMetricTypesSupportedBySource.propTypes = {
+    dataModel: dataModelPropType,
+    report: reportPropType,
+    source: sourceTypePropType,
+}
+
+function createSourceId(dataModel, source) {
+    // Return the stringified version of the source. This creates a source identifier that makes
+    // sources with the same location parameters equal and ignores the source uuid and parameters such as filters,
+    const identifyingFields = {
+        name: getSourceName(source, dataModel),
+        type: source.type,
+        url: source.parameters?.url ?? "",
+        landing_url: source.parameters?.landing_url ?? "",
+        username: source.parameters?.username ?? "",
+        password: source.parameters?.password ?? "",
+        private_token: source.parameters?.private_token ?? "",
+        api_version: source.parameters?.api_version ?? "",
+    }
+    return JSON.stringify(identifyingFields)
+}
+createSourceId.propTypes = {
+    dataModel: dataModelPropType,
+    source: sourcePropType,
+}
+
+function iterateSources(report) {
+    // Iterate over all sources in the report, also returning the containing subjects and metrics, and the uuids
+    const items = []
+    for (const [subjectUuid, subject] of Object.entries(report.subjects ?? {})) {
+        for (const [metricUuid, metric] of Object.entries(subject.metrics ?? {})) {
+            for (const [sourceUuid, source] of Object.entries(metric.sources ?? {})) {
+                items.push({
+                    subject: subject,
+                    subjectUuid: subjectUuid,
+                    metric: metric,
+                    metricUuid: metricUuid,
+                    source: source,
+                    sourceUuid: sourceUuid,
+                })
+            }
+        }
+    }
+    return items
 }

--- a/components/frontend/src/subject/SubjectTable.jsx
+++ b/components/frontend/src/subject/SubjectTable.jsx
@@ -39,15 +39,7 @@ export function SubjectTable({
     const columnsToHide = determineColumnsToHide(dataModel, measurements, metricEntries, dates.length, report, settings)
     return (
         <TableContainer sx={{ overflowX: "visible" }}>
-            <Table
-                className="subjectTable"
-                stickyHeader
-                sx={{
-                    "& .MuiTableCell-sizeMedium": {
-                        padding: "8px",
-                    },
-                }}
-            >
+            <Table className="subjectTable" stickyHeader>
                 <SubjectTableHeader
                     columnDates={dates}
                     columnsToHide={columnsToHide}

--- a/components/frontend/src/widgets/TableHeaderCell.jsx
+++ b/components/frontend/src/widgets/TableHeaderCell.jsx
@@ -106,7 +106,7 @@ SortableTableHeaderCell.propTypes = {
 
 export function UnsortableTableHeaderCell({ colSpan, help, label, textAlign, width, icon }) {
     return (
-        <TableCell align={textAlign} colSpan={colSpan} width={width} aria-label={label}>
+        <TableCell align={textAlign} colSpan={colSpan} width={width} aria-label={label} variant="head">
             <TableHeaderCellContents help={help} label={label} icon={icon} />
         </TableCell>
     )

--- a/components/frontend/src/widgets/TableRowWithDetails.jsx
+++ b/components/frontend/src/widgets/TableRowWithDetails.jsx
@@ -27,6 +27,7 @@ export function TableRowWithDetails(props) {
                             backgroundColor: `${color}.hover`,
                         },
                     },
+                    "& > *": { borderBottom: expanded ? "unset" : "set" },
                 }}
             >
                 {firstTableCellWithExpandButton}
@@ -34,7 +35,9 @@ export function TableRowWithDetails(props) {
             </TableRow>
             {expanded && (
                 <TableRow>
-                    <TableCell colSpan="99">{details}</TableCell>
+                    <TableCell colSpan="99" sx={{ paddingLeft: "50px" }}>
+                        {details}
+                    </TableCell>
                 </TableRow>
             )}
         </>


### PR DESCRIPTION
Show used metrics and unused metric types in the source overview of a report.

Closes #12122.

- [x] Indent source details panels under the source name
- [x] Link metric types to docs
- [x] Add rationale column
- [x] Alternating background color for rows (light grey)