### PR TITLE
Fix PDF-export on Kubernetes

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 - When creating an issue from Quality-time in Jira, make sure that the link back to Quality-time doesn't expand any items but only goes to the metric. Fixes [#12481](https://github.com/ICTU/quality-time/issues/12481).
 - Count a Jira issue linked to multiple metrics only once in the issues dashboard card. Fixes [#12483](https://github.com/ICTU/quality-time/issues/12483).
 - Remove restart policy from docker-compose.yml. Fixes [#12506](https://github.com/ICTU/quality-time/issues/12506).
+- Fix missing service in renderer Helm chart that was causing PDF-exports to fail on Kubernetes. Fixes [#12514](https://github.com/ICTU/quality-time/issues/12514).
 
 ## v5.48.2 - 2026-01-09
 

--- a/helm/templates/api_server.yaml
+++ b/helm/templates/api_server.yaml
@@ -31,6 +31,8 @@ spec:
                 name: {{ .Release.Name }}-{{ template "api_server_name" . }}-env
                 optional: true
           env:
+            - name: RENDERER_HOST
+              value: {{ .Release.Name }}-{{ template "renderer_name" . }}
             - name: DATABASE_HOST
               value: {{ .Release.Name }}-{{ template "database_name" . }}
             - name: DATABASE_USERNAME

--- a/helm/templates/renderer.yaml
+++ b/helm/templates/renderer.yaml
@@ -45,6 +45,26 @@ spec:
       restartPolicy: Always
 ---
 apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-{{ template "renderer_name" . }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: {{ template "renderer_name" . }}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: {{ template "renderer_name" . }}
+  ports:
+    - protocol: TCP
+      port: 9000
+      targetPort: 9000
+  sessionAffinity: None
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-{{ template "renderer_name" . }}-env


### PR DESCRIPTION
Add missing service to renderer Helm chart that was causing PDF-exports to fail on Kubernetes.

Fixes #12514.