### PR TITLE
Fix notifications about metrics without unit

### DIFF
--- a/components/notifier/src/models/metric_notification_data.py
+++ b/components/notifier/src/models/metric_notification_data.py
@@ -6,8 +6,9 @@ from shared_data_model import DATA_MODEL
 
 if TYPE_CHECKING:
     from shared.model.measurement import Measurement
-    from shared.model.metric import Metric, MetricId
+    from shared.model.metric import Metric
     from shared.model.subject import Subject
+    from shared.utils.type import MetricId
 
 NR_OF_MEASUREMENTS_NEEDED_TO_DETERMINE_STATUS: Final = 1
 NR_OF_MEASUREMENTS_NEEDED_TO_DETERMINE_STATUS_CHANGE: Final = 2
@@ -29,8 +30,8 @@ class MetricNotificationData:
         self.metric = metric
         self.metric_uuid = metric_uuid
         self.measurements = measurements
-        self.metric_name = metric["name"] or DATA_MODEL.metrics[metric["type"]].name
-        self.metric_unit = metric["unit"] or DATA_MODEL.metrics[metric["type"]].unit.value
+        self.metric_name = metric.get("name") or DATA_MODEL.metrics[metric["type"]].name
+        self.metric_unit = metric.get("unit") or DATA_MODEL.metrics[metric["type"]].unit.value
         self.subject_name = subject.get("name") or DATA_MODEL.all_subjects[subject["type"]].name
         self.scale = metric.scale()
         self.status = self.__status(LAST)

--- a/components/notifier/tests/models/base.py
+++ b/components/notifier/tests/models/base.py
@@ -1,0 +1,26 @@
+"""Base classes for the model unit tests."""
+
+import json
+import unittest
+from typing import ClassVar, cast
+
+from shared_data_model import DATA_MODEL_JSON
+
+
+class DataModelTestCase(unittest.TestCase):
+    """Base class for unit tests that use the data model."""
+
+    DATA_MODEL: ClassVar[dict] = {}
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Override to set up the data model."""
+        cls.DATA_MODEL = cls.load_data_model()
+
+    @staticmethod
+    def load_data_model() -> dict:
+        """Load the data model from the JSON dump."""
+        data_model = cast(dict, json.loads(DATA_MODEL_JSON))
+        data_model["_id"] = "id"
+        data_model["timestamp"] = "now"
+        return data_model

--- a/components/notifier/tests/models/test_metric_notification_data.py
+++ b/components/notifier/tests/models/test_metric_notification_data.py
@@ -1,50 +1,70 @@
 """Unit tests for the metric notification data model."""
 
-import unittest
-
 from shared.model.metric import Metric
+from shared.model.report import Report
+from shared.model.subject import Subject
 
 from models.metric_notification_data import MetricNotificationData
 
-from tests.fixtures import METRIC_ID
+from tests.fixtures import METRIC_ID, SUBJECT_ID
+
+from .base import DataModelTestCase
 
 
-class MetricNotificationDataModelTestCase(unittest.TestCase):
+class MetricNotificationDataModelTestCase(DataModelTestCase):
     """Unit tests for the metric notification data."""
 
-    def setUp(self):
-        """Set variables for the other testcases."""
-        self.metric = Metric(
-            {},
-            {
-                "type": "metric_type",
-                "name": "default metric 1",
-                "unit": "units",
-                "scale": "count",
-            },
-            METRIC_ID,
-        )
-        self.measurements = [
+    def metric(self, name: str | None = "default metric 1", unit: str | None = "unit") -> Metric:
+        """Create a metric fixture."""
+        metric_data = {"type": "violations", "scale": "count"}
+        if name is not None:
+            metric_data["name"] = name
+        if unit is not None:
+            metric_data["unit"] = unit
+        return Metric(self.DATA_MODEL, metric_data, METRIC_ID)
+
+    def measurements(self, status: str | None = "target_not_met") -> list:
+        """Create measurements fixture."""
+        return [
             {"count": {"value": 10, "status": "target_met"}},
-            {"count": {"value": 20, "status": "target_not_met"}},
+            {"count": {"value": 20, "status": status}},
         ]
-        self.subject = {"type": "software", "name": "Subject"}
+
+    def subject(self) -> Subject:
+        """Create a subject fixture."""
+        report = Report(self.DATA_MODEL, {})
+        return Subject(self.DATA_MODEL, {"type": "software", "name": "Subject"}, SUBJECT_ID, report)
 
     def test_new_status(self):
         """Test that the new status is set correctly."""
-        notification_data = MetricNotificationData(self.metric, METRIC_ID, self.measurements, self.subject)
+        notification_data = MetricNotificationData(self.metric(), METRIC_ID, self.measurements(), self.subject())
+        self.assertEqual("target_not_met", notification_data.status)
+        self.assertEqual("target not met (red)", notification_data.new_metric_status)
+
+    def test_new_status_for_metric_without_unit(self):
+        """Test that the new status is set correctly, even if the metric has no unit."""
+        notification_data = MetricNotificationData(
+            self.metric(unit=None), METRIC_ID, self.measurements(), self.subject()
+        )
+        self.assertEqual("target_not_met", notification_data.status)
+        self.assertEqual("target not met (red)", notification_data.new_metric_status)
+
+    def test_new_status_for_metric_without_name(self):
+        """Test that the new status is set correctly, even if the metric has no name."""
+        notification_data = MetricNotificationData(
+            self.metric(name=None), METRIC_ID, self.measurements(), self.subject()
+        )
         self.assertEqual("target_not_met", notification_data.status)
         self.assertEqual("target not met (red)", notification_data.new_metric_status)
 
     def test_unknown_status(self):
         """Test that a recent measurement without status works."""
-        self.measurements[-1]["count"]["status"] = None
-        notification_data = MetricNotificationData(self.metric, METRIC_ID, self.measurements, self.subject)
+        notification_data = MetricNotificationData(self.metric(), METRIC_ID, self.measurements(None), self.subject())
         self.assertEqual("unknown", notification_data.status)
         self.assertEqual("unknown (white)", notification_data.new_metric_status)
 
     def test_unknown_status_without_recent_measurements(self):
         """Test that a metric without recent measurements works."""
-        notification_data = MetricNotificationData(self.metric, METRIC_ID, [], self.subject)
+        notification_data = MetricNotificationData(self.metric(), METRIC_ID, [], self.subject())
         self.assertEqual("unknown", notification_data.status)
         self.assertEqual("unknown (white)", notification_data.new_metric_status)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,12 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- The notifier would fail to notify about metrics without a unit, such as the version metric. Fixes [#12412](https://github.com/ICTU/quality-time/issues/12412).
+
 ## v5.48.0 - 2025-12-12
 
 ### Fixed


### PR DESCRIPTION
The notifier would fail to notify about metrics without a unit, such as the version metric.

Fixes #12412.