### PR TITLE
Fix SonarCloud frontend test coverage

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -67,7 +67,7 @@ jobs:
         working-directory: components/frontend
         env:
           CI: true
-        run: uvx --from=$(cat $GITHUB_WORKSPACE/tools/requirements-just.txt) just build test cov
+        run: uvx --from=$(cat $GITHUB_WORKSPACE/tools/requirements-just.txt) just test cov
       - name: Create packages
         if: env.SONAR_TOKEN != null
         run: |


### PR DESCRIPTION
Apparently `just build test cov` only runs the build command, despite the documentation saying that it should be possible to specify multiple recipes on the command line. Fixed by removing the build recipe which isn't needed here anyway.