### PR TITLE
Fix name of composite subject in changelog

### DIFF
--- a/components/shared_code/src/shared/model/subject.py
+++ b/components/shared_code/src/shared/model/subject.py
@@ -53,8 +53,16 @@ class Subject(dict):  # noqa: PLW1641
         """Either a custom name or one from the subject type in the data model."""
         if name := self.get("name"):
             return str(name)
-        default_name = self.__data_model["subjects"].get(self.type, {}).get("name")
-        return str(default_name) if default_name else None
+        return self._get_subject_type_name(self.__data_model["subjects"], self.type) if self.type else None
+
+    def _get_subject_type_name(self, subject_types, subject_type_key: str) -> str | None:
+        """Return the name of the subject type."""
+        for key, subject_type in subject_types.items():
+            if key == subject_type_key and (subject_type_name := subject_type.get("name")):
+                return str(subject_type_name)
+            if subject_type_name := self._get_subject_type_name(subject_type.get("subjects", {}), subject_type_key):
+                return subject_type_name
+        return None
 
     def summarize(self, measurements: dict[MetricId, list[Measurement]]) -> dict:
         """Create a summary dict of this subject."""

--- a/components/shared_code/tests/shared/model/test_subject.py
+++ b/components/shared_code/tests/shared/model/test_subject.py
@@ -1,5 +1,7 @@
 """Test the subject model."""
 
+import copy
+
 from shared.model.metric import Metric
 from shared.model.report import Report
 from shared.model.subject import Subject
@@ -57,9 +59,18 @@ class SubjectTest(DataModelTestCase):
         subject = Subject(self.DATA_MODEL, {"type": "software"}, SUBJECT_ID, self.report)
         self.assertEqual("Software", subject.name)
 
+    def test_missing_composite_name(self):
+        """Test that a composite subject has a name."""
+        subject = Subject(self.DATA_MODEL, {"type": "software_source_code"}, SUBJECT_ID, self.report)
+        self.assertEqual("Software source code", subject.name)
+
     def test_missing_default_name(self):
-        """Test that the subject name is None if both the subject and the data model have no name for the subject."""
-        data_model = {"subjects": {"type": "software"}}
+        """Test that the subject name is None if both the subject and the data model have no name for the subject.
+
+        In the current data model all subject types have a name, but in older versions they may not have.
+        """
+        data_model = copy.deepcopy(self.DATA_MODEL)
+        data_model["subjects"]["software"]["name"] = None
         subject = Subject(data_model, {"type": "software"}, SUBJECT_ID, self.report)
         self.assertIsNone(subject.name)
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,12 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- Composite subjects with a default name would be shown as having the name 'None' in the changelog. Fixes [#12318](https://github.com/ICTU/quality-time/issues/12318).
+
 ## v5.47.1 - 2025-11-28
 
 ### Fixed

--- a/tests/feature_tests/src/features/changelog.feature
+++ b/tests/feature_tests/src/features/changelog.feature
@@ -41,6 +41,30 @@ Feature: changelog
       Jane Doe created a new subject in report 'New report'.
       """
 
+  Scenario: create a report and a composite subject
+    When the client creates a report
+    And the client waits a second
+    And the client creates a subject with type "software_source_code"
+    And the client changes the subject name to "New name"
+    Then the changelog reads
+      """
+      Jane Doe changed the name of subject 'Software source code' in report 'New report' from '' to 'New name'.
+      Jane Doe created a new subject in report 'New report'.
+      Jane Doe created a new report.
+      Jane Doe changed the title of the reports overview from 'Reports' to 'Reports overview'.
+      """
+    And the report changelog reads
+      """
+      Jane Doe changed the name of subject 'Software source code' in report 'New report' from '' to 'New name'.
+      Jane Doe created a new subject in report 'New report'.
+      Jane Doe created a new report.
+      """
+    And the subject changelog reads
+      """
+      Jane Doe changed the name of subject 'Software source code' in report 'New report' from '' to 'New name'.
+      Jane Doe created a new subject in report 'New report'.
+      """
+
   Scenario: create a report, a subject, and a metric
     When the client creates a report
     And the client waits a second

--- a/tests/feature_tests/src/features/subject.feature
+++ b/tests/feature_tests/src/features/subject.feature
@@ -9,6 +9,10 @@ Feature: subject
     When the client creates a subject
     Then the subject type is "software"
 
+  Scenario: add composite subject
+    When the client creates a subject with type "software_source_code"
+    Then the subject type is "software_source_code"
+
   Scenario: delete subject
     Given an existing subject
     When the client deletes the subject


### PR DESCRIPTION
Composite subjects with a default name would be shown as having the name 'None' in the changelog.

Fixes #12318.