### PR TITLE
Use ruff to check Markdown Python code blocks

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -33,13 +33,17 @@ line-length = 120
 src = [
     "src",
 ]
+extend-include = [ "src/*.md" ]
+preview = true  # Formatting Markdown Python code blocks is only availabe in preview mode
 lint.select = [
     "ALL",
 ]
 lint.ignore = [
     "COM812", # https://docs.astral.sh/ruff/rules/missing-trailing-comma/ - this rule may cause conflicts when used with the ruff formatter
+    "CPY001", # https://docs.astral.sh/ruff/rules/missing-copyright-notice/ - unstable rule
     "D203",   # https://docs.astral.sh/ruff/rules/one-blank-line-before-class/ - prevent warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible. Ignoring `one-blank-line-before-class`
     "D213",   # https://docs.astral.sh/ruff/rules/multi-line-summary-second-line/ - prevent warning: `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Ignoring `multi-line-summary-second-line`
+    "DOC201", # https://docs.astral.sh/ruff/rules/docstring-missing-returns/ - unstable rule
     "FBT",    # https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt - not sure of the value of preventing "boolean traps"
     "ISC001", # https://docs.astral.sh/ruff/rules/single-line-implicit-string-concatenation/ - this rule may cause conflicts when used with the ruff formatter
     "PD",     # https://docs.astral.sh/ruff/rules/#pandas-vet-pd - pandas isn't used

--- a/docs/src/create_reference_md.py
+++ b/docs/src/create_reference_md.py
@@ -1,5 +1,6 @@
 """Script to convert the data model in a Markdown file."""
 
+import operator
 import pathlib
 import re
 from typing import TYPE_CHECKING, Literal
@@ -44,7 +45,7 @@ def data_model_metric_items() -> list[tuple[str, Metric]]:
 def data_model_metric_source_keys_and_names(metric: Metric) -> list[tuple[str, str]]:
     """Return the data model metric source keys and source names, sorted by name."""
     keys_and_names = [(source_key, DATA_MODEL.sources[source_key].name) for source_key in metric.sources]
-    return sorted(keys_and_names, key=lambda key_and_name: key_and_name[1])
+    return sorted(keys_and_names, key=operator.itemgetter(1))
 
 
 def markdown_paragraph(text: str) -> str:
@@ -244,7 +245,7 @@ def parameter_paragraph(parameters: list[Parameter], mandatory: bool) -> str:
 def parameter_description(parameter: Parameter) -> str:
     """Return the Markdown version of the parameter."""
     help_text = " " + parameter.help if parameter.help else ""
-    if parameter.type in ("single_choice", "multiple_choice_with_defaults", "multiple_choice_without_defaults"):
+    if parameter.type in {"single_choice", "multiple_choice_with_defaults", "multiple_choice_without_defaults"}:
         parameter_type = parameter.type.replace("_", " ")
         values = ", ".join(sorted([f"`{value}`" for value in parameter.values or []]))
         values_text = f" This is a {parameter_type} parameter. Possible values are: {values}."

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -382,9 +382,7 @@ CLOC = Source(
     description="cloc is an open-source tool for counting blank lines, comment lines, and physical lines of source "
     "code in many programming languages.",
     url="https://github.com/AlDanial/cloc",
-    parameters=dict(
-        **access_parameters(["loc"], source_type="cloc report", source_type_format="JSON")
-    ),
+    parameters=dict(**access_parameters(["loc"], source_type="cloc report", source_type_format="JSON")),
 )
 ```
 
@@ -473,9 +471,11 @@ class ClocLOCTest(SourceCollectorTestCase):
     async def test_loc(self):
         """Test that the number of lines is returned."""
         cloc_json = {
-            "header": {}, "SUM": {},  # header and SUM are not used
+            "header": {},
+            "SUM": {},  # header and SUM are not used
             "Python": {"nFiles": 1, "blank": 5, "comment": 10, "code": 60},
-            "JavaScript": {"nFiles": 1, "blank": 2, "comment": 0, "code": 30}}
+            "JavaScript": {"nFiles": 1, "blank": 2, "comment": 0, "code": 30},
+        }
         response = await self.collect(get_request_json_return_value=cloc_json)
         self.assert_measurement(response, value="90", total="100")
 ```


### PR DESCRIPTION
Use ruff to check and fix Markdown Python code blocks in docs/src/*.md.