### PR TITLE
Mass edit changing too many sources

### DIFF
--- a/components/api_server/src/utils/type.py
+++ b/components/api_server/src/utils/type.py
@@ -7,6 +7,10 @@ from typing import Literal, NewType, TypedDict, TYPE_CHECKING
 if TYPE_CHECKING:
     from datetime import datetime
 
+    from model.report import Report
+    from shared.model.metric import Metric
+    from shared.model.source import Source
+    from shared.model.subject import Subject
 
 Change = dict[str, str | dict[str, str]]
 EditScope = Literal["source", "metric", "subject", "report", "reports"]
@@ -47,3 +51,13 @@ class SessionData(TypedDict, total=False):
     email: str
     common_name: str
     session_expiration_datetime: datetime
+
+
+@dataclass
+class SourceContext:
+    """Source, combined with its containing metric, subject, and report."""
+
+    metric: Metric
+    report: Report
+    source: Source
+    subject: Subject

--- a/components/api_server/tests/fixtures.py
+++ b/components/api_server/tests/fixtures.py
@@ -49,7 +49,7 @@ def create_report():
                             SOURCE_ID: {
                                 "type": "sonarqube",
                                 "name": "Source",
-                                "parameters": {"url": "https://url", "password": "password"},  # nosec
+                                "parameters": {"url": "https://url", "password": "password", "tags": ["security"]},  # nosec
                             },
                         },
                     },

--- a/components/shared_code/src/shared/model/source.py
+++ b/components/shared_code/src/shared/model/source.py
@@ -22,9 +22,9 @@ class Source(dict):
         super().__init__(*args, **kwargs)
 
     @property
-    def type(self) -> str | None:
+    def type(self) -> str:
         """Return the type of the source."""
-        return str(self["type"]) if "type" in self else None
+        return str(self.get("type", "unknown"))
 
     @property
     def name(self) -> str | None:

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -15,6 +15,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Fixed
 
 - When creating an issue from Quality-time in Jira, make sure that the link back to Quality-time doesn't expand any items but only goes to the metric. Fixes [#12481](https://github.com/ICTU/quality-time/issues/12481).
+- When mass editing a source parameter, only change sources that actually have the parameter being changed. Fixes [#12482](https://github.com/ICTU/quality-time/issues/12482).
 - Count a Jira issue linked to multiple metrics only once in the issues dashboard card. Fixes [#12483](https://github.com/ICTU/quality-time/issues/12483).
 - Remove restart policy from docker-compose.yml. Fixes [#12506](https://github.com/ICTU/quality-time/issues/12506).
 - Fix missing service in renderer Helm chart that was causing PDF-exports to fail on Kubernetes. Fixes [#12514](https://github.com/ICTU/quality-time/issues/12514).

--- a/tests/feature_tests/src/features/source.feature
+++ b/tests/feature_tests/src/features/source.feature
@@ -121,8 +121,9 @@ Feature: source
     Then the source parameter url equals "None"
     And the availability status code equals "[]"
 
-  Scenario: change source token parameter with token validation path, attempt 4
-    Given an existing source with type "jira" and parameter url "https://jira.doesnotexist"
+  Scenario: change source token parameter with token validation path
+    Given an existing metric with type "issues"
+    And an existing source with type "jira" and parameter url "https://jira.doesnotexist"
     When the client sets the source parameter private_token to "secret"
     Then the source parameter private_token equals "this string replaces credentials"
     And the availability status code equals "-1"


### PR DESCRIPTION
When mass editing a source parameter, only change sources that actually have the parameter being changed.

Fixes #12482.