### PR TITLE
Fix busy wait in the UI

### DIFF
--- a/components/frontend/package-lock.json
+++ b/components/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "quality-time-app",
-    "version": "5.48.3",
+    "version": "5.48.4-rc.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "quality-time-app",
-            "version": "5.48.3",
+            "version": "5.48.4-rc.0",
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",

--- a/components/frontend/src/hooks/hash_fragment.js
+++ b/components/frontend/src/hooks/hash_fragment.js
@@ -16,6 +16,7 @@ export function useHashFragment(trigger = true) {
     useEffect(() => {
         if (!trigger) return // Only scroll if trigger is true, e.g. after loading data has finished
         const { hash } = globalThis.location
+        if (!hash) return // No hash to scroll to
         return waitForElementById(hash?.replace("#", ""), (element) => element.scrollIntoView(true))
     }, [trigger])
 }

--- a/components/frontend/src/hooks/hash_fragment.test.js
+++ b/components/frontend/src/hooks/hash_fragment.test.js
@@ -13,6 +13,7 @@ afterEach(() => {
 
 it("does not scroll if trigger is false", () => {
     globalThis.addEventListener = vi.fn()
+    globalThis.location = { hash: "#d57aa11f-9bbb-4297-91e6-062e20c0a953" }
     const mockScrollIntoView = vi.fn()
     document.getElementById = () => {
         return { scrollIntoView: mockScrollIntoView }
@@ -22,8 +23,21 @@ it("does not scroll if trigger is false", () => {
     expect(mockScrollIntoView).not.toHaveBeenCalled()
 })
 
-it("does not scroll if trigger is true but no element found", () => {
+it("does not scroll if trigger is true but no hash is present", () => {
     globalThis.addEventListener = vi.fn()
+    globalThis.location = { hash: "" }
+    const mockScrollIntoView = vi.fn()
+    document.getElementById = () => {
+        return { scrollIntoView: mockScrollIntoView }
+    }
+    renderHook(() => useHashFragment(true))
+    expect(vi.getTimerCount()).toBe(0)
+    expect(mockScrollIntoView).not.toHaveBeenCalled()
+})
+
+it("does not scroll if trigger is true and hash is present, but element does not appear", () => {
+    globalThis.addEventListener = vi.fn()
+    globalThis.location = { hash: "#d57aa11f-9bbb-4297-91e6-062e20c0a954" }
     document.getElementById = () => {
         return null
     }
@@ -34,8 +48,9 @@ it("does not scroll if trigger is true but no element found", () => {
     expect(vi.getTimerCount()).toBe(0)
 })
 
-it("does scroll if trigger is true and element found", () => {
+it("does scroll if trigger is true, hash is present, and element does appear", () => {
     globalThis.addEventListener = vi.fn()
+    globalThis.location = { hash: "#d57aa11f-9bbb-4297-91e6-062e20c0a955" }
     const mockScrollIntoView = vi.fn()
     document.getElementById = () => {
         return { scrollIntoView: mockScrollIntoView }

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -15,6 +15,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Fixed
 
 - When using an LDAP server with a password hash scheme other than Argon2, Quality-time would not attempt an LDAP bind to verify the user. Fixes [#12595](https://github.com/ICTU/quality-time/issues/12595).
+- Don't make the UI wait for a metric to scroll to if the URL has no hash with a metric identifier. Fixes [#12598](https://github.com/ICTU/quality-time/issues/12598).
 
 ## v5.48.3 - 2026-01-29
 


### PR DESCRIPTION
Don't make the UI wait for a metric to scroll to if the URL has no hash with a metric identifier.

Fixes #12598.