### PR TITLE
Fix parsing OWASP Dependency Check JSON from GitLab

### DIFF
--- a/components/collector/src/source_collectors/owasp_dependency_check_json/base.py
+++ b/components/collector/src/source_collectors/owasp_dependency_check_json/base.py
@@ -1,19 +1,27 @@
 """Base classes for OWASP Dependency-Check JSON collectors."""
 
 from abc import ABC
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, cast
 
 from base_collectors import JSONFileSourceCollector
 from collector_utilities.exceptions import JSONAttributeError
 
+from .json_types import OWASPDependencyCheckJSON
+
 if TYPE_CHECKING:
-    from .json_types import OWASPDependencyCheckJSON
+    from collector_utilities.type import Response
 
 
 class OWASPDependencyCheckJSONBase(JSONFileSourceCollector, ABC):
     """Base class for OWASP Dependency-Check JSON collectors."""
 
     allowed_report_schemas: ClassVar[list[str]] = ["1.1"]
+
+    async def _json(self, response: Response) -> OWASPDependencyCheckJSON:
+        """Extract the JSON from the response."""
+        json = cast(OWASPDependencyCheckJSON, await response.json(content_type=None))
+        self._check_report_schema(json)
+        return json
 
     def _check_report_schema(self, json: OWASPDependencyCheckJSON) -> None:
         """Check that the report schema is allowed."""

--- a/components/collector/src/source_collectors/owasp_dependency_check_json/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/owasp_dependency_check_json/source_up_to_dateness.py
@@ -1,12 +1,11 @@
 """OWASP Dependency-Check JSON source up-to-dateness collector."""
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from base_collectors import TimePassedCollector
 from collector_utilities.date_time import parse_datetime
 
 from .base import OWASPDependencyCheckJSONBase
-from .json_types import OWASPDependencyCheckJSON
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -19,6 +18,5 @@ class OWASPDependencyCheckJSONSourceUpToDateness(OWASPDependencyCheckJSONBase, T
 
     async def _parse_source_response_date_time(self, response: Response) -> datetime:
         """Override to parse the report date from the JSON."""
-        json = cast(OWASPDependencyCheckJSON, await response.json())
-        self._check_report_schema(json)
+        json = await self._json(response)
         return parse_datetime(json.get("projectInfo", {}).get("reportDate", ""))

--- a/components/collector/src/source_collectors/owasp_dependency_check_json/source_version.py
+++ b/components/collector/src/source_collectors/owasp_dependency_check_json/source_version.py
@@ -1,13 +1,12 @@
 """OWASP Dependency-Check JSON source version collector."""
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from packaging.version import Version
 
 from base_collectors import VersionCollector
 
 from .base import OWASPDependencyCheckJSONBase
-from .json_types import OWASPDependencyCheckJSON
 
 if TYPE_CHECKING:
     from collector_utilities.type import Response
@@ -18,6 +17,5 @@ class OWASPDependencyCheckJSONSourceVersion(OWASPDependencyCheckJSONBase, Versio
 
     async def _parse_source_response_version(self, response: Response) -> Version:
         """Override to parse the OWASP Dependency-Check version from the JSON."""
-        json = cast(OWASPDependencyCheckJSON, await response.json())
-        self._check_report_schema(json)
+        json = await self._json(response)
         return Version(json.get("scanInfo", {}).get("engineVersion", ""))

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -10,6 +10,12 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- When measuring source up-to-dateness or source version with OWASP Dependency Check JSON reports located in GitLab, parsing the JSON would fail because GitLab returns the JSON files with mimetype application/octet-stream. Fixes [#12323](https://github.com/ICTU/quality-time/issues/12323).
+
 ## v5.48.1 - 2025-12-19
 
 ### Fixed


### PR DESCRIPTION
When measuring source up-to-dateness or source version with OWASP Dependency Check JSON reports located in GitLab, parsing the JSON would fail because GitLab returns the JSON files with mimetype application/octet-stream.

Fixes #12323.