### PR TITLE
Fix red technical debt target field

### DIFF
--- a/components/frontend/src/fields/TextField.jsx
+++ b/components/frontend/src/fields/TextField.jsx
@@ -43,7 +43,7 @@ export function TextField({
         if (required && !textValue) {
             return false
         }
-        if (type === "number") {
+        if (type === "number" && textValue) {
             return /^\d+$/.test(textValue)
         }
         return true

--- a/components/frontend/src/metric/Target.test.jsx
+++ b/components/frontend/src/metric/Target.test.jsx
@@ -66,6 +66,12 @@ it("sets the metric integer target", async () => {
     await expectNoAccessibilityViolations(container)
 })
 
+it("is valid when the metric integer target is not set", async () => {
+    const { container } = renderMetricTarget({ type: "violations", target: "" })
+    expect(screen.getByLabelText(/Metric target/)).toBeValid()
+    await expectNoAccessibilityViolations(container)
+})
+
 it("sets the metric version target", async () => {
     const { container } = renderMetricTarget({ type: "source_version", target: "10" })
     await typeInField("10", "4.2")

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,6 +14,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ## [Unreleased]
 
+### Fixed
+
+- The label and help text of the technical debt target field were colored red as if the field is mandatory. Fixes [#12300](https://github.com/ICTU/quality-time/issues/12300).
+
 ### Removed
 
 - Removed database migration code. As always, if your currently installed Quality-time version is not the penultimate version, check the upgrade path in the [versioning policy](versioning.md) before upgrading. Closes [#12289](https://github.com/ICTU/quality-time/issues/12289).


### PR DESCRIPTION
The label and help text of the technical debt target field were colored red as if the field is mandatory.

Fixes #12300.