### PR TITLE
Fix suppressed violations SonarQube filters

### DIFF
--- a/components/collector/src/source_collectors/sonarqube/suppressed_violations.py
+++ b/components/collector/src/source_collectors/sonarqube/suppressed_violations.py
@@ -39,6 +39,8 @@ class SonarQubeSuppressedViolations(SonarQubeViolations):
         all_issues_api_url = URL(f"{url}/api/issues/search?projects={component}&branch={branch}")
         resolved_issues_api_url = URL(
             f"{all_issues_api_url}&resolved=yes&resolutions=WONTFIX,FALSE-POSITIVE&additionalFields=comments"
+            f"{self._query_parameter('clean_code_attribute_categories', uppercase=True)}"
+            f"{self._query_parameter('impacted_software_qualities', uppercase=True)}"
             f"{self._query_parameter('impact_severities', uppercase=True)}&ps={self.PAGE_SIZE}",
         )
         return await super()._get_source_responses(*[*urls, resolved_issues_api_url, all_issues_api_url])

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Fixed
 
 - Clarify in the product vision that checking the correct configuration of sources is out of scope for Quality-time. Fixes [#3821](https://github.com/ICTU/quality-time/issues/3821).
+- When measuring suppressed violations with SonarQube as source, take the impacted software qualities into account if configured by the user. Fixes [#12263](https://github.com/ICTU/quality-time/issues/12263).
 
 ## v5.46.0 - 2025-11-13
 


### PR DESCRIPTION
When measuring suppressed violations with SonarQube as source, take the impacted software qualities into account if configured by the user.

Fixes #12263.