### PR TITLE
Fix incorrect sprint names

### DIFF
--- a/components/collector/src/source_collectors/jira/issues.py
+++ b/components/collector/src/source_collectors/jira/issues.py
@@ -12,7 +12,7 @@ from .base import JiraBase
 class JiraIssues(JiraBase):
     """Jira collector for issues."""
 
-    SPRINT_NAME_RE = re.compile(r",name=(.*),startDate=")
+    SPRINT_NAME_RE = re.compile(r",name=(.*),\w+=")
     DEFAULT_MAX_RESULTS: int = 500  # Fallback for maximum number of issues to retrieve per page from Jira
     max_results: int | None = None
 

--- a/components/collector/tests/source_collectors/jira/base.py
+++ b/components/collector/tests/source_collectors/jira/base.py
@@ -10,6 +10,9 @@ from tests.source_collectors.source_collector_test_case import SourceCollectorTe
 if TYPE_CHECKING:
     from model import MetricMeasurement
 
+type Comment = dict[str, list[dict[str, str]]]
+type IssueStatus = dict[str, dict[str, str]]
+
 
 class JiraTestCase(SourceCollectorTestCase):
     """Base class for Jira unit tests."""
@@ -26,7 +29,11 @@ class JiraTestCase(SourceCollectorTestCase):
         self.set_source_parameter("board", "Board 2")
         self.created = "2020-08-06T16:36:48.000+0200"
 
-    def issue(self, key: str = "1", **fields: str | dict[str, dict[str, str]]) -> dict:
+    def issue(
+        self,
+        key: str = "1",
+        **fields: str | int | list[str] | list[dict[str, str | int]] | Comment | IssueStatus | None,
+    ) -> dict:
         """Create a Jira issue."""
         return {"id": key, "key": key, "fields": dict(created=self.created, summary=f"Summary {key}", **fields)}
 

--- a/components/collector/tests/source_collectors/jira/test_user_story_points.py
+++ b/components/collector/tests/source_collectors/jira/test_user_story_points.py
@@ -32,7 +32,7 @@ class JiraUserStoryPointsTest(JiraTestCase):
         """Test that the number of story points and the sprints are returned, when sprint field is in text format."""
         user_stories_json = {
             "issues": [
-                self.issue(key="1", field=10, custom_field_001=["...,state=CLOSED,name=Sprint 1,startDate=..."]),
+                self.issue(key="1", field=10, custom_field_001=["...,state=CLOSED,name=Sprint 1,rapidViewId=..."]),
                 self.issue(key="2", field=32, custom_field_001=None),
             ],
         }
@@ -86,8 +86,8 @@ class JiraUserStoryPointsTest(JiraTestCase):
         """Test that the number of story points and the sprints are returned, when there are mixed sprint fields."""
         user_stories_json = {
             "issues": [
-                self.issue(key="1", field=1, custom_field_001=["...,state=CLOSED,name=Sprint 1,startDate=..."]),
-                self.issue(key="2", field=2, custom_field_001=["...,state=CLOSED,name=Sprint 1,startDate=..."]),
+                self.issue(key="1", field=1, custom_field_001=["...,state=CLOSED,name=Sprint 1,rapidViewId=..."]),
+                self.issue(key="2", field=2, custom_field_001=["...,state=CLOSED,name=Sprint 1,someOtherAttr=..."]),
                 self.issue(key="3", field=3, custom_field_001=[{"id": 1, "name": "Sprint 2", "state": "closed"}]),
                 self.issue(key="4", field=5, custom_field_001=[{"id": 1, "name": "Sprint 2", "state": "closed"}]),
                 self.issue(key="5", field=8, custom_field_001=None),

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,6 +14,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ## [Unreleased]
 
+### Fixed
+
+- When measuring issues with Jira as source, the names of sprints that issues belong to would not be correct. Fixes [#12328](https://github.com/ICTU/quality-time/issues/12328).
+
 ### Changed
 
 - Rename the 'tests' metric to 'test results' and the 'test suites' metric to 'test suite results' to better distinguish them from the 'test cases' metric. 'Tests' and 'test suites' metrics whose default name has not been overriden will automatically use the new default name. Closes [#12322](https://github.com/ICTU/quality-time/issues/12322).


### PR DESCRIPTION
When measuring issues with Jira as source, the names of sprints that issues belong to would not be correct.

Fixes #12328.