### PR TITLE
Remove query from links included in Jira issues

### DIFF
--- a/components/api_server/src/routes/metric.py
+++ b/components/api_server/src/routes/metric.py
@@ -214,7 +214,7 @@ def create_issue_text(metric: Metric, measured_value: Value) -> tuple[str, str]:
     metric_url = dict(bottle.request.json)["metric_url"]
     source_names = ", ".join([source.name or DATA_MODEL.sources[str(source.type)].name for source in metric.sources])
     # See https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=links
-    # for the text formatting notiation used by Jira API version 2.
+    # for the text formatting notation used by Jira API version 2.
     source_urls = [f"[{url}|{url}]" for url in [get_source_url(source) for source in metric.sources] if url]
     percentage = "%" if metric.scale() == "percentage" else ""
     issue_summary = f"Fix {measured_value}{percentage} {metric.unit} from {source_names}"

--- a/components/frontend/src/api/metric.js
+++ b/components/frontend/src/api/metric.js
@@ -27,7 +27,7 @@ export function setMetricDebt(metricUuid, value, reload) {
 }
 
 export function addMetricIssue(metricUuid, reload, showMessage) {
-    const payload = { metric_url: `${globalThis.location}#${metricUuid}` }
+    const payload = { metric_url: `${globalThis.location.origin}${globalThis.location.pathname}#${metricUuid}` }
     return fetchServerApi("post", `metric/${metricUuid}/issue/new`, payload)
         .then((json) => {
             if (json.ok) {

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,6 +14,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ### Fixed
 
+- When creating an issue from Quality-time in Jira, make sure that the link back to Quality-time doesn't expand any items but only goes to the metric. Fixes [#12481](https://github.com/ICTU/quality-time/issues/12481).
 - Count a Jira issue linked to multiple metrics only once in the issues dashboard card. Fixes [#12483](https://github.com/ICTU/quality-time/issues/12483).
 
 ## v5.48.2 - 2026-01-09


### PR DESCRIPTION
When creating an issue from Quality-time in Jira, make sure that the link back to Quality-time doesn't expand any items but only goes to the metric.

Fixes #12481.