### PR TITLE
Don't attempt to verify empty usernames with the LDAP server.

### DIFF
--- a/components/api_server/src/routes/auth.py
+++ b/components/api_server/src/routes/auth.py
@@ -140,7 +140,7 @@ def login(database: Database) -> dict[str, bool | str]:
         user = User(username, username or "", "", username is not None)
     else:
         username, password = get_credentials()
-        user = verify_user(database, username, password)
+        user = verify_user(database, username, password) if username else User(username)
     session_expiration_datetime = (
         create_session(database, user) if user.verified else datetime.min.replace(tzinfo=tzutc())
     )

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,9 +14,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ### Fixed
 
-- When using an LDAP server with a password hash scheme other than Argon2, Quality-time would not attempt an LDAP bind to verify the user. Fixes [#12595](https://github.com/ICTU/quality-time/issues/12595).
-- Don't make the UI wait for a metric to scroll to if the URL has no hash with a metric identifier. Fixes [#12598](https://github.com/ICTU/quality-time/issues/12598).
 - Date pickers would lose focus while editing a date. Fixes [#12591](https://github.com/ICTU/quality-time/issues/12591).
+- When using an LDAP server with a password hash scheme other than Argon2, Quality-time would not attempt an LDAP bind to verify the user. Fixes [#12595](https://github.com/ICTU/quality-time/issues/12595).
+- Don't attempt to verify empty usernames with the LDAP server. Fixes [#12597](https://github.com/ICTU/quality-time/issues/12597).
+- Don't make the UI wait for a metric to scroll to if the URL has no hash with a metric identifier. Fixes [#12598](https://github.com/ICTU/quality-time/issues/12598).
 
 ## v5.48.3 - 2026-01-29
 


### PR DESCRIPTION
Prevent API-server logging:

Could not authenticate LDAP user: list index out of range Traceback (most recent call last):
  File "/Users/fniessink/Developer/quality-time/components/api_server/src/routes/auth.py", line 110, in verify_user
    ldap_user = lookup_connection.entries[0]
                ~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range

Fixes #12597.