### PR TITLE
Allow missing metrics to ignore metric types

### DIFF
--- a/components/collector/src/source_collectors/quality_time/missing_metrics.py
+++ b/components/collector/src/source_collectors/quality_time/missing_metrics.py
@@ -38,7 +38,7 @@ class QualityTimeMissingMetrics(QualityTimeCollector):
         included_entities = Entities(entity for entity in entities if self._include_entity(entity))
         return SourceMeasurement(total=str(total), entities=included_entities)
 
-    def _include_entity(self, entity: Entity) -> bool:
+    def _include_entity(self, entity: Entity) -> bool:  # noqa: PLR0911
         """Return whether to include the entity in the measurement."""
         metric_type = entity["metric_type"]
         metric_source_types = set(self.data_model["metrics"][metric_type]["sources"])
@@ -53,6 +53,9 @@ class QualityTimeMissingMetrics(QualityTimeCollector):
 
         metric_types_to_ignore = self._parameter("metric_types_to_ignore_when_used_at_least_once")
         if metric_type in metric_types_to_ignore and metric_type in self.__used_metric_types(entity["report_uuid"]):
+            return False
+
+        if metric_type in self._parameter("metric_types_to_ignore"):
             return False
 
         subjects_to_include = self._parameter("subjects_to_include")

--- a/components/collector/tests/source_collectors/quality_time/test_missing_metrics.py
+++ b/components/collector/tests/source_collectors/quality_time/test_missing_metrics.py
@@ -213,3 +213,9 @@ class QualityTimeMissingMetricsTest(QualityTimeTestCase):
         self.set_source_parameter("metric_types_to_ignore_when_used_at_least_once", ["Size (LOC)"])
         response = await self.collect(get_request_json_side_effect=[self.data_model, self.reports])
         self.assertNotIn("loc", [entity["metric_type"] for entity in response.sources[0].entities])
+
+    async def test_metric_types_to_ignore(self):
+        """Test that the number of non-ignored missing metrics is returned when filtered by metric type."""
+        self.set_source_parameter("metric_types_to_ignore", ["Test results"])
+        response = await self.collect(get_request_json_side_effect=[self.data_model, self.reports])
+        self.assertNotIn("tests", [entity["metric_type"] for entity in response.sources[0].entities])

--- a/components/shared_code/src/shared_data_model/sources/quality_time.py
+++ b/components/shared_code/src/shared_data_model/sources/quality_time.py
@@ -181,6 +181,13 @@ QUALITY_TIME = Source(
             placeholder="none",
             metrics=["missing_metrics"],
         ),
+        "metric_types_to_ignore": MultipleChoiceWithoutDefaultsParameter(
+            name="Metric types to ignore",
+            values=list(ALL_METRICS.keys()),
+            api_values=ALL_METRICS,
+            placeholder="none",
+            metrics=["missing_metrics"],
+        ),
         "source_type": MultipleChoiceWithDefaultsParameter(
             name="Source types",
             help="If provided, only count metrics with one or more sources of the selected source types.",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -25,6 +25,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Added
 
 - When adding metrics to subjects, allow for hiding metric types already used in the subject or in the whole report. Closes [#12374](https://github.com/ICTU/quality-time/issues/12374).
+- When measuring missing metrics, allow for ignoring specific metric types. Closes [#12377](https://github.com/ICTU/quality-time/issues/12377).
 - When measuring missing metrics, allow for ignoring metric types that have been used at least once. Closes [#12384](https://github.com/ICTU/quality-time/issues/12384).
 
 ## v5.47.2 - 2025-12-05


### PR DESCRIPTION
When measuring missing metrics, allow for ignoring specific metric types.

Closes #12377.