### PR TITLE
Filter metric types when adding metrics

### DIFF
--- a/components/frontend/src/metric/MetricType.jsx
+++ b/components/frontend/src/metric/MetricType.jsx
@@ -38,10 +38,18 @@ export function allMetricTypeOptions(dataModel) {
     return metricTypeOptions
 }
 
-export function usedMetricTypes(subject) {
+export function usedMetricTypesInSubject(subject) {
     const metricTypes = new Set()
     for (const metric of Object.values(subject.metrics)) {
         metricTypes.add(metric.type)
+    }
+    return Array.from(metricTypes)
+}
+
+export function usedMetricTypesInReport(report) {
+    const metricTypes = new Set()
+    for (const subject of Object.values(report.subjects)) {
+        usedMetricTypesInSubject(subject).forEach((metricType) => metricTypes.add(metricType))
     }
     return Array.from(metricTypes)
 }

--- a/components/frontend/src/subject/SubjectTable.jsx
+++ b/components/frontend/src/subject/SubjectTable.jsx
@@ -63,6 +63,7 @@ export function SubjectTable({
                 />
                 <SubjectTableFooter
                     reload={reload}
+                    report={report}
                     reports={reports}
                     stopFilteringAndSorting={() => {
                         handleSort(null)

--- a/components/frontend/src/subject/SubjectTableFooter.jsx
+++ b/components/frontend/src/subject/SubjectTableFooter.jsx
@@ -5,15 +5,20 @@ import { useContext } from "react"
 import { addMetric, copyMetric, moveMetric } from "../api/metric"
 import { DataModel } from "../context/DataModel"
 import { EDIT_REPORT_PERMISSION, ReadOnlyOrEditable } from "../context/Permissions"
-import { allMetricTypeOptions, metricTypeOptions, usedMetricTypes } from "../metric/MetricType"
-import { reportsPropType, subjectPropType } from "../sharedPropTypes"
+import {
+    allMetricTypeOptions,
+    metricTypeOptions,
+    usedMetricTypesInReport,
+    usedMetricTypesInSubject,
+} from "../metric/MetricType"
+import { reportPropType, reportsPropType, subjectPropType } from "../sharedPropTypes"
 import { ButtonRow } from "../widgets/ButtonRow"
 import { AddDropdownButton } from "../widgets/buttons/AddDropdownButton"
 import { CopyButton } from "../widgets/buttons/CopyButton"
 import { MoveButton } from "../widgets/buttons/MoveButton"
 import { metricOptions } from "../widgets/menu_options"
 
-function SubjectTableFooterButtonRow({ subject, subjectUuid, reload, reports, stopFilteringAndSorting }) {
+function SubjectTableFooterButtonRow({ subject, subjectUuid, reload, report, reports, stopFilteringAndSorting }) {
     const dataModel = useContext(DataModel)
     return (
         <TableRow>
@@ -27,7 +32,8 @@ function SubjectTableFooterButtonRow({ subject, subjectUuid, reload, reports, st
                             stopFilteringAndSorting()
                             addMetric(subjectUuid, subtype, reload)
                         }}
-                        usedItemSubtypeKeys={usedMetricTypes(subject)}
+                        usedItemSubtypeKeysInReport={usedMetricTypesInReport(report)}
+                        usedItemSubtypeKeysInSubject={usedMetricTypesInSubject(subject)}
                     />
                     <CopyButton
                         itemType="metric"
@@ -54,6 +60,7 @@ SubjectTableFooterButtonRow.propTypes = {
     subject: subjectPropType,
     subjectUuid: string,
     reload: func,
+    report: reportPropType,
     reports: reportsPropType,
     stopFilteringAndSorting: func,
 }

--- a/components/frontend/src/subject/SubjectTableFooter.test.jsx
+++ b/components/frontend/src/subject/SubjectTableFooter.test.jsx
@@ -23,6 +23,7 @@ it("shows the add metric button and adds a metric when clicked", async () => {
             <DataModel.Provider value={dataModel}>
                 <Table>
                     <SubjectTableFooter
+                        report={report}
                         reports={[]}
                         subjectUuid="subject_uuid"
                         subject={report.subjects.subject_uuid}
@@ -46,9 +47,10 @@ it("copies a metric when the copy button is clicked and a metric is selected", a
             <DataModel.Provider value={dataModel}>
                 <Table>
                     <SubjectTableFooter
+                        report={report}
+                        reports={[report]}
                         subjectUuid="subject_uuid"
                         subject={report.subjects.subject_uuid}
-                        reports={[report]}
                         stopFilteringAndSorting={stopFilteringAndSorting}
                     />
                 </Table>
@@ -68,9 +70,10 @@ it("moves a metric when the move button is clicked and a metric is selected", as
             <Permissions.Provider value={[EDIT_REPORT_PERMISSION]}>
                 <Table>
                     <SubjectTableFooter
+                        report={report}
+                        reports={[report]}
                         subjectUuid="subject_uuid"
                         subject={report.subjects.subject_uuid}
-                        reports={[report]}
                         stopFilteringAndSorting={stopFilteringAndSorting}
                     />
                 </Table>

--- a/components/frontend/src/widgets/buttons/AddDropdownButton.jsx
+++ b/components/frontend/src/widgets/buttons/AddDropdownButton.jsx
@@ -7,6 +7,8 @@ import {
     MenuItem,
     MenuList,
     Popover,
+    Radio,
+    RadioGroup,
     TextField,
     Tooltip,
     Typography,
@@ -27,7 +29,7 @@ FilterCheckbox.propTypes = {
     setFilter: func,
 }
 
-function FilterCheckboxes({
+function Filters({
     itemType,
     allowHidingUnsupportedItems,
     showUnsupportedItems,
@@ -35,6 +37,8 @@ function FilterCheckboxes({
     allowHidingUsedItems,
     hideUsedItems,
     setHideUsedItems,
+    hideUsedItemsScope,
+    setHideUsedItemsScope,
 }) {
     if (!allowHidingUnsupportedItems && !allowHidingUsedItems) {
         return null
@@ -49,16 +53,26 @@ function FilterCheckboxes({
                 />
             )}
             {allowHidingUsedItems && (
-                <FilterCheckbox
-                    label={`Hide ${itemType} types already used`}
-                    filter={hideUsedItems}
-                    setFilter={setHideUsedItems}
-                />
+                <>
+                    <FilterCheckbox
+                        label={`Hide ${itemType} types already used in this:`}
+                        filter={hideUsedItems}
+                        setFilter={setHideUsedItems}
+                    />
+                    <RadioGroup
+                        row
+                        value={hideUsedItemsScope}
+                        onChange={(event) => setHideUsedItemsScope(event.target.value)}
+                    >
+                        <FormControlLabel name="report" value="report" control={<Radio />} label="report" />
+                        <FormControlLabel name="subject" value="subject" control={<Radio />} label="subject" />
+                    </RadioGroup>
+                </>
             )}
         </FormGroup>
     )
 }
-FilterCheckboxes.propTypes = {
+Filters.propTypes = {
     itemType: string,
     allowHidingUnsupportedItems: bool,
     showUnsupportedItems: bool,
@@ -66,9 +80,19 @@ FilterCheckboxes.propTypes = {
     allowHidingUsedItems: bool,
     hideUsedItems: bool,
     setHideUsedItems: func,
+    hideUsedItemsScope: string,
+    setHideUsedItemsScope: func,
 }
 
-export function AddDropdownButton({ itemSubtypes, itemType, onClick, allItemSubtypes, usedItemSubtypeKeys, sort }) {
+export function AddDropdownButton({
+    itemSubtypes,
+    itemType,
+    onClick,
+    allItemSubtypes,
+    usedItemSubtypeKeysInReport,
+    usedItemSubtypeKeysInSubject,
+    sort,
+}) {
     const [anchorEl, setAnchorEl] = useState()
     const handleMenu = (event) => setAnchorEl(event.currentTarget)
     const onClickMenuItem = (value) => {
@@ -78,9 +102,11 @@ export function AddDropdownButton({ itemSubtypes, itemType, onClick, allItemSubt
     const [query, setQuery] = useState("") // Search query to filter item subtypes
     const [showUnsupportedItems, setShowUnsupportedItems] = useState(false) // Show only supported itemSubTypes or also unsupported itemSubTypes?
     const [hideUsedItems, setHideUsedItems] = useState(false) // Hide itemSubTypes already used?
+    const [hideUsedItemsScope, setHideUsedItemsScope] = useState("report") // Hide itemSubTypes already used in report or subject?
     let items = showUnsupportedItems ? allItemSubtypes : itemSubtypes
+    let usedItemKeys = hideUsedItemsScope === "report" ? usedItemSubtypeKeysInReport : usedItemSubtypeKeysInSubject
     if (hideUsedItems) {
-        items = items.filter((item) => !usedItemSubtypeKeys.includes(item.key))
+        items = items.filter((item) => !usedItemKeys.includes(item.key))
     }
     const options = items.filter((itemSubtype) => itemSubtype.text.toLowerCase().includes(query.toLowerCase()))
     // Unless specified not to, sort the options:
@@ -105,14 +131,16 @@ export function AddDropdownButton({ itemSubtypes, itemType, onClick, allItemSubt
                     sx={{ ml: "10px", mt: "10px", pr: "20px" }}
                     type="search"
                 />
-                <FilterCheckboxes
+                <Filters
                     itemType={itemType}
                     allowHidingUnsupportedItems={allItemSubtypes?.length > 0}
                     showUnsupportedItems={showUnsupportedItems}
                     setShowUnsupportedItems={setShowUnsupportedItems}
-                    allowHidingUsedItems={usedItemSubtypeKeys?.length > 0}
+                    allowHidingUsedItems={usedItemKeys?.length > 0}
                     hideUsedItems={hideUsedItems}
                     setHideUsedItems={setHideUsedItems}
+                    hideUsedItemsScope={hideUsedItemsScope}
+                    setHideUsedItemsScope={setHideUsedItemsScope}
                 />
                 <MenuList sx={{ height: "30vh", width: "50vw" }}>
                     <MenuItem disabled divider>
@@ -138,5 +166,6 @@ AddDropdownButton.propTypes = {
     itemType: string,
     onClick: func,
     sort: bool,
-    usedItemSubtypeKeys: arrayOf(string),
+    usedItemSubtypeKeysInReport: arrayOf(string),
+    usedItemSubtypeKeysInSubject: arrayOf(string),
 }

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,12 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Added
+
+- When adding metrics to subjects, allow for hiding metric types already used in the subject or in the whole report. Closes [#12374](https://github.com/ICTU/quality-time/issues/12374).
+
 ## v5.47.2 - 2025-12-05
 
 ### Fixed


### PR DESCRIPTION
When adding metrics to subjects, allow for hiding metric types already used in the subject or in the whole report.

Closes #12374.