### PR TITLE
Fix retrieving suppressed issues from SonarQube

### DIFF
--- a/components/collector/.vulture-whitelist.py
+++ b/components/collector/.vulture-whitelist.py
@@ -65,7 +65,7 @@ GitLabChangeFailureRate  # unused class (src/source_collectors/gitlab/change_fai
 GitLabFailedJobs  # unused class (src/source_collectors/gitlab/failed_jobs.py:13)
 commit  # unused variable (src/source_collectors/gitlab/inactive_branches.py:24)
 GitLabInactiveBranches  # unused class (src/source_collectors/gitlab/inactive_branches.py:30)
-GitLabMergeRequests  # unused class (src/source_collectors/gitlab/merge_requests.py:68)
+GitLabMergeRequests  # unused class (src/source_collectors/gitlab/merge_requests.py:69)
 GitLabPipelineDuration  # unused class (src/source_collectors/gitlab/pipeline_duration.py:14)
 GitLabSourceUpToDateness  # unused class (src/source_collectors/gitlab/source_up_to_dateness.py:107)
 __new__  # unused function (src/source_collectors/gitlab/source_up_to_dateness.py:110)

--- a/components/collector/src/source_collectors/sonarqube/suppressed_violations.py
+++ b/components/collector/src/source_collectors/sonarqube/suppressed_violations.py
@@ -38,7 +38,7 @@ class SonarQubeSuppressedViolations(SonarQubeViolations):
         branch = self._parameter("branch")
         all_issues_api_url = URL(f"{url}/api/issues/search?projects={component}&branch={branch}")
         resolved_issues_api_url = URL(
-            f"{all_issues_api_url}&issuesStatuses=ACCEPTED,FALSE_POSITIVE,IN_SANDBOX&additionalFields=comments"
+            f"{all_issues_api_url}&issueStatuses=ACCEPTED,FALSE_POSITIVE,IN_SANDBOX&additionalFields=comments"
             f"{self._query_parameter('clean_code_attribute_categories', uppercase=True)}"
             f"{self._query_parameter('impacted_software_qualities', uppercase=True)}"
             f"{self._query_parameter('impact_severities', uppercase=True)}&ps={self.PAGE_SIZE}",

--- a/components/collector/tests/source_collectors/sonarqube/test_suppressed_violations.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_suppressed_violations.py
@@ -1,5 +1,7 @@
 """Unit tests for the SonarQube suppressed violations collector."""
 
+from unittest.mock import call
+
 from .base import SonarQubeTestCase
 
 
@@ -40,9 +42,27 @@ class SonarQubeSuppressedViolationsTest(SonarQubeTestCase):
             ],
         }
         total_violations_json = {"total": "4"}
-        response = await self.collect(
+        response, get_mock, _post_mock = await self.collect(
             get_request_json_side_effect=[{}, violations_json, wont_fix_json, total_violations_json],
+            return_mocks=True,
         )
+        call1 = call("https://sonarqube/api/components/show?component=id", allow_redirects=True, headers={}, auth=None)
+        call2 = call(
+            "https://sonarqube/api/issues/search?projects=id&branch=main&resolved=false&ps=500&rules=c:NoSonar,cpp:NoSonar,csharpsquid:S1309,java:NoSonar,java:S1309,java:S1310,java:S1315,javascript:S1291,objc:NoSonar,php:NoSonar,plsql:NoSonarCheck,python:NoSonar,python:S1309,tsql:NoSonar,typescript:S1291",
+            allow_redirects=True,
+            headers={},
+            auth=None,
+        )
+        call3 = call(
+            "https://sonarqube/api/issues/search?projects=id&branch=main&issueStatuses=ACCEPTED,FALSE_POSITIVE,IN_SANDBOX&additionalFields=comments&ps=500",
+            allow_redirects=True,
+            headers={},
+            auth=None,
+        )
+        call4 = call(
+            "https://sonarqube/api/issues/search?projects=id&branch=main", allow_redirects=True, headers={}, auth=None
+        )
+        get_mock.assert_has_calls([call1, call2, call3, call4])
         expected_entities = [
             self.entity(
                 key="violation1",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix retrieving all suppressed issues from SonarQube instead of only accepted, false positive, and sandboxed issues. Fixes [#12707](https://github.com/ICTU/quality-time/issues/12707).
+
 ### Added
 
 - Add singular versions of the metric units to the data model and allow users to override both the singular and plural forms via the UI. Closes [#550](https://github.com/ICTU/quality-time/issues/550).

--- a/docs/styles/config/vocabularies/Base/accept.txt
+++ b/docs/styles/config/vocabularies/Base/accept.txt
@@ -57,6 +57,7 @@ npm
 parameterizable
 [Pp]erformancetest
 project_or_group
+sandboxed
 security_hotspot
 severities
 sparkline


### PR DESCRIPTION
Fix retrieving all suppressed issues from SonarQube instead of only accepted, false positive, and sandboxed issues.

Fixes #12707.