### PR TITLE
Fix Cobertura XML timestamp

### DIFF
--- a/components/collector/src/source_collectors/cobertura/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/cobertura/source_up_to_dateness.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from base_collectors import TimePassedCollector, XMLFileSourceCollector
 from collector_utilities.date_time import datetime_from_timestamp
+from collector_utilities.exceptions import NotFoundError
 from collector_utilities.functions import parse_source_response_xml
 
 if TYPE_CHECKING:
@@ -15,7 +16,12 @@ if TYPE_CHECKING:
 class CoberturaSourceUpToDateness(XMLFileSourceCollector, TimePassedCollector):
     """Collector to collect the Cobertura report age."""
 
+    CUTOFF_YEAR_FOR_TIMESTAMP = 1980
+
     async def _parse_source_response_date_time(self, response: Response) -> datetime:
         """Override to parse the timestamp from the response."""
         tree = await parse_source_response_xml(response)
-        return datetime_from_timestamp(int(tree.get("timestamp", 0)))
+        if timestamp := tree.get("timestamp"):
+            dt = datetime_from_timestamp(float(timestamp))
+            return dt if dt.year > self.CUTOFF_YEAR_FOR_TIMESTAMP else datetime_from_timestamp(float(timestamp) * 1000)
+        raise NotFoundError(type_of_thing="Cobertura XML tag", name_of_thing="timestamp")

--- a/components/collector/tests/source_collectors/cobertura/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/cobertura/test_source_up_to_dateness.py
@@ -10,7 +10,6 @@ from .base import CoberturaTestCase
 class CoberturaSourceUpToDatenessTest(CoberturaTestCase):
     """Unit tests for the Cobertura source up-to-dateness collector."""
 
-    COBERTURA_XML = '<coverage timestamp="1553821197442" />'
     METRIC_TYPE = "source_up_to_dateness"
     METRIC_ADDITION = "max"
 
@@ -19,13 +18,31 @@ class CoberturaSourceUpToDatenessTest(CoberturaTestCase):
         super().setUp()
         self.expected_age = str((datetime.now(tz=tzutc()) - datetime.fromtimestamp(1553821197.442, tz=tzutc())).days)
 
+    def cobertura_xml(self, timestamp: str | None = "1553821197442") -> str:
+        """Create the Cobertura XML."""
+        return "<coverage />" if timestamp is None else f'<coverage timestamp="{timestamp}" />'
+
     async def test_source_up_to_dateness(self):
         """Test that the source age in days is returned."""
-        response = await self.collect(get_request_text=self.COBERTURA_XML)
+        response = await self.collect(get_request_text=self.cobertura_xml())
         self.assert_measurement(response, value=self.expected_age)
+
+    async def test_source_up_to_dateness_with_timestamp_in_seconds(self):
+        """Test that the source age in days is returned."""
+        timestamp = 1553821197
+        response = await self.collect(get_request_text=self.cobertura_xml(timestamp=str(timestamp)))
+        self.assert_measurement(response, value=self.expected_age)
+        timestamp -= 24 * 60 * 60  # One day older
+        response = await self.collect(get_request_text=self.cobertura_xml(timestamp=str(timestamp)))
+        self.assert_measurement(response, value=str(int(self.expected_age) + 1))
 
     async def test_zipped_report(self):
         """Test that a zipped report can be read."""
         self.set_source_parameter("url", "https://example.org/cobertura.zip")
-        response = await self.collect(get_request_content=self.zipped_report(("cobertura.xml", self.COBERTURA_XML)))
+        response = await self.collect(get_request_content=self.zipped_report(("cobertura.xml", self.cobertura_xml())))
         self.assert_measurement(response, value=self.expected_age)
+
+    async def test_missing_timestamp(self):
+        """Test that an exception is thrown when the timestamp is missing."""
+        response = await self.collect(get_request_text=self.cobertura_xml(timestamp=None))
+        self.assert_measurement(response, parse_error="Cobertura XML tag 'timestamp' not found")

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Fixed
 
 - Clarify in the product vision that checking the correct configuration of sources is out of scope for Quality-time. Fixes [#3821](https://github.com/ICTU/quality-time/issues/3821).
+- When using Cobertura XML files as source, be prepared for timestamps without milliseconds. Also, report an error if the timestamp is missing. Fixes [#12247](https://github.com/ICTU/quality-time/issues/12247).
 - When measuring suppressed violations with SonarQube as source, take the impacted software qualities into account if configured by the user. Fixes [#12263](https://github.com/ICTU/quality-time/issues/12263).
 - Source configurations in the report source overview did not display parameter values. Fixes [#12281](https://github.com/ICTU/quality-time/issues/12281).
 


### PR DESCRIPTION
When using Cobertura XML files as source, be prepared for timestamps without milliseconds. Also, report an error if the timestamp is missing.

Fixes #12247.