### PR TITLE
Fix report source overview

### DIFF
--- a/components/frontend/src/report/ReportSources.jsx
+++ b/components/frontend/src/report/ReportSources.jsx
@@ -38,7 +38,7 @@ function SourceParameters({ reload, report, source, sourceUuid }) {
                 sourceUuid={sourceUuid}
                 parameter={allParameters[key]}
                 parameterKey={key}
-                parameterValue={source?.[key]}
+                parameterValue={source?.parameters?.[key]}
                 reload={(json) => reloadAfterMassEditSource(json, reload)}
                 requiredPermissions={[EDIT_REPORT_PERMISSION]}
             />

--- a/components/frontend/src/report/ReportSources.test.jsx
+++ b/components/frontend/src/report/ReportSources.test.jsx
@@ -180,7 +180,7 @@ it("changes the value of a parameter of a source without parameter layout", asyn
         },
         ["source_uuid:0"],
     )
-    await userEvent.type(screen.getAllByLabelText(/URL/)[0], "https://source.org/new{Enter}")
+    await userEvent.type(screen.getAllByLabelText(/URL/)[0], "/new{Enter}")
     expectFetch("post", "source/source_uuid/parameter/url", { url: "https://source.org/new", edit_scope: "report" })
     await expectNoAccessibilityViolations(container)
 })

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - Clarify in the product vision that checking the correct configuration of sources is out of scope for Quality-time. Fixes [#3821](https://github.com/ICTU/quality-time/issues/3821).
 - When measuring suppressed violations with SonarQube as source, take the impacted software qualities into account if configured by the user. Fixes [#12263](https://github.com/ICTU/quality-time/issues/12263).
+- Source configurations in the report source overview did not display parameter values. Fixes [#12281](https://github.com/ICTU/quality-time/issues/12281).
 
 ## v5.46.0 - 2025-11-13
 


### PR DESCRIPTION
Source configurations in the report source overview did not display parameter values.

Fixes #12281.