### PR TITLE
Attempt LDAP bind if password hash isn't Argon2

### DIFF
--- a/components/api_server/src/routes/auth.py
+++ b/components/api_server/src/routes/auth.py
@@ -54,10 +54,14 @@ def set_session_cookie(session_id: SessionId, expires_datetime: datetime) -> Non
     bottle.response.set_cookie("session_id", session_id, **options)
 
 
-def check_password(password_hash, password) -> bool:
+def check_password(password_hash: bytes, password: str) -> bool:
     """Check the OpenLDAP password hash against the given password."""
     # Note we currently only support ARGON2 hashes
-    return argon2.PasswordHasher().verify(password_hash.decode().removeprefix("{ARGON2}"), password)
+    hash_prefix = "{ARGON2}"
+    decoded_hash = password_hash.decode()
+    if decoded_hash.startswith(hash_prefix):
+        return argon2.PasswordHasher().verify(decoded_hash.removeprefix(hash_prefix), password)
+    return False
 
 
 def get_credentials() -> tuple[str, str]:

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -10,6 +10,12 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- When using an LDAP server with a password hash scheme other than Argon2, Quality-time would not attempt an LDAP bind to verify the user. Fixes [#12595](https://github.com/ICTU/quality-time/issues/12595).
+
 ## v5.48.3 - 2026-01-29
 
 ### Fixed

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -88,4 +88,5 @@ linkcheck_ignore = [
     # 404 Client Error: Not Found
     # See https://community.sonarsource.com/t/https-rules-sonarsource-com-down/177294?u=fniessink:
     "https://rules.sonarsource.com/.*",
+    "https://www.ictu.nl/en/about-us",  # False negative: 415 Client Error: Unsupported Media Type
 ]

--- a/docs/src/deployment.md
+++ b/docs/src/deployment.md
@@ -92,7 +92,7 @@ See [https://ldap.com/ldap-filters/](https://ldap.com/ldap-filters/) for more in
 Quality-time tries two methods to authenticate users:
 
 - If the LDAP-server returns the `userPassword` (containing a hash of the users' password), Quality-time uses that to verify the password. Note that currently only `ARGON2` hashes are supported. Please submit a feature request if you need support for another type of hash.
-- If the `userPassword` is not returned, Quality-time attempts an LDAP-bind.
+- If the `userPassword` is not returned or it is no `ARGON2` hash, Quality-time attempts an LDAP-bind operation using the user's distinguished name as returned by the LDAP-server and the password entered by the user.
 
 ```{index} Forwarded Authentication
 ```

--- a/docs/src/versioning.md
+++ b/docs/src/versioning.md
@@ -29,7 +29,8 @@ The MongoDB version, the MongoDB feature compatibility, and the migrations all l
 
 | Version    | Date       | Mongo  | FC     | Migrations  | Max. downgrade | Max. upgrade | Manual changes |
 |------------|------------|--------|--------|-------------|----------------|--------------|----------------|
-| v5.48.3    | 2026-01-29 | v8     | v8     |             | v5.47.2        | n/a          | no             |
+| v5.48.4    | 2026-02-06 | v8     | v8     |             | v5.47.2        | n/a          | no             |
+| v5.48.3    | 2026-01-29 | v8     | v8     |             | v5.47.2        | latest       | no             |
 | v5.48.2    | 2026-01-09 | v8     | v8     |             | v5.47.2        | latest       | no             |
 | v5.48.1    | 2025-12-19 | v8     | v8     |             | v5.47.2        | latest       | no             |
 | v5.48.0    | 2025-12-12 | v8     | v8     |             | v5.47.2        | latest       | no             |


### PR DESCRIPTION
When using an LDAP server with a password hash scheme other than Argon2, Quality-time would not attempt an LDAP bind to verify the user.

Fixes #12595.