### PR TITLE
Missing metrics ignore types used at least once

### DIFF
--- a/components/collector/src/source_collectors/quality_time/missing_metrics.py
+++ b/components/collector/src/source_collectors/quality_time/missing_metrics.py
@@ -1,11 +1,16 @@
 """Quality-time missing metrics collector."""
 
+from typing import TYPE_CHECKING
+
 from collector_utilities.functions import match_string_or_regular_expression
 from collector_utilities.type import URL
 from model import SourceMeasurement, SourceResponses
 from model.entity import Entities, Entity
 
 from .base import QualityTimeCollector
+
+if TYPE_CHECKING:
+    from shared.utils.type import ReportId
 
 
 class QualityTimeMissingMetrics(QualityTimeCollector):
@@ -26,16 +31,17 @@ class QualityTimeMissingMetrics(QualityTimeCollector):
         """Get the metric entities from the responses."""
         datamodel_response, reports_response = responses
         self.data_model = await datamodel_response.json()
-        reports = await self._get_reports(reports_response)
+        self.reports = await self._get_reports(reports_response)
         landing_url = await self._landing_url(responses)
-        total = self.__nr_of_possible_metric_types(self.data_model, reports)
-        entities = self.__missing_metric_type_entities(self.data_model, reports, landing_url)
+        total = self.__nr_of_possible_metric_types(self.data_model, self.reports)
+        entities = self.__missing_metric_type_entities(self.data_model, self.reports, landing_url)
         included_entities = Entities(entity for entity in entities if self._include_entity(entity))
         return SourceMeasurement(total=str(total), entities=included_entities)
 
     def _include_entity(self, entity: Entity) -> bool:
         """Return whether to include the entity in the measurement."""
-        metric_source_types = set(self.data_model["metrics"][entity["metric_type"]]["sources"])
+        metric_type = entity["metric_type"]
+        metric_source_types = set(self.data_model["metrics"][metric_type]["sources"])
 
         source_types_to_include = set(self._parameter("source_types_to_include"))
         if not (source_types_to_include & metric_source_types):
@@ -43,6 +49,10 @@ class QualityTimeMissingMetrics(QualityTimeCollector):
 
         source_types_to_ignore = set(self._parameter("source_types_to_ignore"))
         if metric_source_types - source_types_to_ignore == set():
+            return False
+
+        metric_types_to_ignore = self._parameter("metric_types_to_ignore_when_used_at_least_once")
+        if metric_type in metric_types_to_ignore and metric_type in self.__used_metric_types(entity["report_uuid"]):
             return False
 
         subjects_to_include = self._parameter("subjects_to_include")
@@ -77,6 +87,15 @@ class QualityTimeMissingMetrics(QualityTimeCollector):
             entities.extend(self.__report_missing_metric_type_entities(data_model, report, landing_url))
         return entities
 
+    def __used_metric_types(self, report_uuid: ReportId) -> set[str]:
+        """Return the metric types used in the report with the given report UUID."""
+        metric_types = set()
+        report = next(report for report in self.reports if report["report_uuid"] == report_uuid)
+        for subject in report.get("subjects", {}).values():
+            for metric in subject.get("metrics", {}).values():
+                metric_types.add(metric["type"])
+        return metric_types
+
     def __report_missing_metric_type_entities(self, data_model: dict, report: dict, landing_url: URL) -> Entities:
         """Return the report's missing metric types as entities."""
         entities = Entities()
@@ -101,6 +120,7 @@ class QualityTimeMissingMetrics(QualityTimeCollector):
             Entity(
                 key=f"{report_uuid}:{subject_uuid}:{metric_type}",
                 report=report["title"],
+                report_uuid=report_uuid,
                 report_url=report_url,
                 subject=subject.get("name") or subject_type_name,
                 subject_url=f"{report_url}#{subject_uuid}",

--- a/components/shared_code/src/shared_data_model/sources/quality_time.py
+++ b/components/shared_code/src/shared_data_model/sources/quality_time.py
@@ -173,6 +173,14 @@ QUALITY_TIME = Source(
             api_values=ALL_METRICS,
             metrics=["metrics"],
         ),
+        "metric_types_to_ignore_when_used_at_least_once": MultipleChoiceWithoutDefaultsParameter(
+            name="Metric types to ignore when used at least once",
+            help="Ignore these metric types if they have been used at least once in the report.",
+            values=list(ALL_METRICS.keys()),
+            api_values=ALL_METRICS,
+            placeholder="none",
+            metrics=["missing_metrics"],
+        ),
         "source_type": MultipleChoiceWithDefaultsParameter(
             name="Source types",
             help="If provided, only count metrics with one or more sources of the selected source types.",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Added
 
 - When adding metrics to subjects, allow for hiding metric types already used in the subject or in the whole report. Closes [#12374](https://github.com/ICTU/quality-time/issues/12374).
+- When measuring missing metrics, allow for ignoring metric types that have been used at least once. Closes [#12384](https://github.com/ICTU/quality-time/issues/12384).
 
 ## v5.47.2 - 2025-12-05
 


### PR DESCRIPTION
When measuring missing metrics, allow for ignoring metric types that have been used at least once.

Closes #12384.