### PR TITLE
Rmove unnecessary suppression in CHANGELOG.md

### DIFF
--- a/docs/.markdownlint.json
+++ b/docs/.markdownlint.json
@@ -1,11 +1,13 @@
 {
-  "MD013": {
-    "line_length": 10000
-  },
-  "MD024": false,
-  "MD025": false,
-  "MD034": false,
-  "MD046": {
-    "style": "fenced"
-  }
+    "MD013": {
+        "line_length": 10000
+    },
+    "MD024": {
+        "siblings_only": true
+    },
+    "MD025": false,
+    "MD034": false,
+    "MD046": {
+        "style": "fenced"
+    }
 }

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,7 +1,5 @@
 # Changelog
 
-<!-- markdownlint-disable MD024 -->
-
 All notable changes to *Quality-time* will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).


### PR DESCRIPTION
Rmove the unnecessary suppression of duplicate-headers in CHANGELOG.md. Markdownlint supports checking for duplicatie headers in siblings only.