### PR TITLE
Improve frontend unit test performance

### DIFF
--- a/components/frontend/src/App.test.jsx
+++ b/components/frontend/src/App.test.jsx
@@ -18,9 +18,11 @@ import {
 } from "./testUtils"
 import * as toast from "./widgets/toast"
 
-function setUserInLocalStorage(sessionExpirationDatetime, email) {
+function setUserInLocalStorage(hoursLeftInSession, email) {
+    // sessionHoursLeft is the time in hours left in the current session. Can be negative for expired sessions.
     localStorage.setItem("user", "admin")
     localStorage.setItem("email", email ?? "admin@example.org")
+    const sessionExpirationDatetime = new Date(Date.now() + 60 * 60 * 1000 * hoursLeftInSession).toISOString()
     localStorage.setItem("session_expiration_datetime", sessionExpirationDatetime)
 }
 
@@ -47,84 +49,78 @@ function reportDateButton() {
     return screen.getByLabelText(/Change report date/, { selector: "button" })
 }
 
-it("shows spinner", async () => {
+it("has no accessibility violations", async () => {
     const { container } = render(<App />)
-    expectLabelText(/Loading/)
     await expectNoAccessibilityViolations(container)
+})
+
+it("shows spinner", async () => {
+    render(<App />)
+    expectLabelText(/Loading/)
 })
 
 it("sets the user from local storage", async () => {
-    setUserInLocalStorage("3000-02-23T22:00:50.945Z")
-    const { container } = render(<App />)
+    setUserInLocalStorage(1)
+    render(<App />)
     expectText(/admin/)
     expect(screen.getAllByAltText(/Avatar for admin/).length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not set invalid email addresses", async () => {
-    setUserInLocalStorage("3000-02-23T22:00:50.945Z", "admin at example.org")
-    const { container } = render(<App />)
+    setUserInLocalStorage(1, "admin at example.org")
+    render(<App />)
     expectText(/admin/)
     expectNoLabelText(/Avatar for admin/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("resets the user when the session is expired on mount", async () => {
-    setUserInLocalStorage("2000-02-23T22:00:50.945Z")
-    const { container } = render(<App />)
+    setUserInLocalStorage(-1)
+    render(<App />)
     expectNoText(/admin/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("resets the user when the user clicks logout", async () => {
-    setUserInLocalStorage("3000-02-23T22:00:50.945Z")
-    const { container } = render(<App />)
+    setUserInLocalStorage(1)
+    render(<App />)
     clickText(/admin/)
     clickText(/Logout/)
     expectNoText(/admin/)
-    await expectNoAccessibilityViolations(container)
 })
 
-async function select15thOfPreviousMonth(container) {
+async function select15thOfPreviousMonth() {
     fireEvent.click(reportDateButton())
-    await expectNoAccessibilityViolations(container)
     clickButton("Previous month")
     clickRole("gridcell", "15", 0)
 }
 
 it("handles a date change", async () => {
-    const { container } = render(<App />)
-    await select15thOfPreviousMonth(container)
+    render(<App />)
+    await select15thOfPreviousMonth()
     const expectedDate = dayjs().subtract(1, "month").date(15).toDate().toLocaleDateString()
     expect(reportDateButton().textContent).toMatch(expectedDate)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("handles a date change between two dates in the past", async () => {
     history.push("/?report_date=2022-03-13")
-    const { container } = render(<App />)
-    await select15thOfPreviousMonth(container)
+    render(<App />)
+    await select15thOfPreviousMonth()
     const expectedDate = dayjs("2022-03-13").subtract(1, "month").date(15).toDate().toLocaleDateString()
     expect(reportDateButton().textContent).toMatch(expectedDate)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("reads the report date query parameter", async () => {
     history.push("/?report_date=2020-03-13")
-    const { container } = render(<App />)
+    render(<App />)
     const expectedDate = dayjs("2020-03-13").toDate().toLocaleDateString()
     expect(reportDateButton().textContent).toMatch(expectedDate)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("handles a date reset", async () => {
     history.push("/?report_date=2020-03-13")
-    const { container } = render(<App />)
+    render(<App />)
     fireEvent.click(reportDateButton())
-    await expectNoAccessibilityViolations(container)
     clickButton("Today")
     expect(reportDateButton().textContent).toMatch(/today/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("handles the nr of measurements event source", async () => {

--- a/components/frontend/src/AppUI.test.jsx
+++ b/components/frontend/src/AppUI.test.jsx
@@ -48,10 +48,14 @@ async function renderAppUI({ reports = [], reportDate = null, reportUuid = "" } 
     return result
 }
 
-it("shows an error message when there are no reports", async () => {
-    const { container } = await renderAppUI({ reportDate: new Date() })
-    expectText(/Sorry, no reports/)
+it("has no accessibility violations", async () => {
+    const { container } = await renderAppUI({ reports: [report], reportUuid: "report_uuid" })
     await expectNoAccessibilityViolations(container)
+})
+
+it("shows an error message when there are no reports", async () => {
+    await renderAppUI({ reportDate: new Date() })
+    expectText(/Sorry, no reports/)
 })
 
 it("handles sorting", async () => {

--- a/components/frontend/src/PageContent.test.jsx
+++ b/components/frontend/src/PageContent.test.jsx
@@ -44,32 +44,33 @@ async function renderPageContent({ loading = false, reports = [], reportDate = n
     return result
 }
 
-it("shows the reports overview", async () => {
+it("has no accessibility violations", async () => {
     const { container } = await renderPageContent({ reportDate: new Date(2023, 10, 25) })
-    expectText(/Sorry, no reports/)
     await expectNoAccessibilityViolations(container)
+})
+
+it("shows the reports overview", async () => {
+    await renderPageContent({ reportDate: new Date(2023, 10, 25) })
+    expectText(/Sorry, no reports/)
 })
 
 it("shows that the report is missing", async () => {
-    const { container } = await renderPageContent({ reports: [{}], reportUuid: "uuid" })
+    await renderPageContent({ reports: [{}], reportUuid: "uuid" })
     expectText(/Sorry, this report doesn't exist/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows that the report was missing", async () => {
-    const { container } = await renderPageContent({
+    await renderPageContent({
         reportDate: new Date("2022-03-31"),
         reports: [{}],
         reportUuid: "uuid",
     })
     expectText(/Sorry, this report didn't exist/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the loading spinner", async () => {
-    const { container } = await renderPageContent({ loading: true })
+    await renderPageContent({ loading: true })
     expect(screen.getAllByRole("progressbar").length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 function expectMeasurementsCall(date, offset = 0) {
@@ -82,9 +83,8 @@ function expectMeasurementsCall(date, offset = 0) {
 it("fetches measurements", async () => {
     const mockedDate = new Date("2022-04-27T16:00:05+0000")
     vi.setSystemTime(mockedDate)
-    const { container } = await renderPageContent({ reportDate: null })
+    await renderPageContent({ reportDate: null })
     expectMeasurementsCall(mockedDate)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("fetches measurements if nr dates > 1", async () => {

--- a/components/frontend/src/changelog/ChangeLog.test.jsx
+++ b/components/frontend/src/changelog/ChangeLog.test.jsx
@@ -26,55 +26,53 @@ function expectNrEventsToBe(nr) {
     expect(rows.length).toBe(nr)
 }
 
+it("has no accessibility violations", async () => {
+    const { container } = render(<ChangeLog reportUuid="uuid" />)
+    await expectNoAccessibilityViolations(container)
+})
+
 it("renders no changes", async () => {
     fetchServerApi.fetchServerApi.mockImplementation(() => Promise.resolve({ changelog: [] }))
-    const { container } = await renderChangeLog({})
+    await renderChangeLog({})
     expectNrEventsToBe(0)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders one report change", async () => {
-    const { container } = await renderChangeLog({ reportUuid: "uuid" })
+    await renderChangeLog({ reportUuid: "uuid" })
     expectNrEventsToBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders one subject change", async () => {
-    const { container } = await renderChangeLog({ subjectUuid: "uuid" })
+    await renderChangeLog({ subjectUuid: "uuid" })
     expectNrEventsToBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders one metric change", async () => {
-    const { container } = await renderChangeLog({ metricUuid: "uuid" })
+    await renderChangeLog({ metricUuid: "uuid" })
     expectNrEventsToBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders one source change", async () => {
-    const { container } = await renderChangeLog({ sourceUuid: "uuid" })
+    await renderChangeLog({ sourceUuid: "uuid" })
     expectNrEventsToBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("loads more changes", async () => {
-    const { container } = await renderChangeLog({ sourceUuid: "uuid" })
+    await renderChangeLog({ sourceUuid: "uuid" })
     fetchServerApi.fetchServerApi.mockImplementation(() =>
         Promise.resolve({ changelog: [{ timestamp: "2020-01-01" }, { timestamp: "2020-01-02" }] }),
     )
     await asyncClickText(/Load more changes/)
     expectNrEventsToBe(2)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows error when loading more changes fails", async () => {
-    const { container } = await renderChangeLog({ sourceUuid: "uuid" })
+    await renderChangeLog({ sourceUuid: "uuid" })
     fetchServerApi.fetchServerApi.mockImplementation(() => Promise.reject(new Error("Couldn't retrieve changelog")))
     const showMessage = vi.spyOn(toast, "showMessage")
     await asyncClickText(/Load more changes/)
     await waitFor(async () => {
         expect(showMessage).toHaveBeenCalledTimes(1)
-        await expectNoAccessibilityViolations(container)
     })
     expectNrEventsToBe(1)
 })

--- a/components/frontend/src/dashboard/CardDashboard.test.jsx
+++ b/components/frontend/src/dashboard/CardDashboard.test.jsx
@@ -25,10 +25,14 @@ function renderCardDashboard({ cards = [], initialLayout = [], saveLayout = vi.f
     )
 }
 
+it("has no accessibility violations", async () => {
+    const { container } = renderCardDashboard()
+    await expectNoAccessibilityViolations(container)
+})
+
 it("returns null without cards", async () => {
     const { container } = renderCardDashboard()
     expect(container.children[0].children.length).toBe(0)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("adds the card to the dashboard", async () => {
@@ -44,12 +48,11 @@ it("adds the card to the dashboard", async () => {
         ],
     })
     expect(container.children.length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not save the layout after click", async () => {
     const mockCallback = vi.fn()
-    const { container } = renderCardDashboard({
+    renderCardDashboard({
         cards: [
             <MetricSummaryCard
                 header="Card"
@@ -64,5 +67,4 @@ it("does not save the layout after click", async () => {
     })
     clickText("Card")
     expect(mockCallback).not.toHaveBeenCalled()
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/dashboard/IssuesCard.test.jsx
+++ b/components/frontend/src/dashboard/IssuesCard.test.jsx
@@ -29,23 +29,25 @@ function renderIssuesCard({ selected = false } = {}) {
     return render(<IssuesCard report={report} selected={selected} />)
 }
 
-it("shows the correct title", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderIssuesCard()
-    expectText(/Issues/)
     await expectNoAccessibilityViolations(container)
+})
+
+it("shows the correct title", async () => {
+    renderIssuesCard()
+    expectText(/Issues/)
 })
 
 it("shows the title as selected when the card is selected", async () => {
-    const { container } = renderIssuesCard({ selected: true })
+    renderIssuesCard({ selected: true })
     expect(screen.getByText(/Issues/)).toHaveClass("selected")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the number of issues", async () => {
-    const { container } = renderIssuesCard()
+    renderIssuesCard()
     expect(screen.getByRole("row", { name: "Todo 0" })).toBeInTheDocument()
     expect(screen.getByRole("row", { name: "Doing 1" })).toBeInTheDocument()
     expect(screen.getByRole("row", { name: "Done 0" })).toBeInTheDocument()
     expect(screen.getByRole("row", { name: "Unknown 3" })).toBeInTheDocument()
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/dashboard/MetricsRequiringActionCard.test.jsx
+++ b/components/frontend/src/dashboard/MetricsRequiringActionCard.test.jsx
@@ -29,23 +29,25 @@ function renderMetricsRequiringActionCard({ selected = false } = {}) {
     return render(<MetricsRequiringActionCard reports={[report]} selected={selected} />)
 }
 
-it("shows the correct title", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderMetricsRequiringActionCard()
-    expectText(/Action required/)
     await expectNoAccessibilityViolations(container)
+})
+
+it("shows the correct title", async () => {
+    renderMetricsRequiringActionCard()
+    expectText(/Action required/)
 })
 
 it("shows the title as selected when the card is selected", async () => {
-    const { container } = renderMetricsRequiringActionCard({ selected: true })
+    renderMetricsRequiringActionCard({ selected: true })
     expect(screen.getByText(/Action required/)).toHaveClass("selected")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the number of metrics", async () => {
-    const { container } = renderMetricsRequiringActionCard()
+    renderMetricsRequiringActionCard()
     expect(screen.getByRole("row", { name: "Unknown 0" })).toBeInTheDocument()
     expect(screen.getByRole("row", { name: "Target not met 1" })).toBeInTheDocument()
     expect(screen.getByRole("row", { name: "Near target met 2" })).toBeInTheDocument()
     expect(screen.getByRole("row", { name: "Total 3" })).toBeInTheDocument()
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/dashboard/PageHeader.test.jsx
+++ b/components/frontend/src/dashboard/PageHeader.test.jsx
@@ -36,41 +36,40 @@ function renderPageHeader({ lastUpdate = new Date(), report = null, reportDate =
     return render(<PageHeader lastUpdate={lastUpdate} report={report} reportDate={reportDate} />)
 }
 
-it("displays correct title for the reports overview", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderPageHeader({})
-    expectText(/Reports overview/)
     await expectNoAccessibilityViolations(container)
 })
 
+it("displays correct title for the reports overview", async () => {
+    renderPageHeader({})
+    expectText(/Reports overview/)
+})
+
 it("displays correct title for a report", async () => {
-    const { container } = renderPageHeader({ report: report })
+    renderPageHeader({ report: report })
     expectText(/Title/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays dates in en-GB format", async () => {
     const mockReportDate = new Date("2024-03-24T12:34:56")
-    const { container } = renderPageHeader({ lastUpdate: mockLastUpdate, report: report, reportDate: mockReportDate })
+    renderPageHeader({ lastUpdate: mockLastUpdate, report: report, reportDate: mockReportDate })
     expectText(/Report date: 24\/03\/2024/)
     expectText(/Generated: 26\/03\/2024, 12:34/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays report URL", async () => {
-    const { container } = renderPageHeader({ report: report })
+    renderPageHeader({ report: report })
     expect(screen.getByTestId("reportUrl")).toBeInTheDocument()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays version link", async () => {
-    const { container } = renderPageHeader({ lastUpdate: mockLastUpdate, report: report })
+    renderPageHeader({ lastUpdate: mockLastUpdate, report: report })
     expect(screen.getByTestId("version")).toBeInTheDocument()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays today as report date if no report date is provided", async () => {
-    const { container } = renderPageHeader({ lastUpdate: mockLastUpdate, report: report })
+    renderPageHeader({ lastUpdate: mockLastUpdate, report: report })
     const expectedDate = renderHook(() => formatDate(new Date()))
     expectText(`Report date: ${expectedDate.result.current}`)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/dashboard/StatusBarChart.test.jsx
+++ b/components/frontend/src/dashboard/StatusBarChart.test.jsx
@@ -20,26 +20,28 @@ function renderBarChart(maxY, red) {
 
 const dateString = new Date("2023-01-02").toLocaleDateString()
 
-it("shows the number of metrics per status when the total is zero", async () => {
-    const { container } = renderBarChart(0, 0)
-    expect(screen.queryAllByLabelText(`Status on ${dateString}: no metrics`, { exact: false }).length).toBe(1)
+it("has no accessibility violations", async () => {
+    const { container } = renderBarChart(2, 2)
     await expectNoAccessibilityViolations(container)
+})
+
+it("shows the number of metrics per status when the total is zero", async () => {
+    renderBarChart(0, 0)
+    expect(screen.queryAllByLabelText(`Status on ${dateString}: no metrics`, { exact: false }).length).toBe(1)
 })
 
 it("shows the number of metrics per status when the total is not zero", async () => {
-    const { container } = renderBarChart(10, 0)
+    renderBarChart(10, 0)
     expect(screen.queryAllByLabelText(`Status on ${dateString}: no metrics`, { exact: false }).length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the number of metrics per status", async () => {
-    const { container } = renderBarChart(2, 2)
+    renderBarChart(2, 2)
     expect(
         screen.queryAllByLabelText(`Status on ${dateString}: 2 metrics, 2 target not met`, {
             exact: false,
         }).length,
     ).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the tooltip", async () => {
@@ -48,5 +50,4 @@ it("shows the tooltip", async () => {
     const targetNotMetLabel = "Target not met"
     await userEvent.hover(targetNotMetBar)
     expect(queryAllByText(container, targetNotMetLabel).length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/dashboard/StatusPieChart.test.jsx
+++ b/components/frontend/src/dashboard/StatusPieChart.test.jsx
@@ -16,18 +16,21 @@ function renderPieChart({ summary = { blue: 0, red: 0, green: 0, yellow: 0, whit
 
 const dateString = new Date("2023-01-01").toLocaleDateString()
 
-it("shows there are no metrics", async () => {
-    const { container } = renderPieChart()
-    expectLabelText(`Status on ${dateString}: no metrics.`)
+it("has no accessibility violations", async () => {
+    const { container } = renderPieChart({ summary: { blue: 2, red: 1, green: 2, yellow: 3, white: 1, grey: 1 } })
     await expectNoAccessibilityViolations(container)
 })
 
+it("shows there are no metrics", async () => {
+    renderPieChart()
+    expectLabelText(`Status on ${dateString}: no metrics.`)
+})
+
 it("shows the number of metrics per status", async () => {
-    const { container } = renderPieChart({ summary: { blue: 2, red: 1, green: 2, yellow: 3, white: 1, grey: 1 } })
+    renderPieChart({ summary: { blue: 2, red: 1, green: 2, yellow: 3, white: 1, grey: 1 } })
     expectLabelText(
         `Status on ${dateString}: 10 metrics, 2 target met, 1 target not met, 3 near target, 1 with accepted technical debt, 2 informative, 1 with unknown status.`,
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the tooltip", async () => {
@@ -36,5 +39,4 @@ it("shows the tooltip", async () => {
     const unknownLabel = "Unknown"
     await userEvent.hover(unknownPie)
     expect(queryAllByText(container, unknownLabel).length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/header_footer/Footer.test.jsx
+++ b/components/frontend/src/header_footer/Footer.test.jsx
@@ -3,23 +3,25 @@ import { render, screen } from "@testing-library/react"
 import { expectNoAccessibilityViolations, expectText } from "../testUtils"
 import { Footer } from "./Footer"
 
+it("has no accessibility violations", async () => {
+    const { container } = render(<Footer />)
+    await expectNoAccessibilityViolations(container)
+})
+
 it("renders the report title when there is a report", async () => {
     const lastUpdate = new Date()
-    const { container } = render(<Footer lastUpdate={lastUpdate} report={{ title: "Report title" }} />)
+    render(<Footer lastUpdate={lastUpdate} report={{ title: "Report title" }} />)
     expectText("Report title")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a quote when there is no report", async () => {
-    const { container } = render(<Footer />)
+    render(<Footer />)
     expectText(/Jez Humble|Johan Cruyff|DeMarco and Lister|Henry Ford|Robert M. Pirsig/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a link to the report url", async () => {
-    const { container } = render(<Footer report={{ title: "Report title" }} />)
+    render(<Footer report={{ title: "Report title" }} />)
     expect(screen.getByText("Report title").closest("a")).toHaveAttribute("href", "http://localhost:3000/")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a link to the report url from the search parameter", () => {

--- a/components/frontend/src/header_footer/Menubar.test.jsx
+++ b/components/frontend/src/header_footer/Menubar.test.jsx
@@ -46,13 +46,17 @@ function renderMenubar({
     )
 }
 
-async function enterCredentials(container) {
+async function enterCredentials() {
     clickText(/Login/)
-    await expectNoAccessibilityViolations(container)
     fireEvent.change(screen.getByLabelText("Username"), { target: { value: CREDENTIALS.username } })
     fireEvent.change(screen.getByLabelText("Password"), { target: { value: CREDENTIALS.password } })
     await asyncClickText(/Submit/)
 }
+
+it("has no accessibility violations", async () => {
+    const { container } = renderMenubar()
+    await expectNoAccessibilityViolations(container)
+})
 
 it("logs in", async () => {
     vi.spyOn(fetchServerApi, "fetchServerApi").mockResolvedValue({
@@ -61,44 +65,40 @@ it("logs in", async () => {
         session_expiration_datetime: "2021-02-24T13:10:00+00:00",
     })
     const setUser = vi.fn()
-    const { container } = renderMenubar({ setUser: setUser })
-    await enterCredentials(container)
+    renderMenubar({ setUser: setUser })
+    await enterCredentials()
     expectFetch("post", "login", CREDENTIALS)
     const expectedDate = new Date(Date.parse("2021-02-24T13:10:00+00:00"))
     expect(setUser).toHaveBeenCalledWith("user@example.org", "user@example.org", expectedDate)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows invalid credential message", async () => {
     vi.spyOn(fetchServerApi, "fetchServerApi").mockResolvedValue({ ok: false })
     const setUser = vi.fn()
-    const { container } = renderMenubar({ setUser: setUser })
-    await enterCredentials(container)
+    renderMenubar({ setUser: setUser })
+    await enterCredentials()
     expectText(/Invalid credentials/)
     expectFetch("post", "login", CREDENTIALS)
     expect(setUser).not.toHaveBeenCalled()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows connection error message", async () => {
     vi.spyOn(fetchServerApi, "fetchServerApi").mockRejectedValue(new Error("Async error message"))
     const setUser = vi.fn()
-    const { container } = renderMenubar({ setUser: setUser })
-    await enterCredentials(container)
+    renderMenubar({ setUser: setUser })
+    await enterCredentials()
     expectText(/Connection error/)
     expectFetch("post", "login", CREDENTIALS)
     expect(setUser).not.toHaveBeenCalled()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("closes the dialog on cancel", async () => {
     const setUser = vi.fn()
-    const { container } = renderMenubar({ setUser: setUser })
+    renderMenubar({ setUser: setUser })
     clickText(/Login/)
     await asyncClickText(/Cancel/)
     await waitFor(async () => {
         expect(screen.queryAllByLabelText("Username").length).toBe(0)
-        await expectNoAccessibilityViolations(container)
     })
     expect(setUser).not.toHaveBeenCalled()
 })
@@ -117,32 +117,29 @@ it("closes the dialog on escape", async () => {
 it("logs out", async () => {
     vi.spyOn(fetchServerApi, "fetchServerApi").mockResolvedValue({ ok: true })
     const setUser = vi.fn()
-    const { container } = renderMenubar({ setUser: setUser, user: "jadoe" })
+    renderMenubar({ setUser: setUser, user: "jadoe" })
     clickButton("User options")
     clickMenuItem("Logout")
     expectFetch("post", "logout", {})
     expect(setUser).toHaveBeenCalledWith(null)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not go to home page if on reports overview", async () => {
     const openReportsOverview = vi.fn()
-    const { container } = renderMenubar({ reportUuid: "", openReportsOverview: openReportsOverview })
+    renderMenubar({ reportUuid: "", openReportsOverview: openReportsOverview })
     act(() => {
         fireEvent.click(screen.getByAltText(/Go to reports overview/))
     })
     expect(openReportsOverview).not.toHaveBeenCalled()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("goes to home page if on report", async () => {
     const openReportsOverview = vi.fn()
-    const { container } = renderMenubar({ openReportsOverview: openReportsOverview })
+    renderMenubar({ openReportsOverview: openReportsOverview })
     await act(async () => {
         fireEvent.click(screen.getByAltText(/Go to reports overview/))
     })
     expect(openReportsOverview).toHaveBeenCalled()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("goes to home page on keypress", async () => {
@@ -153,10 +150,9 @@ it("goes to home page on keypress", async () => {
 })
 
 it("shows and hides the settings panel on button click", async () => {
-    const { container } = renderMenubar({ panel: <div>Hello</div> })
+    renderMenubar({ panel: <div>Hello</div> })
     clickText(/Settings/)
     expectText(/Hello/)
-    await expectNoAccessibilityViolations(container)
     clickText(/Settings/)
     await waitFor(() => expectNoText(/Hello/))
 })
@@ -170,19 +166,17 @@ it("shows and hides the settings panel on keypress", async () => {
 })
 
 it("shows and hides the report period panel on button click", async () => {
-    const { container } = renderMenubar({ panel: <div>Hello</div> })
+    renderMenubar({ panel: <div>Hello</div> })
     clickText(/today/)
     expectText(/Report date/)
-    await expectNoAccessibilityViolations(container)
     clickText(/today/)
     await waitFor(() => expectNoText(/Report date/))
 })
 
 it("switches from settings to report period panel", async () => {
-    const { container } = renderMenubar({ panel: <div>Hello</div> })
+    renderMenubar({ panel: <div>Hello</div> })
     clickText(/Settings/)
     clickText(/today/)
     expectNoText(/Hello/)
     expectText(/Report date/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/header_footer/ReportPeriodPanel.test.jsx
+++ b/components/frontend/src/header_footer/ReportPeriodPanel.test.jsx
@@ -27,12 +27,16 @@ function renderReportPeriodPanel() {
     )
 }
 
+it("has no accessibility violations", async () => {
+    const { container } = renderReportPeriodPanel()
+    await expectNoAccessibilityViolations(container)
+})
+
 it("sets the number of dates", async () => {
     history.push("?nr_dates=2")
-    const { container } = renderReportPeriodPanel()
+    renderReportPeriodPanel()
     clickText(/7 dates/)
     expectSearch("?nr_dates=7")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the number of dates by keypress", async () => {

--- a/components/frontend/src/header_footer/SettingsPanel.test.jsx
+++ b/components/frontend/src/header_footer/SettingsPanel.test.jsx
@@ -47,11 +47,15 @@ function renderSettingsPanel({
     )
 }
 
-it("hides the metrics not requiring action", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderSettingsPanel()
+    await expectNoAccessibilityViolations(container)
+})
+
+it("hides the metrics not requiring action", async () => {
+    renderSettingsPanel()
     clickText(/Metrics requiring action/)
     expectSearch("?metrics_to_hide=no_action_required")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows all metrics", async () => {

--- a/components/frontend/src/header_footer/UIModeMenu.test.jsx
+++ b/components/frontend/src/header_footer/UIModeMenu.test.jsx
@@ -7,22 +7,25 @@ import { UIModeMenu } from "./UIModeMenu"
 
 const openUIModeMenu = () => clickLabeledElement(/Dark\/light mode/)
 
+it("has no accessibility violations", async () => {
+    const { container } = render(<UIModeMenu />)
+    await expectNoAccessibilityViolations(container)
+})
+
 it("sets dark mode", async () => {
     const setUIMode = vi.fn()
-    const { container } = render(<UIModeMenu setUIMode={setUIMode} />)
+    render(<UIModeMenu setUIMode={setUIMode} />)
     openUIModeMenu()
     clickText("Dark mode")
     expect(setUIMode).toHaveBeenCalledWith("dark")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets light mode", async () => {
     const setUIMode = vi.fn()
-    const { container } = render(<UIModeMenu setUIMode={setUIMode} uiMode="dark" />)
+    render(<UIModeMenu setUIMode={setUIMode} uiMode="dark" />)
     openUIModeMenu()
     clickText("Light mode")
     expect(setUIMode).toHaveBeenCalledWith("light")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets follows os mode", () => {

--- a/components/frontend/src/header_footer/buttons/CollapseButton.test.jsx
+++ b/components/frontend/src/header_footer/buttons/CollapseButton.test.jsx
@@ -3,15 +3,23 @@ import history from "history/browser"
 
 import { createTestableSettings } from "../../__fixtures__/fixtures"
 import { useExpandedItemsSearchQuery } from "../../app_ui_settings"
-import { clickButton } from "../../testUtils"
+import { clickButton, expectNoAccessibilityViolations } from "../../testUtils"
 import { CollapseButton } from "./CollapseButton"
 
 beforeEach(() => history.push(""))
 
 function renderCollapseButton({ expandedItems = null } = {}) {
     const settings = createTestableSettings()
-    render(<CollapseButton expandedItems={expandedItems ?? settings.expandedItems} />)
+    return render(<CollapseButton expandedItems={expandedItems ?? settings.expandedItems} />)
 }
+
+it("has no accessibility violations", async () => {
+    history.push("?expanded=tab:0")
+    const expandedItems = renderHook(() => useExpandedItemsSearchQuery())
+    expect(expandedItems.result.current.value).toStrictEqual(["tab:0"])
+    const { container } = renderCollapseButton({ expandedItems: expandedItems.result.current })
+    await expectNoAccessibilityViolations(container)
+})
 
 it("resets the expanded items", () => {
     history.push("?expanded=tab:0")

--- a/components/frontend/src/header_footer/buttons/DownloadAsPdfButton.test.jsx
+++ b/components/frontend/src/header_footer/buttons/DownloadAsPdfButton.test.jsx
@@ -3,7 +3,7 @@ import history from "history/browser"
 import { vi } from "vitest"
 
 import * as fetchServerApi from "../../api/fetch_server_api"
-import { asyncClickText, expectFetch, expectLabelText } from "../../testUtils"
+import { asyncClickText, expectFetch, expectLabelText, expectNoAccessibilityViolations } from "../../testUtils"
 import * as toast from "../../widgets/toast"
 import { DownloadAsPdfButton } from "./DownloadAsPdfButton"
 
@@ -11,6 +11,11 @@ beforeEach(() => {
     history.push("")
     vi.spyOn(fetchServerApi, "fetchServerApi").mockImplementation(() => Promise.resolve({ ok: true }))
     vi.spyOn(toast, "showMessage")
+})
+
+it("has no accessibility violations", async () => {
+    const { container } = render(<DownloadAsPdfButton />)
+    await expectNoAccessibilityViolations(container)
 })
 
 test("DownloadAsPdfButton has the correct label for reports overview", () => {

--- a/components/frontend/src/header_footer/buttons/LoginButton.test.jsx
+++ b/components/frontend/src/header_footer/buttons/LoginButton.test.jsx
@@ -1,8 +1,8 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { render } from "@testing-library/react"
 import { vi } from "vitest"
 
 import * as fetchServerApi from "../../api/fetch_server_api"
-import { asyncClickButton, clickButton, expectText, expectTextAfterWait } from "../../testUtils"
+import { asyncClickButton, clickButton, expectNoAccessibilityViolations, expectTextAfterWait } from "../../testUtils"
 import { LoginButton } from "./LoginButton"
 
 function renderLoginButton() {
@@ -10,6 +10,11 @@ function renderLoginButton() {
     render(<LoginButton setUser={setUser} />)
     return setUser
 }
+
+it("has no accessibility violations", async () => {
+    const { container } = render(<LoginButton />)
+    await expectNoAccessibilityViolations(container)
+})
 
 it("logs in the user", async () => {
     vi.spyOn(fetchServerApi, "fetchServerApi").mockResolvedValue({

--- a/components/frontend/src/header_footer/buttons/ResetSettingsButton.test.jsx
+++ b/components/frontend/src/header_footer/buttons/ResetSettingsButton.test.jsx
@@ -3,7 +3,7 @@ import history from "history/browser"
 import { vi } from "vitest"
 
 import { createTestableSettings } from "../../__fixtures__/fixtures"
-import { clickText, expectSearch } from "../../testUtils"
+import { clickText, expectNoAccessibilityViolations, expectSearch } from "../../testUtils"
 import { ResetSettingsButton } from "./ResetSettingsButton"
 
 beforeEach(() => {
@@ -16,7 +16,7 @@ function renderResetSettingsButton({
     reportDate = null,
     settings = null,
 } = {}) {
-    render(
+    return render(
         <ResetSettingsButton
             atReportsOverview={atReportsOverview}
             handleDateChange={handleDateChange}
@@ -25,6 +25,11 @@ function renderResetSettingsButton({
         />,
     )
 }
+
+it("has no accessibility violations", async () => {
+    const { container } = renderResetSettingsButton({ settings: createTestableSettings() })
+    await expectNoAccessibilityViolations(container)
+})
 
 it("resets the settings", async () => {
     history.push(

--- a/components/frontend/src/header_footer/buttons/UserButton.test.jsx
+++ b/components/frontend/src/header_footer/buttons/UserButton.test.jsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event"
 import { vi } from "vitest"
 
 import * as fetchServerApi from "../../api/fetch_server_api"
-import { clickButton, clickMenuItem } from "../../testUtils"
+import { clickButton, clickMenuItem, expectNoAccessibilityViolations } from "../../testUtils"
 import { UserButton } from "./UserButton"
 
 beforeAll(() => {
@@ -15,6 +15,11 @@ function renderUserButton() {
     render(<UserButton user="jadoe" email="jadoe@example.org" setUser={setUser} />)
     return setUser
 }
+
+it("has no accessibility violations", async () => {
+    const { container } = render(<UserButton user="jadoe" email="jadoe@example.org" />)
+    await expectNoAccessibilityViolations(container)
+})
 
 it("logs out the user when clicking the log out menu item", () => {
     const setUser = renderUserButton()

--- a/components/frontend/src/issue/IssueStatus.test.jsx
+++ b/components/frontend/src/issue/IssueStatus.test.jsx
@@ -69,246 +69,219 @@ beforeEach(() => {
     history.push("")
 })
 
-it("displays the issue id", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderIssueStatus()
-    expectText(/123/)
     await expectNoAccessibilityViolations(container)
+})
+
+it("displays the issue id", async () => {
+    renderIssueStatus()
+    expectText(/123/)
 })
 
 it("opens the issue landing url", async () => {
     globalThis.open = vi.fn()
-    const { container } = renderIssueStatus()
+    renderIssueStatus()
     clickText(/123/)
     expect(globalThis.open).toHaveBeenCalledWith("https://issue")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not open an url if the issue has no landing url", async () => {
     globalThis.open = vi.fn()
-    const { container } = renderIssueStatus({ landingUrl: "" })
+    renderIssueStatus({ landingUrl: "" })
     clickText(/123/)
     expect(globalThis.open).not.toHaveBeenCalled()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays a question mark as status if the issue has no status", async () => {
-    const { container } = renderIssueStatus({ status: null })
+    renderIssueStatus({ status: null })
     expectText(/\?/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the issue summary in the label if configured", async () => {
     history.push("?show_issue_summary=true")
-    const { container } = renderIssueStatus()
+    renderIssueStatus()
     expectText(/summary/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the creation date in the label if configured", async () => {
     history.push("?show_issue_creation_date=true")
-    const { container } = renderIssueStatus()
+    renderIssueStatus()
     expectText(/4 days ago/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not display the creation date in the label if not configured", async () => {
-    const { container } = renderIssueStatus()
+    renderIssueStatus()
     expectNoText(/4 days ago/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the issue summary in the popup", async () => {
-    const { container } = renderIssueStatus()
+    renderIssueStatus()
     await hoverText(/123/)
     await expectTextAfterWait("Issue summary")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the creation date in the popup", async () => {
-    const { container } = renderIssueStatus({ updated: false })
+    renderIssueStatus({ updated: false })
     await hoverText(/123/)
     await expectTextAfterWait(/4 days ago/)
     expectNoText(/2 days ago/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the update date in the label if configured", async () => {
     history.push("?show_issue_update_date=true")
-    const { container } = renderIssueStatus({ updated: true })
+    renderIssueStatus({ updated: true })
     expectText(/2 days ago/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not display the update date in the label if not configured", async () => {
-    const { container } = renderIssueStatus({ updated: true })
+    renderIssueStatus({ updated: true })
     expectNoText(/2 days ago/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the update date in the popup", async () => {
-    const { container } = renderIssueStatus({ updated: true })
+    renderIssueStatus({ updated: true })
     await hoverText(/123/)
     await expectTextAfterWait(/4 days ago/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the due date in the label if configured", async () => {
     history.push("?show_issue_due_date=true")
-    const { container } = renderIssueStatus({ due: true })
+    renderIssueStatus({ due: true })
     expectText(/in 2 days/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not display the due date in the label if not configured", async () => {
-    const { container } = renderIssueStatus({ due: true })
+    renderIssueStatus({ due: true })
     expectNoText(/2 days from now/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the due date in the popup", async () => {
-    const { container } = renderIssueStatus({ due: true })
+    renderIssueStatus({ due: true })
     await hoverText(/123/)
     await expectTextAfterWait(/in 2 days/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the planned release in the label if configured", async () => {
     history.push("?show_issue_release=true")
-    const { container } = renderIssueStatus({ release: true })
+    renderIssueStatus({ release: true })
     expectText(/1.0/)
     expectText(/planned/)
     expectText(/in \d+ years/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the released release in the label if configured", async () => {
     history.push("?show_issue_release=true")
-    const { container } = renderIssueStatus({ release: true, releaseReleased: true })
+    renderIssueStatus({ release: true, releaseReleased: true })
     expectText(/1.0/)
     expectText(/released/)
     expectText(/in \d+ years/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the release in the label if configured, but without release date", async () => {
     history.push("?show_issue_release=true")
-    const { container } = renderIssueStatus({ release: true, releaseDate: null })
+    renderIssueStatus({ release: true, releaseDate: null })
     expectText(/1.0/)
     expectText(/planned/)
     expectNoText(/from now/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the release without doubling release in the label", async () => {
     history.push("?show_issue_release=true")
-    const { container } = renderIssueStatus({ release: true, releaseName: "Release 1.0" })
+    renderIssueStatus({ release: true, releaseName: "Release 1.0" })
     expectText(/Release 1.0/)
     expectNoText(/Release Release 1.0/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not display the release in the label if not configured", async () => {
-    const { container } = renderIssueStatus({ release: true })
+    renderIssueStatus({ release: true })
     expectNoText(/1.0/)
     expectNoText(/planned/)
     expectNoText(/from now/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the release in the popup", async () => {
-    const { container } = renderIssueStatus({ release: true })
+    renderIssueStatus({ release: true })
     await hoverText(/123/)
     await expectTextAfterWait(/1.0/)
     expectText(/planned/)
     expectText(/in \d+ years/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the release in the popup without release date", async () => {
-    const { container } = renderIssueStatus({ release: true, releaseDate: null })
+    renderIssueStatus({ release: true, releaseDate: null })
     await hoverText(/123/)
     await expectTextAfterWait(/1.0/)
     expectNoText(/planned/)
     expectNoText(/from now/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the sprint in the label if configured", async () => {
     history.push("?show_issue_sprint=true")
-    const { container } = renderIssueStatus({ sprint: true })
+    renderIssueStatus({ sprint: true })
     expectText(/Sprint 42/)
     expectText(/active/)
     expectText(/in \d+ years/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the sprint in the label if configured, but without sprint end date", async () => {
     history.push("?show_issue_sprint=true")
-    const { container } = renderIssueStatus({ sprint: true, sprintEndDate: null })
+    renderIssueStatus({ sprint: true, sprintEndDate: null })
     expectText(/Sprint 42/)
     expectText(/active/)
     expectNoText(/from now/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not display the sprint in the label if not configured", async () => {
-    const { container } = renderIssueStatus({ sprint: true })
+    renderIssueStatus({ sprint: true })
     expectNoText(/Sprint 42/)
     expectNoText(/active/)
     expectNoText(/from now/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the sprint in the popup", async () => {
-    const { container } = renderIssueStatus({ sprint: true })
+    renderIssueStatus({ sprint: true })
     await hoverText(/123/)
     await expectTextAfterWait(/Sprint 42/)
     expectText(/active/)
     expectText(/in \d+ years/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the sprint in the popup without sprint end date", async () => {
-    const { container } = renderIssueStatus({ sprint: true, sprintEndDate: null })
+    renderIssueStatus({ sprint: true, sprintEndDate: null })
     await hoverText(/123/)
     await expectTextAfterWait(/Sprint 42/)
     expectText(/active/)
     expectNoText(/from now/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays no popup if the issue has no creation date and there is no error", async () => {
-    const { container } = renderIssueStatus({ created: false })
+    renderIssueStatus({ created: false })
     await hoverText(/123/)
     await expectNoTextAfterWait("4 days ago")
     expectNoText("2 days ago")
     expectNoText("2 days from now")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays a connection error in the popup", async () => {
-    const { container } = renderIssueStatus({ connectionError: true })
+    renderIssueStatus({ connectionError: true })
     await hoverText(/123/)
     await expectTextAfterWait("Connection error")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays a parse error in the popup", async () => {
-    const { container } = renderIssueStatus({ parseError: true })
+    renderIssueStatus({ parseError: true })
     await hoverText(/123/)
     await expectTextAfterWait("Parse error")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays nothing if the metric has no issue status", async () => {
-    const { container } = render(<IssueStatus metric={{}} />)
+    render(<IssueStatus metric={{}} />)
     expectNoText(/123/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays an error message if the metric has issue ids but the report has no issue tracker", async () => {
-    const { container } = renderIssueStatus({ issueTrackerMissing: true })
+    renderIssueStatus({ issueTrackerMissing: true })
     await hoverText(/123/)
     await expectTextAfterWait(/No issue tracker configured/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/issue/IssuesRows.test.jsx
+++ b/components/frontend/src/issue/IssuesRows.test.jsx
@@ -41,20 +41,23 @@ function renderIssuesRow({
     )
 }
 
-it("does not show an error message if the metric has no issues and no issue tracker is configured", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderIssuesRow()
-    expectNoText(/No issue tracker configured/)
     await expectNoAccessibilityViolations(container)
+})
+
+it("does not show an error message if the metric has no issues and no issue tracker is configured", async () => {
+    renderIssuesRow()
+    expectNoText(/No issue tracker configured/)
 })
 
 it("does not show an error message if the metric has no issues and an issue tracker is configured", async () => {
-    const { container } = renderIssuesRow({ report: { issue_tracker: { type: "Jira" } } })
+    renderIssuesRow({ report: { issue_tracker: { type: "Jira" } } })
     expectNoText(/No issue tracker configured/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not show an error message if the metric has issues and an issue tracker is configured", async () => {
-    const { container } = renderIssuesRow({
+    renderIssuesRow({
         issueIds: ["BAR-42"],
         report: {
             issue_tracker: {
@@ -64,27 +67,23 @@ it("does not show an error message if the metric has issues and an issue tracker
         },
     })
     expectNoText(/No issue tracker configured/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows an error message if the metric has issues but no issue tracker is configured", async () => {
-    const { container } = renderIssuesRow({ issueIds: ["FOO-42"] })
+    renderIssuesRow({ issueIds: ["FOO-42"] })
     expectText(/No issue tracker configured/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows a connection error", async () => {
-    const { container } = renderIssuesRow({ issueStatus: [{ issue_id: "FOO-43", connection_error: "Oops" }] })
+    renderIssuesRow({ issueStatus: [{ issue_id: "FOO-43", connection_error: "Oops" }] })
     expectText(/Connection error/)
     expectText(/Oops/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows a parse error", async () => {
-    const { container } = renderIssuesRow({ issueStatus: [{ issue_id: "FOO-43", parse_error: "Oops" }] })
+    renderIssuesRow({ issueStatus: [{ issue_id: "FOO-43", parse_error: "Oops" }] })
     expectText(/Parse error/)
     expectText(/Oops/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("creates an issue", async () => {
@@ -95,12 +94,11 @@ it("creates an issue", async () => {
         pathname: "/report_uuid",
         search: "?query=ignored",
     }
-    const { container } = renderIssuesRow({ report: reportWithIssueTracker })
+    renderIssuesRow({ report: reportWithIssueTracker })
     clickText(/Create new issue/)
     expectFetch("post", "metric/metric_uuid/issue/new", {
         metric_url: "https://quality-time.example.org/report_uuid#metric_uuid",
     })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("tries to create an issue", async () => {
@@ -111,7 +109,7 @@ it("tries to create an issue", async () => {
         pathname: "/report_uuid",
         search: "?query=ignored",
     }
-    const { container } = renderIssuesRow({ report: reportWithIssueTracker })
+    renderIssuesRow({ report: reportWithIssueTracker })
     clickText(/Create new issue/)
     expectFetch("post", "metric/metric_uuid/issue/new", {
         metric_url: "https://quality-time.example.org/report_uuid#metric_uuid",
@@ -120,39 +118,35 @@ it("tries to create an issue", async () => {
         expect(showMessage).toHaveBeenCalledTimes(1)
         expect(showMessage).toHaveBeenCalledWith("error", "Could not create issue", "Failed to create issue")
     })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("disables the create issue button if the user has no permissions", async () => {
-    const { container } = renderIssuesRow({ report: reportWithIssueTracker, permissions: [] })
+    renderIssuesRow({ report: reportWithIssueTracker, permissions: [] })
     expect(screen.getByText(/Create new issue/)).toBeDisabled()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("adds an issue id", async () => {
     fetchServerApi.fetchServerApi.mockResolvedValue({ suggestions: [{ key: "FOO-42", text: "Suggestion" }] })
-    const { container } = renderIssuesRow()
+    renderIssuesRow()
     await userEvent.type(screen.getByLabelText(/Issue identifiers/), "FOO-42{Enter}")
     expectFetch("post", "metric/metric_uuid/attribute/issue_ids", {
         issue_ids: ["FOO-42"],
     })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows issue id suggestions", async () => {
     fetchServerApi.fetchServerApi.mockResolvedValue({ suggestions: [{ key: "FOO-42", text: "Suggestion" }] })
-    const { container } = renderIssuesRow({
+    renderIssuesRow({
         report: { issue_tracker: { type: "Jira", parameters: { url: "https://jira" } } },
     })
     await userEvent.type(screen.getByLabelText(/Issue identifiers/), "u")
     expectText(/FOO-42: Suggestion/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows an error message if fetching suggestions fails", async () => {
     fetchServerApi.fetchServerApi.mockRejectedValue(new Error("fetching suggestions failed"))
     const showMessage = vi.spyOn(toast, "showMessage")
-    const { container } = renderIssuesRow({
+    renderIssuesRow({
         report: { issue_tracker: { type: "Jira", parameters: { url: "https://jira" } } },
     })
     await userEvent.type(screen.getByLabelText(/Issue identifiers/), "u")
@@ -162,18 +156,15 @@ it("shows an error message if fetching suggestions fails", async () => {
         "Could not fetch issue identifiers",
         "Error: fetching suggestions failed",
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows no issue id suggestions without a query", async () => {
     fetchServerApi.fetchServerApi.mockResolvedValue({ suggestions: [{ key: "FOO-42", text: "Suggestion" }] })
-    const { container } = renderIssuesRow({
+    renderIssuesRow({
         report: { issue_tracker: { type: "Jira", parameters: { url: "https://jira" } } },
     })
     await userEvent.type(screen.getByRole("combobox"), "s")
     expectText(/FOO-42: Suggestion/)
-    await expectNoAccessibilityViolations(container)
     await userEvent.clear(screen.getByRole("combobox"))
     expectNoText(/FOO-42: Suggestion/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/measurement/MeasurementSources.test.jsx
+++ b/components/frontend/src/measurement/MeasurementSources.test.jsx
@@ -20,17 +20,24 @@ function renderMeasurementSources(sources, latestMeasurement) {
     )
 }
 
-it("renders one measurement source", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderMeasurementSources(
         { source_uuid: { type: "source_type", name: "Source name" } },
         { sources: [{ source_uuid: "source_uuid" }] },
     )
-    expectText(/Source name/)
     await expectNoAccessibilityViolations(container)
 })
 
+it("renders one measurement source", async () => {
+    renderMeasurementSources(
+        { source_uuid: { type: "source_type", name: "Source name" } },
+        { sources: [{ source_uuid: "source_uuid" }] },
+    )
+    expectText(/Source name/)
+})
+
 it("renders multiple measurement sources", async () => {
-    const { container } = renderMeasurementSources(
+    renderMeasurementSources(
         {
             source_uuid1: { type: "source_type", name: "Source name 1" },
             source_uuid2: { type: "source_type", name: "Source name 2" },
@@ -40,5 +47,4 @@ it("renders multiple measurement sources", async () => {
         },
     )
     expectText(/Source name 1, Source name 2/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/measurement/MeasurementTarget.test.jsx
+++ b/components/frontend/src/measurement/MeasurementTarget.test.jsx
@@ -26,39 +26,39 @@ function renderMeasurementTarget(metric) {
     )
 }
 
-it("renders the target", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderMeasurementTarget({ type: "violations" })
-    expectText(/≦ 0/)
     await expectNoAccessibilityViolations(container)
+})
+
+it("renders the target", async () => {
+    renderMeasurementTarget({ type: "violations" })
+    expectText(/≦ 0/)
 })
 
 it("does not render the target if the metric is informative", async () => {
-    const { container } = renderMeasurementTarget({ type: "violations", evaluate_targets: false })
+    renderMeasurementTarget({ type: "violations", evaluate_targets: false })
     expectNoText(/≦ 0/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders the target with minutes", async () => {
-    const { container } = renderMeasurementTarget({ type: "duration" })
+    renderMeasurementTarget({ type: "duration" })
     expectText(/≦ 0/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders the target with minutes percentage", async () => {
-    const { container } = renderMeasurementTarget({ type: "duration", scale: "percentage" })
+    renderMeasurementTarget({ type: "duration", scale: "percentage" })
     expectText(/≦ 0%/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not render the technical debt popup if technical debt is not accepted", async () => {
-    const { container } = renderMeasurementTarget({ type: "violations", target: "100", debt_end_date: "2022-12-31" })
+    renderMeasurementTarget({ type: "violations", target: "100", debt_end_date: "2022-12-31" })
     await hoverText(/100/)
     await expectNoTextAfterWait(/accepted as technical debt/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders the technical debt popup if technical debt is accepted", async () => {
-    const { container } = renderMeasurementTarget({
+    renderMeasurementTarget({
         type: "violations",
         debt_target: "50",
         target: "100",
@@ -67,11 +67,10 @@ it("renders the technical debt popup if technical debt is accepted", async () =>
     })
     await hoverText(/100/)
     await expectTextAfterWait(/Measurements ≦ 50 violations are accepted as technical debt/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("uses the singular unit in the technical debt popup if the technical debt target is one", async () => {
-    const { container } = renderMeasurementTarget({
+    renderMeasurementTarget({
         type: "violations",
         debt_target: "1",
         target: "100",
@@ -80,11 +79,10 @@ it("uses the singular unit in the technical debt popup if the technical debt tar
     })
     await hoverText(/100/)
     await expectTextAfterWait(/Measurements ≦ 1 violation are accepted as technical debt/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders the technical debt popup if technical debt is accepted with a future end date", async () => {
-    const { container } = renderMeasurementTarget({
+    renderMeasurementTarget({
         type: "violations",
         target: "100",
         accept_debt: true,
@@ -92,11 +90,10 @@ it("renders the technical debt popup if technical debt is accepted with a future
     })
     await hoverText(/100/)
     await expectTextAfterWait(/accepted as technical debt until/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders the issue status if all issues are done", async () => {
-    const { container } = renderMeasurementTarget({
+    renderMeasurementTarget({
         type: "violations",
         target: "100",
         accept_debt: true,
@@ -104,22 +101,20 @@ it("renders the issue status if all issues are done", async () => {
     })
     await hoverText(/100/)
     await expectTextAfterWait(/all issues for this metric have been marked done/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not render the issue status if technical debt is not accepted", async () => {
-    const { container } = renderMeasurementTarget({
+    renderMeasurementTarget({
         type: "violations",
         target: "100",
         issue_status: [{ status_category: "done" }],
     })
     await hoverText(/100/)
     await expectNoTextAfterWait(/all issues for this metric have been marked done/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders both the issue status and the technical debt end date", async () => {
-    const { container } = renderMeasurementTarget({
+    renderMeasurementTarget({
         type: "violations",
         target: "100",
         accept_debt: true,
@@ -128,11 +123,10 @@ it("renders both the issue status and the technical debt end date", async () => 
     })
     await hoverText(/100/)
     await expectTextAfterWait(/all issues for this metric have been marked done and technical debt was accepted/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not crash when the technical end date is invalid", async () => {
-    const { container } = renderMeasurementTarget({
+    renderMeasurementTarget({
         type: "violations",
         target: "100",
         accept_debt: true,
@@ -140,5 +134,4 @@ it("does not crash when the technical end date is invalid", async () => {
     })
     await hoverText(/100/)
     await expectTextAfterWait(/Measurements ≦ 0 violations are accepted as technical debt/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/measurement/MeasurementValue.test.jsx
+++ b/components/frontend/src/measurement/MeasurementValue.test.jsx
@@ -46,28 +46,30 @@ function renderMeasurementValue({
     )
 }
 
-it("renders the value", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderMeasurementValue({ latestMeasurement: { count: { value: "42" } } })
-    expectText(/42/)
     await expectNoAccessibilityViolations(container)
+})
+
+it("renders the value", async () => {
+    renderMeasurementValue({ latestMeasurement: { count: { value: "42" } } })
+    expectText(/42/)
 })
 
 it("renders an unknown value", async () => {
-    const { container } = renderMeasurementValue({ latestMeasurement: { count: { value: null } } })
+    renderMeasurementValue({ latestMeasurement: { count: { value: null } } })
     expectText(/\?/)
     expect(screen.queryAllByTestId("LoopIcon").length).toBe(0)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a value that has not been measured yet", async () => {
-    const { container } = renderMeasurementValue()
+    renderMeasurementValue()
     expectText(/\?/)
     expect(screen.queryAllByTestId("LoopIcon").length).toBe(0)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a value that can not be measured yet", async () => {
-    const { container } = renderMeasurementValue({
+    renderMeasurementValue({
         latestMeasurement: {
             count: { value: 1 },
             outdated: true,
@@ -78,11 +80,10 @@ it("renders a value that can not be measured yet", async () => {
     })
     expectText(/1/)
     expect(screen.queryAllByTestId("LoopIcon").length).toBe(0)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders an outdated value", async () => {
-    const { container } = renderMeasurementValue({
+    renderMeasurementValue({
         latestMeasurement: {
             count: { value: 1 },
             outdated: true,
@@ -94,12 +95,11 @@ it("renders an outdated value", async () => {
     await hoverText(/1/)
     await expectTextAfterWait(/Latest measurement out of date/)
     expectText(/The source configuration of this metric was changed after the latest measurement/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a value for which a measurement was requested", async () => {
     const now = new Date().toISOString()
-    const { container } = renderMeasurementValue({
+    renderMeasurementValue({
         latestMeasurement: { count: { value: 1 }, start: now, end: now },
         measurementRequested: now,
     })
@@ -107,12 +107,11 @@ it("renders a value for which a measurement was requested", async () => {
     await hoverText(/1/)
     await expectTextAfterWait(/Measurement requested/)
     expectText(/An update of the latest measurement was requested by a user/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a value for which a measurement was requested, but which is now up to date", async () => {
     const now = new Date().toISOString()
-    const { container } = renderMeasurementValue({
+    renderMeasurementValue({
         latestMeasurement: { count: { value: 1 }, start: now, end: now },
         measurementRequested: "2024-01-01T00:00:00",
     })
@@ -120,85 +119,77 @@ it("renders a value for which a measurement was requested, but which is now up t
     await hoverText(/1/)
     await expectNoTextAfterWait(/Measurement requested/)
     expectNoText(/An update of the latest measurement was requested by a user/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a minutes value", async () => {
-    const { container } = renderMeasurementValue({
+    renderMeasurementValue({
         type: "duration",
         unit: "foo units",
         latestMeasurement: { count: { value: "42" } },
     })
     expectText(/42/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders an unknown minutes value", async () => {
-    const { container } = renderMeasurementValue({
+    renderMeasurementValue({
         type: "duration",
         unit: "foo units",
         latestMeasurement: { count: { value: null } },
     })
     expectText(/\?/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a minutes percentage", async () => {
-    const { container } = renderMeasurementValue({
+    renderMeasurementValue({
         type: "duration",
         scale: "percentage",
         unit: "foo units",
         latestMeasurement: { percentage: { value: "42" } },
     })
     expectText(/42%/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders an unknown minutes percentage", async () => {
-    const { container } = renderMeasurementValue({
+    renderMeasurementValue({
         type: "duration",
         scale: "percentage",
         unit: "foo units",
         latestMeasurement: { percentage: { value: null } },
     })
     expectText(/\?%/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows when the metric was last measured", async () => {
-    const { container } = renderMeasurementValue({
+    renderMeasurementValue({
         status: "target_met",
         latestMeasurement: { start: "2022-01-16T00:31:00", end: "2022-01-16T00:51:00", count: { value: "42" } },
     })
     await hoverText(/42/)
     await expectTextAfterWait(/The metric was last measured/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows when the last measurement attempt was", async () => {
-    const { container } = renderMeasurementValue({
+    renderMeasurementValue({
         latestMeasurement: { start: "2022-01-16T00:31:00", end: "2022-01-16T00:51:00", count: { value: null } },
     })
     await hoverText(/\?/)
     await expectTextAfterWait(/This metric was not recently measured/)
     expectText(/Last measurement attempt/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not show an error message for past measurements that were recently measured at the time", async () => {
     const reportDate = new Date("2022-01-16T01:00:00")
-    const { container } = renderMeasurementValue({
+    renderMeasurementValue({
         latestMeasurement: { start: "2022-01-16T00:31:00", end: "2022-01-16T00:51:00" },
         reportDate: reportDate,
     })
     await hoverText(/\?/)
     await expectNoTextAfterWait(/This metric was not recently measured/)
     expectText(/Last measurement attempt/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows ignored measurement entities", async () => {
-    const { container } = renderMeasurementValue({
+    renderMeasurementValue({
         status: "target_met",
         unit_singular: "foo",
         latestMeasurement: {
@@ -216,11 +207,10 @@ it("shows ignored measurement entities", async () => {
     })
     await hoverText(/1/)
     await expectTextAfterWait(/Ignored foo/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not show ignored measurement entities that no longer exist", async () => {
-    const { container } = renderMeasurementValue({
+    renderMeasurementValue({
         status: "target_met",
         unit_singular: "foo",
         latestMeasurement: {
@@ -238,5 +228,4 @@ it("does not show ignored measurement entities that no longer exist", async () =
     })
     await hoverText(/1/)
     await expectNoTextAfterWait(/Ignored foo/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/measurement/Overrun.test.jsx
+++ b/components/frontend/src/measurement/Overrun.test.jsx
@@ -22,23 +22,29 @@ function renderOverrun({ measurements = [], dates = [] } = {}) {
     )
 }
 
-it("renders nothing if there is no overrun", async () => {
-    const { container } = renderOverrun()
-    expect(screen.queryAllByDisplayValue(/days/).length).toBe(0)
-    await expectNoAccessibilityViolations(container)
-})
-
-it("renders the days overrun if the metric has overrun its deadline", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderOverrun({
         dates: dates,
         measurements: [{ metric_uuid: "uuid", start: "2020-01-01", end: "2020-01-31" }],
     })
-    expectText(/27 days/)
     await expectNoAccessibilityViolations(container)
 })
 
+it("renders nothing if there is no overrun", async () => {
+    renderOverrun()
+    expect(screen.queryAllByDisplayValue(/days/).length).toBe(0)
+})
+
+it("renders the days overrun if the metric has overrun its deadline", async () => {
+    renderOverrun({
+        dates: dates,
+        measurements: [{ metric_uuid: "uuid", start: "2020-01-01", end: "2020-01-31" }],
+    })
+    expectText(/27 days/)
+})
+
 it("merges the days overrun if the metric has consecutive measurements", async () => {
-    const { container } = renderOverrun({
+    renderOverrun({
         dates: dates,
         measurements: [
             { metric_uuid: "uuid", start: "2020-01-01", end: "2020-01-10" },
@@ -46,5 +52,4 @@ it("merges the days overrun if the metric has consecutive measurements", async (
         ],
     })
     expectText(/16 days/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/measurement/SourceStatus.test.jsx
+++ b/components/frontend/src/measurement/SourceStatus.test.jsx
@@ -18,45 +18,44 @@ function renderSourceStatus(metric, measurementSource) {
     )
 }
 
-it("renders the hyperlink label if the source has a landing url", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderSourceStatus(metric, { landing_url: "https://landing", source_uuid: "source_uuid" })
-    expect(screen.getAllByRole("link").length).toBe(1)
     await expectNoAccessibilityViolations(container)
+})
+
+it("renders the hyperlink label if the source has a landing url", async () => {
+    renderSourceStatus(metric, { landing_url: "https://landing", source_uuid: "source_uuid" })
+    expect(screen.getAllByRole("link").length).toBe(1)
 })
 
 it("renders the source label if there is no error", async () => {
-    const { container } = renderSourceStatus(metric, { source_uuid: "source_uuid" })
+    renderSourceStatus(metric, { source_uuid: "source_uuid" })
     expectText(/Source name/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders the source label and the popup if there is an connection error", async () => {
-    const { container } = renderSourceStatus(metric, { source_uuid: "source_uuid", connection_error: "error" })
+    renderSourceStatus(metric, { source_uuid: "source_uuid", connection_error: "error" })
     expectText(/Source name/)
     await hoverText(/Source name/)
     await expectTextAfterWait("Connection error")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders the source label and the popup if there is a parse error", async () => {
-    const { container } = renderSourceStatus(metric, { source_uuid: "source_uuid", parse_error: "error" })
+    renderSourceStatus(metric, { source_uuid: "source_uuid", parse_error: "error" })
     expectText(/Source name/)
     await hoverText(/Source name/)
     await expectTextAfterWait("Parse error")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders the source label and the popup if there is a configuration error", async () => {
     metric.sources["source_uuid"]["type"] = "source_type2"
-    const { container } = renderSourceStatus(metric, { source_uuid: "source_uuid" })
+    renderSourceStatus(metric, { source_uuid: "source_uuid" })
     expectText(/Source name/)
     await hoverText(/Source name/)
     await expectTextAfterWait("Configuration error")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders nothing if the source has been deleted", async () => {
-    const { container } = renderSourceStatus(metric, { source_uuid: "other_source_uuid" })
+    renderSourceStatus(metric, { source_uuid: "other_source_uuid" })
     expectNoText(/Source name/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/measurement/StatusIcon.test.jsx
+++ b/components/frontend/src/measurement/StatusIcon.test.jsx
@@ -4,29 +4,30 @@ import userEvent from "@testing-library/user-event"
 import { expectNoAccessibilityViolations, expectTextAfterWait } from "../testUtils"
 import { StatusIcon } from "./StatusIcon"
 
-it("renders a checkmark if the status is target met", async () => {
-    const { container, getAllByLabelText } = render(<StatusIcon status="target_met" />)
-    expect(getAllByLabelText(/Target met/).length).toBe(1)
+it("has no accessibility violations", async () => {
+    const { container } = render(<StatusIcon status="informative" />)
     await expectNoAccessibilityViolations(container)
+})
+
+it("renders a checkmark if the status is target met", async () => {
+    const { getAllByLabelText } = render(<StatusIcon status="target_met" />)
+    expect(getAllByLabelText(/Target met/).length).toBe(1)
 })
 
 it("renders an info icon if the status is informative", async () => {
-    const { container, getAllByLabelText } = render(<StatusIcon status="informative" />)
+    const { getAllByLabelText } = render(<StatusIcon status="informative" />)
     expect(getAllByLabelText(/Informative/).length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a question mark if the status is missing", async () => {
-    const { container, getAllByLabelText } = render(<StatusIcon />)
+    const { getAllByLabelText } = render(<StatusIcon />)
     expect(getAllByLabelText(/Unknown/).length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a popup with the date the status started", async () => {
     let startDate = new Date()
     startDate.setDate(startDate.getDate() - 4)
-    const { container, queryByLabelText } = render(<StatusIcon status="target_met" statusStart={startDate} />)
+    const { queryByLabelText } = render(<StatusIcon status="target_met" statusStart={startDate} />)
     await userEvent.hover(queryByLabelText(/Target met/))
     await expectTextAfterWait(/4 days ago/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/measurement/TimeLeft.test.jsx
+++ b/components/frontend/src/measurement/TimeLeft.test.jsx
@@ -3,19 +3,7 @@ import { render } from "@testing-library/react"
 import { expectNoAccessibilityViolations, expectNoText, expectText } from "../testUtils"
 import { TimeLeft } from "./TimeLeft"
 
-it("does not render the time left if the status does not demand action", async () => {
-    const { container } = render(<TimeLeft metric={{ status: "target_met" }} report={{}} />)
-    expectNoText(/day/)
-    await expectNoAccessibilityViolations(container)
-})
-
-it("does not render the time left if there is no status start date", async () => {
-    const { container } = render(<TimeLeft metric={{ status: "target_not_met" }} report={{}} />)
-    expectNoText(/day/)
-    await expectNoAccessibilityViolations(container)
-})
-
-it("does render the time left if technical debt is accepted with an end date", async () => {
+it("has no accessibility violations", async () => {
     const { container } = render(
         <TimeLeft
             metric={{
@@ -26,31 +14,45 @@ it("does render the time left if technical debt is accepted with an end date", a
             report={{}}
         />,
     )
-    expectText(/day/)
     await expectNoAccessibilityViolations(container)
+})
+
+it("does not render the time left if the status does not demand action", async () => {
+    render(<TimeLeft metric={{ status: "target_met" }} report={{}} />)
+    expectNoText(/day/)
+})
+
+it("does not render the time left if there is no status start date", async () => {
+    render(<TimeLeft metric={{ status: "target_not_met" }} report={{}} />)
+    expectNoText(/day/)
+})
+
+it("does render the time left if technical debt is accepted with an end date", async () => {
+    render(
+        <TimeLeft
+            metric={{
+                status: "debt_target_met",
+                status_start: "2022-01-01",
+                debt_end_date: "3000-01-01",
+            }}
+            report={{}}
+        />,
+    )
+    expectText(/day/)
 })
 
 it("does not render the time left if technical debt is accepted without an end date", async () => {
-    const { container } = render(
-        <TimeLeft metric={{ status: "debt_target_met", status_start: "2022-01-01" }} report={{}} />,
-    )
+    render(<TimeLeft metric={{ status: "debt_target_met", status_start: "2022-01-01" }} report={{}} />)
     expectNoText(/day/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders 0 days left if the deadline is in the past", async () => {
-    const { container } = render(
-        <TimeLeft metric={{ status: "target_not_met", status_start: "2022-01-01" }} report={{}} />,
-    )
+    render(<TimeLeft metric={{ status: "target_not_met", status_start: "2022-01-01" }} report={{}} />)
     expectText(/0 days/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders the time left if status demands action", async () => {
     const now = new Date()
-    const { container } = render(
-        <TimeLeft metric={{ status: "target_not_met", status_start: now.toISOString() }} report={{}} />,
-    )
+    render(<TimeLeft metric={{ status: "target_not_met", status_start: now.toISOString() }} report={{}} />)
     expectText(/days/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/measurement/TrendSparkline.test.jsx
+++ b/components/frontend/src/measurement/TrendSparkline.test.jsx
@@ -3,20 +3,28 @@ import { render, screen } from "@testing-library/react"
 import { expectNoAccessibilityViolations } from "../testUtils"
 import { TrendSparkline } from "./TrendSparkline"
 
-it("returns null when the metric scale is version number", async () => {
-    const { container } = render(<TrendSparkline scale="version_number" />)
-    expect(screen.queryAllByLabelText(/sparkline graph/).length).toBe(0)
+it("has no accessibility violations", async () => {
+    const { container } = render(
+        <TrendSparkline
+            measurements={[{ count: { value: "1" }, start: "2019-09-29", end: "2019-09-30" }]}
+            scale="count"
+        />,
+    )
     await expectNoAccessibilityViolations(container)
+})
+
+it("returns null when the metric scale is version number", async () => {
+    render(<TrendSparkline scale="version_number" />)
+    expect(screen.queryAllByLabelText(/sparkline graph/).length).toBe(0)
 })
 
 it("renders an empty sparkline if there are no measurements", async () => {
-    const { container } = render(<TrendSparkline />)
+    render(<TrendSparkline />)
     expect(screen.queryAllByLabelText(/sparkline graph showing 0 different measurement values/).length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a recent measurement", async () => {
-    const { container } = render(
+    render(
         <TrendSparkline
             measurements={[{ count: { value: "1" }, start: "2019-09-29", end: "2019-09-30" }]}
             scale="count"
@@ -26,11 +34,10 @@ it("renders a recent measurement", async () => {
         screen.queryAllByLabelText(/sparkline graph showing 1 different measurement value in the week before today/)
             .length,
     ).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders multiple recent measurements", async () => {
-    const { container } = render(
+    render(
         <TrendSparkline
             measurements={[
                 { count: { value: null }, start: "2019-09-27", end: "2019-09-28" },
@@ -44,12 +51,11 @@ it("renders multiple recent measurements", async () => {
         screen.queryAllByLabelText(/sparkline graph showing 2 different measurement values in the week before today/)
             .length,
     ).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders old measurements", async () => {
     const date = new Date("2020-01-01")
-    const { container } = render(
+    render(
         <TrendSparkline
             measurements={[{ count: { value: "1" }, start: "2019-09-29", end: "2019-09-30" }]}
             reportDate={date}
@@ -61,5 +67,4 @@ it("renders old measurements", async () => {
             `sparkline graph showing 1 different measurement value in the week before ${date.toLocaleDateString()}`,
         ).length,
     ).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/metric/MetricConfigurationParameters.test.jsx
+++ b/components/frontend/src/metric/MetricConfigurationParameters.test.jsx
@@ -75,70 +75,67 @@ function expectMetricAttributePost(attribute, payload) {
     expectFetch("post", endPoint, { [attribute]: payload })
 }
 
-it("sets the metric name", async () => {
+it("has no accessibility violations", async () => {
     const { container } = await renderMetricParameters()
+    await expectNoAccessibilityViolations(container)
+})
+
+it("sets the metric name", async () => {
+    await renderMetricParameters()
     await typeInField(/Metric name/, "New metric name")
     expectMetricAttributePost("name", "New metric name")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the metric secondary name", async () => {
-    const { container } = await renderMetricParameters()
+    await renderMetricParameters()
     await typeInField(/Metric secondary name/, "New metric secondary name")
     expectMetricAttributePost("secondary_name", "New metric secondary name")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("adds a tag on enter", async () => {
-    const { container } = await renderMetricParameters()
+    await renderMetricParameters()
     await typeInField(/Metric tags/, "New tag", "Enter")
     expectMetricAttributePost("tags", ["New tag"])
-    await expectNoAccessibilityViolations(container)
 })
 
 it("adds a tag on tab", async () => {
-    const { container } = await renderMetricParameters()
+    await renderMetricParameters()
     await typeInField(/Metric tags/, "New tag", "Tab")
     expectMetricAttributePost("tags", ["New tag"])
-    await expectNoAccessibilityViolations(container)
 })
 
 it("changes the scale", async () => {
-    const { container } = await renderMetricParameters()
+    await renderMetricParameters()
     fireEvent.mouseDown(screen.getByLabelText(/Metric scale/))
     clickText(/Percentage/)
     expectMetricAttributePost("scale", "percentage")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("changes the direction", async () => {
-    const { container } = await renderMetricParameters()
+    await renderMetricParameters()
     fireEvent.mouseDown(screen.getByLabelText(/direction/))
     clickText(/More violations is better/)
     expectMetricAttributePost("direction", ">")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the metric unit for metrics with the count scale", async () => {
-    const { container } = await renderMetricParameters()
+    await renderMetricParameters()
     await typeInField(/Metric unit plural/, "New metric units")
     expectMetricAttributePost("unit", "New metric units")
     await typeInField(/Metric unit singular/, "New metric unit")
     expectMetricAttributePost("unit_singular", "New metric unit")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the metric unit for metrics with the percentage scale", async () => {
-    const { container } = await renderMetricParameters("percentage")
+    await renderMetricParameters("percentage")
     await typeInField(/Metric unit plural/, "New metric units")
     expectMetricAttributePost("unit", "New metric units")
     await typeInField(/Metric unit singular/, "New metric unit")
     expectMetricAttributePost("unit_singular", "New metric unit")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("skips the metric unit fields for metrics with the version number scale", async () => {
-    const { container } = render(
+    render(
         <DataModel.Provider value={dataModel}>
             <MetricConfigurationParameters
                 report={{ subjects: {} }}
@@ -149,12 +146,10 @@ it("skips the metric unit fields for metrics with the version number scale", asy
         </DataModel.Provider>,
     )
     expectNoText(/Metric unit/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("turns off evaluation of targets", async () => {
-    const { container } = await renderMetricParameters()
+    await renderMetricParameters()
     await userEvent.type(screen.getByLabelText(/Evaluate metric targets/), "No{Enter}")
     expectMetricAttributePost("evaluate_targets", false)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/metric/MetricDebtParameters.test.jsx
+++ b/components/frontend/src/metric/MetricDebtParameters.test.jsx
@@ -63,50 +63,48 @@ beforeEach(() => {
     vi.spyOn(fetchServerApi, "fetchServerApi").mockResolvedValue({ ok: true })
 })
 
-it("accepts technical debt", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderMetricDebtParameters()
+    await expectNoAccessibilityViolations(container)
+})
+
+it("accepts technical debt", async () => {
+    renderMetricDebtParameters()
     await userEvent.type(screen.getByLabelText(/Accept technical debt/), "Yes{Enter}")
     expectFetch("post", "metric/metric_uuid/attribute/accept_debt", { accept_debt: true })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("accepts technical debt and sets target and end date", async () => {
-    const { container } = renderMetricDebtParameters()
+    renderMetricDebtParameters()
     await userEvent.type(screen.getByLabelText(/Accept technical debt/), "Yes, and{Enter}")
     expectFetch("post", "metric/metric_uuid/debt", { accept_debt: true })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("unaccepts technical debt and resets target and end date", async () => {
-    const { container } = renderMetricDebtParameters({ acceptDebt: true })
+    renderMetricDebtParameters({ acceptDebt: true })
     await userEvent.type(screen.getByLabelText(/Accept technical debt/), "No, and{Enter}")
     expectFetch("post", "metric/metric_uuid/debt", { accept_debt: false })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("adds a comment", async () => {
-    const { container } = renderMetricDebtParameters()
+    renderMetricDebtParameters()
     await userEvent.type(screen.getByLabelText(/Comment/), "Keep cool{Tab}")
     expectFetch("post", "metric/metric_uuid/attribute/comment", { comment: "Keep cool" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("undoes changes to a comment", async () => {
-    const { container } = renderMetricDebtParameters()
+    renderMetricDebtParameters()
     await userEvent.type(screen.getByLabelText(/Comment/), "Keep cool{Escape}")
     expectNoFetch()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the technical debt end date", async () => {
-    const { container } = renderMetricDebtParameters()
+    renderMetricDebtParameters()
     await userEvent.type(screen.getAllByLabelText(/Technical debt end date/)[0], "12312022{Enter}")
     expectFetch("post", "metric/metric_uuid/attribute/debt_end_date", { debt_end_date: dayjs("2022-12-31") })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows days ago for the technical debt end date", async () => {
-    const { container } = renderMetricDebtParameters({ debtEndDate: "2000-01-01" })
+    renderMetricDebtParameters({ debtEndDate: "2000-01-01" })
     expectText(/years ago/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/metric/MetricDetails.test.jsx
+++ b/components/frontend/src/metric/MetricDetails.test.jsx
@@ -136,12 +136,16 @@ async function renderMetricDetails({
     return result
 }
 
+it("has no accessibility violations", async () => {
+    const { container } = await renderMetricDetails()
+    await expectNoAccessibilityViolations(container)
+})
+
 it("shows the trend graph tab even if the metric scale is version number", async () => {
     report.subjects["subject_uuid"].metrics["metric_uuid"].scale = "version_number"
-    const { container } = await renderMetricDetails()
+    await renderMetricDetails()
     expectText(/Trend graph/)
     report.subjects["subject_uuid"].metrics["metric_uuid"].scale = "count"
-    await expectNoAccessibilityViolations(container)
 })
 
 it("removes the existing hashtag from the URL to share", async () => {
@@ -156,15 +160,13 @@ it("removes the existing hashtag from the URL to share", async () => {
 })
 
 it("displays whether sources have errors", async () => {
-    const { container } = await renderMetricDetails({ connectionError: "Connection error" })
+    await renderMetricDetails({ connectionError: "Connection error" })
     expect(screen.getByText(/Sources/)).toHaveClass("error")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays whether sources have warnings", async () => {
-    const { container } = await renderMetricDetails()
+    await renderMetricDetails()
     expect(screen.getByText(/Sources/)).toHaveClass("warning")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("moves the metric", async () => {
@@ -202,52 +204,47 @@ it("does not measure the metric if the metric source configuration is incomplete
 
 it("loads an empty list of measurements", async () => {
     history.push("?expanded=metric_uuid:5")
-    const { container } = await renderMetricDetails({
+    await renderMetricDetails({
         getMetricMeasurements: () => Promise.resolve({ measurements: [] }),
     })
     expectNoText(/Loading measurements failed/)
     expect(toast.showMessage).toHaveBeenCalledTimes(0)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("loads a missing list of measurements", async () => {
     history.push("?expanded=metric_uuid:5")
-    const { container } = await renderMetricDetails({
+    await renderMetricDetails({
         getMetricMeasurements: () => Promise.resolve({}),
     })
     expectNoText(/Loading measurements failed/)
     expect(toast.showMessage).toHaveBeenCalledTimes(0)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("fails to load measurements due to a failed promise", async () => {
     history.push("?expanded=metric_uuid:5")
-    const { container } = await renderMetricDetails({
+    await renderMetricDetails({
         getMetricMeasurements: () => Promise.reject(new Error("Failure")),
     })
     expectText(/Loading measurements failed/)
     expect(toast.showMessage).toHaveBeenCalledTimes(1)
     expect(toast.showMessage).toHaveBeenCalledWith("error", "Could not fetch measurements", "Failure")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("fails to load measurements due to an internal server error", async () => {
     history.push("?expanded=metric_uuid:5")
-    const { container } = await renderMetricDetails({
+    await renderMetricDetails({
         getMetricMeasurements: () => Promise.resolve({ ok: false, statusText: "Internal Server Error" }),
     })
     expectText(/Loading measurements failed/)
     expect(toast.showMessage).toHaveBeenCalledTimes(1)
     expect(toast.showMessage).toHaveBeenCalledWith("error", "Could not fetch measurements", "Internal Server Error")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("reloads the measurements after editing a measurement entity", async () => {
     history.push("?expanded=metric_uuid:5")
-    const { container } = await renderMetricDetails()
+    await renderMetricDetails()
     expect(measurementApi.getMetricMeasurements).toHaveBeenCalledTimes(1)
     clickButton("Expand/collapse")
-    await expectNoAccessibilityViolations(container)
     fireEvent.mouseDown(screen.getByText("Unconfirm"))
     await asyncClickText("Confirm")
     expect(measurementApi.getMetricMeasurements).toHaveBeenCalledTimes(2)
@@ -255,7 +252,6 @@ it("reloads the measurements after editing a measurement entity", async () => {
 
 it("loads the changelog", async () => {
     history.push("?expanded=metric_uuid:3")
-    const { container } = await renderMetricDetails()
+    await renderMetricDetails()
     expectFetch("get", "changelog/metric/metric_uuid/5")
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/metric/MetricType.test.jsx
+++ b/components/frontend/src/metric/MetricType.test.jsx
@@ -55,35 +55,35 @@ function renderMetricType(metricType) {
     )
 }
 
+it("has no accessibility violations", async () => {
+    const { container } = renderMetricType("violations")
+    await expectNoAccessibilityViolations(container)
+})
+
 it("sets the metric type", async () => {
     vi.spyOn(fetchServerApi, "fetchServerApi").mockResolvedValue({ ok: true })
-    const { container } = renderMetricType("violations")
+    renderMetricType("violations")
     await userEvent.type(screen.getByRole("combobox"), "Source version{Enter}")
     expectFetch("post", "metric/metric_uuid/attribute/type", { type: "source_version" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the metric type even when not supported by the subject type", async () => {
-    const { container } = renderMetricType("unsupported")
+    renderMetricType("unsupported")
     expectText(/Unsupported/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the metric type read the docs URL", async () => {
-    const { container } = renderMetricType("violations")
+    renderMetricType("violations")
     expectText(/Read the Docs/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the metric type has extra documentation", async () => {
-    const { container } = renderMetricType("source_version")
+    renderMetricType("source_version")
     expectText(/for additional information on how to configure this metric type/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("uses the name of the metric type for the documentation link", async () => {
-    const { container } = renderMetricType("failed_jobs")
+    renderMetricType("failed_jobs")
     const readTheDocsLink = screen.getByRole("link", { name: "Read the Docs" })
     expect(readTheDocsLink).toHaveAttribute("href", expect.stringContaining("#failed-ci-jobs"))
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/metric/Target.test.jsx
+++ b/components/frontend/src/metric/Target.test.jsx
@@ -56,28 +56,29 @@ function expectMetricAttributePost(attribute, payload) {
     expectFetch("post", endPoint, { [attribute]: payload })
 }
 
-it("sets the metric integer target", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderMetricTarget({ type: "violations", target: "10" })
+    await expectNoAccessibilityViolations(container)
+})
+
+it("sets the metric integer target", async () => {
+    renderMetricTarget({ type: "violations", target: "10" })
     await typeInField("10", "42")
     expectMetricAttributePost("target", "42")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("is valid when the metric integer target is not set", async () => {
-    const { container } = renderMetricTarget({ type: "violations", target: "" })
+    renderMetricTarget({ type: "violations", target: "" })
     expect(screen.getByLabelText(/Metric target/)).toBeValid()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the metric version target", async () => {
-    const { container } = renderMetricTarget({ type: "source_version", target: "10" })
+    renderMetricTarget({ type: "source_version", target: "10" })
     await typeInField("10", "4.2")
     expectMetricAttributePost("target", "4.2")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("displays the default target if changed", async () => {
-    const { container } = renderMetricTarget({ type: "violations_with_default_target" })
+    renderMetricTarget({ type: "violations_with_default_target" })
     expectText(/Default/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/metric/TargetVisualiser.test.jsx
+++ b/components/frontend/src/metric/TargetVisualiser.test.jsx
@@ -50,8 +50,13 @@ function expectNotVisible(...matchers) {
     matchers.forEach((matcher) => expectNoText(matcher))
 }
 
-it("shows help for evaluated metric without tech debt", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderVisualiser({ type: "violations", target: "1", near_target: "15" })
+    await expectNoAccessibilityViolations(container)
+})
+
+it("shows help for evaluated metric without tech debt", async () => {
+    renderVisualiser({ type: "violations", target: "1", near_target: "15" })
     expectVisible(
         /Target met/,
         /≦ 1 violation$/,
@@ -61,11 +66,10 @@ it("shows help for evaluated metric without tech debt", async () => {
         /> 15 violations/,
     )
     expectNotVisible(/Debt target met/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows help for evaluated metric with tech debt", async () => {
-    const { container } = renderVisualiser({
+    renderVisualiser({
         type: "violations",
         target: "1",
         debt_target: "15",
@@ -82,11 +86,10 @@ it("shows help for evaluated metric with tech debt", async () => {
         /Target not met/,
         /> 20 violations/,
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows help for evaluated metric with tech debt if debt target is missing", async () => {
-    const { container } = renderVisualiser({ type: "violations", target: "10", near_target: "20", accept_debt: true })
+    renderVisualiser({ type: "violations", target: "10", near_target: "20", accept_debt: true })
     expectVisible(
         /Target met/,
         /≦ 10 violations/,
@@ -96,11 +99,10 @@ it("shows help for evaluated metric with tech debt if debt target is missing", a
         /> 20 violations/,
     )
     expectNotVisible(/Debt target met/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows help for evaluated metric with tech debt with end date", async () => {
-    const { container } = renderVisualiser({
+    renderVisualiser({
         type: "violations",
         target: "10",
         debt_target: "15",
@@ -118,11 +120,10 @@ it("shows help for evaluated metric with tech debt with end date", async () => {
         /Target not met/,
         /> 20 violations/,
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows help for evaluated metric with tech debt with end date in the past", async () => {
-    const { container } = renderVisualiser({
+    renderVisualiser({
         type: "violations",
         target: "10",
         debt_target: "15",
@@ -139,11 +140,10 @@ it("shows help for evaluated metric with tech debt with end date in the past", a
         /> 20 violations/,
     )
     expectNotVisible(/Debt target met/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows help for evaluated metric with tech debt completely overlapping near target", async () => {
-    const { container } = renderVisualiser({
+    renderVisualiser({
         type: "violations",
         target: "10",
         debt_target: "20",
@@ -159,18 +159,16 @@ it("shows help for evaluated metric with tech debt completely overlapping near t
         /> 20 violations/,
     )
     expectNotVisible(/Near target met/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows help for evaluated metric without tech debt and target completely overlapping near target", async () => {
-    const { container } = renderVisualiser({ type: "violations", target: "10", near_target: "10" })
+    renderVisualiser({ type: "violations", target: "10", near_target: "10" })
     expectVisible(/Target met/, /≦ 10 violations/, /Target not met/, /> 10 violations/)
     expectNotVisible(/Debt target met/, /Near target met/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows help for evaluated more-is-better metric without tech debt", async () => {
-    const { container } = renderVisualiser({ type: "violations", target: "15", near_target: "10", direction: ">" })
+    renderVisualiser({ type: "violations", target: "15", near_target: "10", direction: ">" })
     expectVisible(
         /Target not met/,
         /< 10 violations/,
@@ -180,11 +178,10 @@ it("shows help for evaluated more-is-better metric without tech debt", async () 
         /≧ 15 violations/,
     )
     expectNotVisible(/Debt target met/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows help for evaluated more-is-better metric with tech debt", async () => {
-    const { container } = renderVisualiser({
+    renderVisualiser({
         type: "violations",
         target: "15",
         near_target: "5",
@@ -202,11 +199,10 @@ it("shows help for evaluated more-is-better metric with tech debt", async () => 
         /Target met/,
         /≧ 15 violations/,
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows help for evaluated more-is-better metric with tech debt and missing debt target", async () => {
-    const { container } = renderVisualiser({
+    renderVisualiser({
         type: "violations",
         target: "15",
         near_target: "5",
@@ -222,11 +218,10 @@ it("shows help for evaluated more-is-better metric with tech debt and missing de
         /≧ 15 violations/,
     )
     expectNotVisible(/Debt target met/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows help for evaluated more-is-better metric with tech debt completely overlapping near target", async () => {
-    const { container } = renderVisualiser({
+    renderVisualiser({
         type: "violations",
         target: "15",
         near_target: "5",
@@ -243,26 +238,22 @@ it("shows help for evaluated more-is-better metric with tech debt completely ove
         /≧ 15 violations/,
     )
     expectNotVisible(/Near target met/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows help for evaluated more-is-better metric without tech debt and target completely overlapping near target", async () => {
-    const { container } = renderVisualiser({ type: "violations", target: "15", near_target: "15", direction: ">" })
+    renderVisualiser({ type: "violations", target: "15", near_target: "15", direction: ">" })
     expectVisible(/Target not met/, /< 15 violations/, /Target met/, /≧ 15 violations/)
     expectNotVisible(/Near target met/, /Debt target met/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows help for evaluated metric without tech debt and zero target completely overlapping near target", async () => {
-    const { container } = renderVisualiser({ type: "violations", target: "0", near_target: "0", direction: ">" })
+    renderVisualiser({ type: "violations", target: "0", near_target: "0", direction: ">" })
     expectVisible(/Target met/, /≧ 0 violations/)
     expectNotVisible(/Debt target met/, /Near target met/, /Target not met/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows help for informative metric", async () => {
-    const { container } = renderVisualiser({ type: "violations", evaluate_targets: false })
+    renderVisualiser({ type: "violations", evaluate_targets: false })
     expectVisible(/Informative/, /violations are not evaluated/)
     expectNotVisible(/Target met/, /Debt target met/, /Near target met/, /Target not met/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/metric/TrendGraph.test.jsx
+++ b/components/frontend/src/metric/TrendGraph.test.jsx
@@ -21,12 +21,18 @@ function renderTrendgraph({ measurements = [], scale = "count", loading = "loade
     )
 }
 
-it("renders the measurements", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderTrendgraph({
         measurements: [{ count: { value: "1" }, start: "2019-09-29", end: "2019-09-30" }],
     })
-    expectText(/Time/)
     await expectNoAccessibilityViolations(container)
+})
+
+it("renders the measurements", async () => {
+    renderTrendgraph({
+        measurements: [{ count: { value: "1" }, start: "2019-09-29", end: "2019-09-30" }],
+    })
+    expectText(/Time/)
 })
 
 it("renders the tooltip", async () => {
@@ -38,12 +44,11 @@ it("renders the tooltip", async () => {
         writable: true,
         value: vi.fn().mockImplementation(createSVGMatrix),
     })
-    const { container } = renderTrendgraph({
+    renderTrendgraph({
         measurements: [{ count: { value: "1", status: "target_met" }, start: "2019-09-29", end: "2019-09-30" }],
     })
     userEvent.hover(screen.getAllByTestId(/Point/)[0])
     await expectTextAfterWait(/1 violations \(target met\) on/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders measurements with targets", () => {

--- a/components/frontend/src/notification/NotificationDestinations.test.jsx
+++ b/components/frontend/src/notification/NotificationDestinations.test.jsx
@@ -30,42 +30,42 @@ function renderNotificationDestinations(destinations) {
 
 beforeEach(() => vi.spyOn(fetchServerApi, "fetchServerApi").mockImplementation(() => Promise.resolve({ ok: true })))
 
-it("creates the first notification destination when the add notification destination button is clicked", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderNotificationDestinations({})
+    await expectNoAccessibilityViolations(container)
+})
+
+it("creates the first notification destination when the add notification destination button is clicked", async () => {
+    renderNotificationDestinations({})
     clickText(/Add notification destination/)
     expectFetch("post", "report/report_uuid/notification_destination/new", { report_url: "http://localhost:3000/" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("creates a new notification destination when the add notification destination button is clicked", async () => {
-    const { container } = renderNotificationDestinations(notificationDestinations)
+    renderNotificationDestinations(notificationDestinations)
     clickText(/Add notification destination/)
     expectFetch("post", "report/report_uuid/notification_destination/new", { report_url: "http://localhost:3000/" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("edits notification destination name attribute when it is changed in the input field", async () => {
-    const { container } = renderNotificationDestinations(notificationDestinations)
+    renderNotificationDestinations(notificationDestinations)
     await userEvent.type(screen.getByLabelText(/Webhook name/), " changed{Enter}")
     expectFetch("post", "report/report_uuid/notification_destination/destination_uuid1/attributes", {
         name: "new changed",
     })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("edits multiple notification destination attributes when they are changed in the input fields", async () => {
-    const { container } = renderNotificationDestinations(notificationDestinations)
+    renderNotificationDestinations(notificationDestinations)
     await userEvent.type(screen.getByPlaceholderText(/https:\/\/example/), "new.webhook.com{Enter}")
     expectFetch("post", "report/report_uuid/notification_destination/destination_uuid1/attributes", {
         webhook: "new.webhook.com",
         url: "http://localhost:3000/",
     })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("removes the notification destination when the delete notification destination button is clicked", async () => {
-    const { container } = renderNotificationDestinations(notificationDestinations)
+    renderNotificationDestinations(notificationDestinations)
     clickText(/Delete notification destination/)
     expectFetch("delete", "report/report_uuid/notification_destination/destination_uuid1", {})
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/report/IssueTracker.test.jsx
+++ b/components/frontend/src/report/IssueTracker.test.jsx
@@ -55,14 +55,18 @@ const reportWithIssueTracker = {
     issue_tracker: { type: "jira" },
 }
 
-it("sets the issue tracker type", async () => {
+it("has no accessibility violations", async () => {
     const { container } = await renderIssueTracker()
+    await expectNoAccessibilityViolations(container)
+})
+
+it("sets the issue tracker type", async () => {
+    await renderIssueTracker()
     fireEvent.mouseDown(screen.getByLabelText(/Issue tracker type/))
     clickText("Jira")
     expect(reportApi.setReportIssueTrackerAttribute).toHaveBeenLastCalledWith("report_uuid", "type", "jira", reload)
     fireEvent.click(screen.getByText("None"))
     expect(reportApi.setReportIssueTrackerAttribute).toHaveBeenLastCalledWith("report_uuid", "type", "", reload)
-    await expectNoAccessibilityViolations(container)
 })
 
 function expectIssueTrackerFieldsToBeDisabled() {
@@ -73,23 +77,21 @@ function expectIssueTrackerFieldsToBeDisabled() {
 }
 
 it("cannot edit issue tracker fields without picking an issue tracker type", async () => {
-    const { container } = await renderIssueTracker()
+    await renderIssueTracker()
     expectIssueTrackerFieldsToBeDisabled()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("cannot edit issue tracker fields if the issue tracker type is None", async () => {
-    const { container } = await renderIssueTracker({
+    await renderIssueTracker({
         report_uuid: "report_uuid",
         title: "Report",
         issue_tracker: { type: "None" },
     })
     expectIssueTrackerFieldsToBeDisabled()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the issue tracker url", async () => {
-    const { container } = await renderIssueTracker({ report: reportWithIssueTracker })
+    await renderIssueTracker({ report: reportWithIssueTracker })
     await userEvent.type(screen.getByLabelText(/URL/), "https://jira.example.org{Enter}")
     expect(reportApi.setReportIssueTrackerAttribute).toHaveBeenLastCalledWith(
         "report_uuid",
@@ -97,11 +99,10 @@ it("sets the issue tracker url", async () => {
         "https://jira.example.org",
         reload,
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the issue tracker username", async () => {
-    const { container } = await renderIssueTracker({ report: reportWithIssueTracker })
+    await renderIssueTracker({ report: reportWithIssueTracker })
     expect(screen.getByLabelText(/Username/)).not.toBeDisabled()
     await userEvent.type(screen.getByLabelText(/Username/), "janedoe{Enter}")
     expect(reportApi.setReportIssueTrackerAttribute).toHaveBeenLastCalledWith(
@@ -110,11 +111,10 @@ it("sets the issue tracker username", async () => {
         "janedoe",
         reload,
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the issue tracker password", async () => {
-    const { container } = await renderIssueTracker({ report: reportWithIssueTracker })
+    await renderIssueTracker({ report: reportWithIssueTracker })
     await userEvent.type(screen.getByLabelText(/Password/), "secret{Enter}")
     expect(reportApi.setReportIssueTrackerAttribute).toHaveBeenLastCalledWith(
         "report_uuid",
@@ -122,11 +122,10 @@ it("sets the issue tracker password", async () => {
         "secret",
         reload,
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the issue tracker private token", async () => {
-    const { container } = await renderIssueTracker({ report: reportWithIssueTracker })
+    await renderIssueTracker({ report: reportWithIssueTracker })
     await userEvent.type(screen.getByLabelText(/Private token/), "secret{Enter}")
     expect(reportApi.setReportIssueTrackerAttribute).toHaveBeenLastCalledWith(
         "report_uuid",
@@ -134,7 +133,6 @@ it("sets the issue tracker private token", async () => {
         "secret",
         reload,
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not show the issue tracker private token help url if there is no issue tracker", async () => {
@@ -143,13 +141,11 @@ it("does not show the issue tracker private token help url if there is no issue 
         helpUrl: "https://help.example.org",
     })
     expect(container.querySelector("a")).toBe(null)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not show the issue tracker private token help url if the data model has no help url", async () => {
     const { container } = await renderIssueTracker()
     expect(container.querySelector("a")).toBe(null)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the issue tracker private token help url", async () => {
@@ -158,11 +154,10 @@ it("shows the issue tracker private token help url", async () => {
         helpUrl: "https://help.example.org",
     })
     expect(container.querySelector("a")).toHaveAttribute("href", "https://help.example.org")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the issue tracker API version", async () => {
-    const { container } = await renderIssueTracker({ report: reportWithIssueTracker })
+    await renderIssueTracker({ report: reportWithIssueTracker })
     fireEvent.mouseDown(screen.getByLabelText(/API version/))
     clickText(/v3/)
     expect(reportApi.setReportIssueTrackerAttribute).toHaveBeenLastCalledWith(
@@ -171,11 +166,10 @@ it("sets the issue tracker API version", async () => {
         "v3",
         reload,
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the issue tracker project", async () => {
-    const { container } = await renderIssueTracker({ report: reportWithIssueTracker, helpUrl: "https://help" })
+    await renderIssueTracker({ report: reportWithIssueTracker, helpUrl: "https://help" })
     fireEvent.mouseDown(screen.getByLabelText(/Project for new issues/))
     clickText(/Project name/)
     expect(reportApi.setReportIssueTrackerAttribute).toHaveBeenLastCalledWith(
@@ -184,11 +178,10 @@ it("sets the issue tracker project", async () => {
         "PRJ",
         reload,
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the issue tracker issue type", async () => {
-    const { container } = await renderIssueTracker({ report: reportWithIssueTracker, helpUrl: "https://help" })
+    await renderIssueTracker({ report: reportWithIssueTracker, helpUrl: "https://help" })
     fireEvent.mouseDown(screen.getByLabelText(/Issue type/))
     clickText(/Bug/)
     expect(reportApi.setReportIssueTrackerAttribute).toHaveBeenLastCalledWith(
@@ -197,11 +190,10 @@ it("sets the issue tracker issue type", async () => {
         "Bug",
         reload,
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the issue tracker issue labels", async () => {
-    const { container } = await renderIssueTracker({ report: reportWithIssueTracker, helpUrl: "https://help" })
+    await renderIssueTracker({ report: reportWithIssueTracker, helpUrl: "https://help" })
     await userEvent.type(screen.getByLabelText(/Labels/), "Label{Enter}")
     expect(reportApi.setReportIssueTrackerAttribute).toHaveBeenLastCalledWith(
         "report_uuid",
@@ -209,11 +201,10 @@ it("sets the issue tracker issue labels", async () => {
         ["Label"],
         reload,
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the issue tracker epic link", async () => {
-    const { container } = await renderIssueTracker({ report: reportWithIssueTracker, helpUrl: "https://help" })
+    await renderIssueTracker({ report: reportWithIssueTracker, helpUrl: "https://help" })
     fireEvent.mouseDown(screen.getByLabelText(/Epic link/))
     clickText(/FOO-420/)
     expect(reportApi.setReportIssueTrackerAttribute).toHaveBeenLastCalledWith(
@@ -222,17 +213,15 @@ it("sets the issue tracker epic link", async () => {
         "FOO-420",
         reload,
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not show the issue labels warning without tracker project", async () => {
-    const { container } = await renderIssueTracker({ report: reportWithIssueTracker })
+    await renderIssueTracker({ report: reportWithIssueTracker })
     expectNoText(/Labels not supported/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not show the issue labels warning without issue type", async () => {
-    const { container } = await renderIssueTracker({
+    await renderIssueTracker({
         report: {
             report_uuid: "report_uuid",
             title: "Report",
@@ -240,11 +229,10 @@ it("does not show the issue labels warning without issue type", async () => {
         },
     })
     expectNoText(/Labels not supported/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not show the issue labels warning with issue type that supports labels", async () => {
-    const { container } = await renderIssueTracker({
+    await renderIssueTracker({
         report: {
             report_uuid: "report_uuid",
             title: "Report",
@@ -255,7 +243,6 @@ it("does not show the issue labels warning with issue type that supports labels"
         },
     })
     expectNoText(/Labels not supported/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does show the issue labels warning with issue type that does not support labels", async () => {
@@ -267,7 +254,7 @@ it("does show the issue labels warning with issue type that does not support lab
             epic_links: [],
         }),
     )
-    const { container } = await renderIssueTracker({
+    await renderIssueTracker({
         report: {
             report_uuid: "report_uuid",
             title: "Report",
@@ -278,5 +265,4 @@ it("does show the issue labels warning with issue type that does not support lab
         },
     })
     expectText(/Labels not supported/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/report/Report.test.jsx
+++ b/components/frontend/src/report/Report.test.jsx
@@ -81,22 +81,29 @@ async function renderReport({
     return result
 }
 
-it("shows the report", async () => {
+it("has no accessibility violations", async () => {
     const { container } = await renderReport({ reportToRender: report })
-    expectText(/Subject title/, 2) // Once as dashboard card and once as subject header
     await expectNoAccessibilityViolations(container)
+})
+
+it("has no accessibility violations when report is missing", async () => {
+    const { container } = await renderReport({})
+    await expectNoAccessibilityViolations(container)
+})
+
+it("shows the report", async () => {
+    await renderReport({ reportToRender: report })
+    expectText(/Subject title/, 2) // Once as dashboard card and once as subject header
 })
 
 it("shows an error message if there is no report", async () => {
-    const { container } = await renderReport()
+    await renderReport()
     expectText(/Sorry, this report doesn't exist/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows an error message if there was no report", async () => {
-    const { container } = await renderReport({ reportDate: new Date("2020-01-01") })
+    await renderReport({ reportDate: new Date("2020-01-01") })
     expectText(/Sorry, this report didn't exist/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides columns on load", async () => {

--- a/components/frontend/src/report/ReportDashboard.test.jsx
+++ b/components/frontend/src/report/ReportDashboard.test.jsx
@@ -56,129 +56,119 @@ function renderDashboard({ hiddenTags = null, dates = [new Date()], onClick = vi
     )
 }
 
-it("shows the dashboard", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderDashboard({ reportToRender: report })
+    await expectNoAccessibilityViolations(container)
+})
+
+it("shows the dashboard", async () => {
+    renderDashboard({ reportToRender: report })
     expectText(/Subject title/)
     expectText(/Legend/)
     expectText(/tag/)
     expectText(/other/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides tags", async () => {
     history.push("?hidden_tags=other")
     const hiddenTags = renderHook(() => useHiddenTagsURLSearchQuery())
-    const { container } = renderDashboard({ reportToRender: report, hiddenTags: hiddenTags.result.current })
+    renderDashboard({ reportToRender: report, hiddenTags: hiddenTags.result.current })
     expectText(/Subject title/)
     expectText(/tag/)
     expectNoText(/other/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides a subject if all its tags are hidden", async () => {
     history.push("?hidden_tags=other,tag")
     const hiddenTags = renderHook(() => useHiddenTagsURLSearchQuery())
-    const { container } = renderDashboard({ reportToRender: report, hiddenTags: hiddenTags.result.current })
+    renderDashboard({ reportToRender: report, hiddenTags: hiddenTags.result.current })
     expectNoText(/Subject title/)
     expectNoText(/tag/)
     expectNoText(/other/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("expands the subject title on click", async () => {
     const onClick = vi.fn()
-    const { container } = renderDashboard({ reportToRender: report, onClick: onClick })
+    renderDashboard({ reportToRender: report, onClick: onClick })
     clickText(/Subject title/)
     expect(onClick).toHaveBeenCalledWith(expect.anything(), "subject_uuid")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides the subject cards", async () => {
     history.push("?hidden_cards=subjects")
-    const { container } = renderDashboard({ reportToRender: report })
+    renderDashboard({ reportToRender: report })
     expectNoText(/Subject title/)
     expectText(/Action required/)
     expectText(/tag/)
     expectText(/other/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides the tag cards", async () => {
     history.push("?hidden_cards=tags")
-    const { container } = renderDashboard({ reportToRender: report })
+    renderDashboard({ reportToRender: report })
     expectText(/Subject title/)
     expectText(/Action required/)
     expectNoText(/tag/)
     expectNoText(/other/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides the required actions cards", async () => {
     history.push("?hidden_cards=action_required")
-    const { container } = renderDashboard({ reportToRender: report })
+    renderDashboard({ reportToRender: report })
     expectText(/Subject title/)
     expectNoText(/Action required/)
     expectText(/tag/)
     expectText(/other/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides metrics not requiring action", async () => {
-    const { container } = renderDashboard({ reportToRender: report })
+    renderDashboard({ reportToRender: report })
     clickText(/Action required/)
     expectSearch("?metrics_to_hide=no_action_required")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("unhides metrics not requiring action", async () => {
     history.push("?metrics_to_hide=no_action_required")
-    const { container } = renderDashboard({ reportToRender: report })
+    renderDashboard({ reportToRender: report })
     clickText(/Action required/)
     expectSearch("")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides the legend card", async () => {
     history.push("?hidden_cards=legend")
-    const { container } = renderDashboard({ reportToRender: report })
+    renderDashboard({ reportToRender: report })
     expectNoText(/Legend/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not show the issues card without issue tracker", async () => {
-    const { container } = renderDashboard({ reportToRender: report })
+    renderDashboard({ reportToRender: report })
     expectNoText(/Issues/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does show the issues card with issue tracker", async () => {
     report["issue_tracker"] = { type: "jira" }
-    const { container } = renderDashboard({ reportToRender: report })
+    renderDashboard({ reportToRender: report })
     expectText(/Issues/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides the issues card", async () => {
     history.push("?hidden_cards=issues")
     report["issue_tracker"] = { type: "jira" }
-    const { container } = renderDashboard({ reportToRender: report })
+    renderDashboard({ reportToRender: report })
     expectNoText(/Issues/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides metrics without issues", async () => {
     report["issue_tracker"] = { type: "jira" }
-    const { container } = renderDashboard({ reportToRender: report })
+    renderDashboard({ reportToRender: report })
     clickText(/Issues/)
     expectSearch("?metrics_to_hide=no_issues")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("unhides metrics without issues", async () => {
     report["issue_tracker"] = { type: "jira" }
     history.push("?metrics_to_hide=no_issues")
-    const { container } = renderDashboard({ reportToRender: report })
+    renderDashboard({ reportToRender: report })
     clickText(/Issues/)
     expectSearch("")
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/report/ReportSources.test.jsx
+++ b/components/frontend/src/report/ReportSources.test.jsx
@@ -26,26 +26,28 @@ function renderReportSources(report, expandedItems, theDataModel) {
 
 beforeEach(() => vi.spyOn(fetchServerApi, "fetchServerApi").mockResolvedValue({ ok: true }))
 
-it("shows a message if the report has no subjects", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderReportSources({})
-    expectText(/No sources have been configured yet/)
     await expectNoAccessibilityViolations(container)
+})
+
+it("shows a message if the report has no subjects", async () => {
+    renderReportSources({})
+    expectText(/No sources have been configured yet/)
 })
 
 it("shows a message if none of the subjects has metrics", async () => {
-    const { container } = renderReportSources({ subjects: { subject_uuid: {} } })
+    renderReportSources({ subjects: { subject_uuid: {} } })
     expectText(/No sources have been configured yet/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the sources", async () => {
-    const { container } = renderReportSources(report)
+    renderReportSources(report)
     expectText(/Source 2/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows a message for sources without url", async () => {
-    const { container } = renderReportSources(
+    renderReportSources(
         {
             subjects: {
                 subject_uuid: {
@@ -63,17 +65,15 @@ it("shows a message for sources without url", async () => {
         ["source_uuid:0"],
     )
     expectText(/This source has no location parameters/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("counts the metrics", async () => {
-    const { container } = renderReportSources(report)
+    renderReportSources(report)
     expectText("1", 2) // Two sources, each used once and each without unused metric types
-    await expectNoAccessibilityViolations(container)
 })
 
 it("counts the metrics using the same source", async () => {
-    const { container } = renderReportSources({
+    renderReportSources({
         subjects: {
             subject_uuid: {
                 metrics: {
@@ -88,11 +88,10 @@ it("counts the metrics using the same source", async () => {
         },
     })
     expectText("2")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("considers sources different if only the API-version differs", async () => {
-    const { container } = renderReportSources({
+    renderReportSources({
         subjects: {
             subject_uuid: {
                 metrics: {
@@ -117,11 +116,10 @@ it("considers sources different if only the API-version differs", async () => {
         },
     })
     expectText("https://source.org", 2) // Two sources, each used once
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the default source name if the source doesn't have an own name", async () => {
-    const { container } = renderReportSources({
+    renderReportSources({
         subjects: {
             subject_uuid: {
                 metrics: {
@@ -133,11 +131,10 @@ it("shows the default source name if the source doesn't have an own name", async
         },
     })
     expectText("Source type name", 2) // Source type and source name are equal
-    await expectNoAccessibilityViolations(container)
 })
 
 it("considers a source without name the same as a source that has a name equal to the default name", async () => {
-    const { container } = renderReportSources({
+    renderReportSources({
         subjects: {
             subject_uuid: {
                 metrics: {
@@ -160,11 +157,10 @@ it("considers a source without name the same as a source that has a name equal t
         },
     })
     expectText("Source type name", 2) // Source type and source name are equal
-    await expectNoAccessibilityViolations(container)
 })
 
 it("changes the value of a parameter of a source without parameter layout", async () => {
-    const { container } = renderReportSources(
+    renderReportSources(
         {
             subjects: {
                 subject_uuid: {
@@ -182,7 +178,6 @@ it("changes the value of a parameter of a source without parameter layout", asyn
     )
     await userEvent.type(screen.getAllByLabelText(/URL/)[0], "/new{Enter}")
     expectFetch("post", "source/source_uuid/parameter/url", { url: "https://source.org/new", edit_scope: "report" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("changes the value of a parameter of a source with parameter layout", async () => {
@@ -193,7 +188,7 @@ it("changes the value of a parameter of a source with parameter layout", async (
     theDataModel.sources["source_type"].parameter_layout = {
         location: { parameters: ["api_version"] },
     }
-    const { container } = renderReportSources(
+    renderReportSources(
         {
             subjects: {
                 subject_uuid: {
@@ -212,7 +207,6 @@ it("changes the value of a parameter of a source with parameter layout", async (
     )
     await userEvent.type(screen.getByLabelText(/API version/), "{Backspace}3{Enter}")
     expectFetch("post", "source/source_uuid/parameter/api_version", { api_version: "3", edit_scope: "report" })
-    await expectNoAccessibilityViolations(container)
 })
 
 function expectOrder(expected) {
@@ -254,56 +248,49 @@ function createReport(name1, name2) {
 }
 
 it("sorts the sources by name", async () => {
-    const { container } = renderReportSources(createReport("source2", "source1"))
+    renderReportSources(createReport("source2", "source1"))
     expectOrder(["source1", "source2"])
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sorts the sources by type if not all names are available", async () => {
-    const { container } = renderReportSources(createReport("", "source1"))
+    renderReportSources(createReport("", "source1"))
     expectOrder(["https://source1.org", "source1"]) // "Source type" comes before "source1"
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sorts the sources by type if no names are available", async () => {
-    const { container } = renderReportSources(createReport("", ""))
+    renderReportSources(createReport("", ""))
     expectOrder(["https://source1.org", "https://source2.org"]) // Source order unchanged because the source types are equal
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the metrics using the source", async () => {
     history.push("?expanded=source_uuid:1")
-    const { container } = renderReportSources(report)
+    renderReportSources(report)
     expectText("M1")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the secondary names of metrics using the source", async () => {
     history.push("?expanded=source_uuid2:1") // Use the second metric and source for better test coverage
     report.subjects["subject_uuid"].metrics["metric_uuid2"].secondary_name = "secondary name"
-    const { container } = renderReportSources(report)
+    renderReportSources(report)
     expectText(/M2.*secondary name/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("ignores an empty report", async () => {
     history.push("?expanded=source_uuid:1")
-    const { container } = renderReportSources({})
-    await expectNoAccessibilityViolations(container)
+    renderReportSources({})
+    expectText("No sources")
 })
 
 it("ignores subjects without metrics", async () => {
     history.push("?expanded=source_uuid:1")
-    const { container } = renderReportSources({ subjects: { subject_uuid: {} } })
+    renderReportSources({ subjects: { subject_uuid: {} } })
     expectNoText("M1")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("ignores metrics without sources", async () => {
     history.push("?expanded=source_uuid:1")
-    const { container } = renderReportSources({ subjects: { subject_uuid: { metrics: { metric_uuid: {} } } } })
+    renderReportSources({ subjects: { subject_uuid: { metrics: { metric_uuid: {} } } } })
     expectNoText("M1")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the unused metric types", async () => {
@@ -334,13 +321,12 @@ it("shows the unused metric types", async () => {
             },
         },
     }
-    const { container } = renderReportSources(report)
+    renderReportSources(report)
     expectText("Metric type 2")
     const readTheDocsLink = screen.getByRole("link", { name: "Metric type 2" })
     expect(readTheDocsLink).toHaveAttribute("href", expect.stringContaining("#metric-type-2"))
     expectText("Metric type description")
     expectText("Metric type rationale")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows a message if there are no unused metric types", async () => {
@@ -362,7 +348,6 @@ it("shows a message if there are no unused metric types", async () => {
             },
         },
     }
-    const { container } = renderReportSources(report)
+    renderReportSources(report)
     expectText("All metric types that this source supports are being used.")
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/report/ReportTitle.test.jsx
+++ b/components/frontend/src/report/ReportTitle.test.jsx
@@ -52,42 +52,49 @@ it("deletes the report", async () => {
 describe("configuration tab", () => {
     beforeEach(() => history.push("?expanded=report_uuid:0"))
 
-    it("sets the title", async () => {
+    it("has no accessibility violations", async () => {
         const { container } = renderReportTitle()
+        await expectNoAccessibilityViolations(container)
+    })
+
+    it("sets the title", async () => {
+        renderReportTitle()
         await userEvent.type(screen.getByLabelText(/Report title/), "New title{Enter}", {
             initialSelectionStart: 0,
             initialSelectionEnd: 12,
         })
         expectFetch("post", "report/report_uuid/attribute/title", { title: "New title" })
-        await expectNoAccessibilityViolations(container)
     })
 
     it("sets the subtitle", async () => {
-        const { container } = renderReportTitle()
+        renderReportTitle()
         await userEvent.type(screen.getByLabelText(/Report subtitle/), "New subtitle{Enter}", {
             initialSelectionStart: 0,
             initialSelectionEnd: 12,
         })
         expectFetch("post", "report/report_uuid/attribute/subtitle", { subtitle: "New subtitle" })
-        await expectNoAccessibilityViolations(container)
     })
 
     it("sets the comment", async () => {
-        const { container } = renderReportTitle()
+        renderReportTitle()
         await userEvent.type(screen.getByLabelText(/Comment/), "New comment{Shift>}{Enter}", {
             initialSelectionStart: 0,
             initialSelectionEnd: 8,
         })
         expectFetch("post", "report/report_uuid/attribute/comment", { comment: "New comment" })
-        await expectNoAccessibilityViolations(container)
     })
 })
 
 describe("desired reaction times tab", () => {
     beforeEach(() => history.push("?expanded=report_uuid:1"))
 
-    it("sets the unknown status reaction time", async () => {
+    it("has no accessibility violations", async () => {
         const { container } = renderReportTitle()
+        await expectNoAccessibilityViolations(container)
+    })
+
+    it("sets the unknown status reaction time", async () => {
+        renderReportTitle()
         await asyncClickLabeledElement("Unknown")
         await userEvent.type(screen.getByLabelText("Unknown"), "4{Enter}}", {
             initialSelectionStart: 0,
@@ -96,11 +103,10 @@ describe("desired reaction times tab", () => {
         expectFetch("post", "report/report_uuid/attribute/desired_response_times", {
             desired_response_times: { unknown: 4 },
         })
-        await expectNoAccessibilityViolations(container)
     })
 
     it("sets the target not met status reaction time", async () => {
-        const { container } = renderReportTitle()
+        renderReportTitle()
         await userEvent.type(screen.getByLabelText("Target not met"), "5{Enter}}", {
             initialSelectionStart: 0,
             initialSelectionEnd: 1,
@@ -108,11 +114,10 @@ describe("desired reaction times tab", () => {
         expectFetch("post", "report/report_uuid/attribute/desired_response_times", {
             desired_response_times: { target_not_met: 5 },
         })
-        await expectNoAccessibilityViolations(container)
     })
 
     it("sets the near target met status reaction time", async () => {
-        const { container } = renderReportTitle()
+        renderReportTitle()
         await userEvent.type(screen.getByLabelText("Near target met"), "6{Enter}}", {
             initialSelectionStart: 0,
             initialSelectionEnd: 2,
@@ -120,11 +125,10 @@ describe("desired reaction times tab", () => {
         expectFetch("post", "report/report_uuid/attribute/desired_response_times", {
             desired_response_times: { near_target_met: 6 },
         })
-        await expectNoAccessibilityViolations(container)
     })
 
     it("sets the tech debt target status reaction time", async () => {
-        const { container } = renderReportTitle()
+        renderReportTitle()
         await userEvent.type(screen.getByLabelText(/Technical debt target met/), "6{Enter}}", {
             initialSelectionStart: 0,
             initialSelectionEnd: 2,
@@ -132,11 +136,10 @@ describe("desired reaction times tab", () => {
         expectFetch("post", "report/report_uuid/attribute/desired_response_times", {
             desired_response_times: { debt_target_met: 6 },
         })
-        await expectNoAccessibilityViolations(container)
     })
 
     it("sets the confirmed measurement entity status reaction time", async () => {
-        const { container } = renderReportTitle()
+        renderReportTitle()
         await userEvent.type(screen.getByLabelText("Confirmed"), "60{Enter}}", {
             initialSelectionStart: 0,
             initialSelectionEnd: 3,
@@ -144,11 +147,10 @@ describe("desired reaction times tab", () => {
         expectFetch("post", "report/report_uuid/attribute/desired_response_times", {
             desired_response_times: { confirmed: 60 },
         })
-        await expectNoAccessibilityViolations(container)
     })
 
     it("sets the false positive measurement entity status reaction time", async () => {
-        const { container } = renderReportTitle()
+        renderReportTitle()
         await userEvent.type(screen.getByLabelText("False positive"), "70{Enter}}", {
             initialSelectionStart: 0,
             initialSelectionEnd: 3,
@@ -156,11 +158,10 @@ describe("desired reaction times tab", () => {
         expectFetch("post", "report/report_uuid/attribute/desired_response_times", {
             desired_response_times: { false_positive: 70 },
         })
-        await expectNoAccessibilityViolations(container)
     })
 
     it("sets the fixed measurement entity status reaction time", async () => {
-        const { container } = renderReportTitle()
+        renderReportTitle()
         await userEvent.type(screen.getByLabelText("Fixed"), "80{Enter}}", {
             initialSelectionStart: 0,
             initialSelectionEnd: 3,
@@ -168,11 +169,10 @@ describe("desired reaction times tab", () => {
         expectFetch("post", "report/report_uuid/attribute/desired_response_times", {
             desired_response_times: { fixed: 80 },
         })
-        await expectNoAccessibilityViolations(container)
     })
 
     it("sets the won't fixed measurement entity status reaction time", async () => {
-        const { container } = renderReportTitle()
+        renderReportTitle()
         await userEvent.type(screen.getByLabelText("Won't fix"), "90{Enter}}", {
             initialSelectionStart: 0,
             initialSelectionEnd: 3,
@@ -180,91 +180,106 @@ describe("desired reaction times tab", () => {
         expectFetch("post", "report/report_uuid/attribute/desired_response_times", {
             desired_response_times: { wont_fix: 90 },
         })
-        await expectNoAccessibilityViolations(container)
     })
 })
 
 describe("notification destinations tab", () => {
     beforeEach(() => history.push("?expanded=report_uuid:2"))
 
-    it("shows the notification destinations", async () => {
+    it("has no accessibility violations", async () => {
         const { container } = renderReportTitle()
-        expectText(/No notification destinations/, 2)
         await expectNoAccessibilityViolations(container)
+    })
+
+    it("shows the notification destinations", async () => {
+        renderReportTitle()
+        expectText(/No notification destinations/, 2)
     })
 })
 
 describe("issue tracker tab", () => {
     beforeEach(() => history.push("?expanded=report_uuid:3"))
 
+    it("has no accessibility violations", async () => {
+        const { container } = renderReportTitle()
+        await expectNoAccessibilityViolations(container)
+    })
+
     it("sets the issue tracker type", async () => {
         fetchServerApi.fetchServerApi.mockImplementation(() =>
             Promise.resolve({ projects: [], issue_types: [], fields: [], epic_links: [] }),
         )
-        const { container } = renderReportTitle()
+        renderReportTitle()
         fireEvent.mouseDown(screen.getByLabelText(/Issue tracker type/))
         const listbox = within(screen.getByRole("listbox"))
         await act(async () => fireEvent.click(listbox.getByText(/Jira/)))
         expectFetch("post", "report/report_uuid/issue_tracker/type", { type: "jira" })
-        await expectNoAccessibilityViolations(container)
     })
 
     it("sets the issue tracker url", async () => {
-        const { container } = renderReportTitle({ issueTrackerType: "jira" })
+        renderReportTitle({ issueTrackerType: "jira" })
         await userEvent.type(screen.getByLabelText(/URL/), "https://jira{Enter}")
         expectFetch("post", "report/report_uuid/issue_tracker/url", { url: "https://jira" })
-        await expectNoAccessibilityViolations(container)
     })
 
     it("sets the issue tracker username", async () => {
-        const { container } = renderReportTitle({ issueTrackerType: "jira" })
+        renderReportTitle({ issueTrackerType: "jira" })
         await userEvent.type(screen.getByLabelText(/Username/), "janedoe{Enter}")
         expectFetch("post", "report/report_uuid/issue_tracker/username", { username: "janedoe" })
-        await expectNoAccessibilityViolations(container)
     })
 
     it("sets the issue tracker password", async () => {
-        const { container } = renderReportTitle({ issueTrackerType: "jira" })
+        renderReportTitle({ issueTrackerType: "jira" })
         await userEvent.type(screen.getByLabelText(/Password/), "secret{Enter}")
         expectFetch("post", "report/report_uuid/issue_tracker/password", { password: "secret" })
-        await expectNoAccessibilityViolations(container)
     })
 
     it("sets the issue tracker private token", async () => {
-        const { container } = renderReportTitle({ issueTrackerType: "jira" })
+        renderReportTitle({ issueTrackerType: "jira" })
         await userEvent.type(screen.getByLabelText(/Private token/), "secret{Enter}")
         expectFetch("post", "report/report_uuid/issue_tracker/private_token", { private_token: "secret" })
-        await expectNoAccessibilityViolations(container)
     })
 })
 
 describe("sources tab", () => {
     beforeEach(() => history.push("?expanded=report_uuid:4"))
 
-    it("shows the sources, if available", async () => {
+    it("has no accessibility violations", async () => {
         const { container } = renderReportTitle()
-        expectText(/No sources have been configured yet/)
         await expectNoAccessibilityViolations(container)
+    })
+
+    it("shows the sources, if available", async () => {
+        renderReportTitle()
+        expectText(/No sources have been configured yet/)
     })
 })
 
 describe("tags tab", () => {
     beforeEach(() => history.push("?expanded=report_uuid:5"))
 
-    it("shows the tags", async () => {
+    it("has no accessibility violations", async () => {
         const { container } = renderReportTitle()
-        expectText(/Tags/)
         await expectNoAccessibilityViolations(container)
+    })
+
+    it("shows the tags", async () => {
+        renderReportTitle()
+        expectText(/Tags/)
     })
 })
 
 describe("changelog tab", () => {
     beforeEach(() => history.push("?expanded=report_uuid:6"))
 
+    it("has no accessibility violations", async () => {
+        const { container } = renderReportTitle()
+        await expectNoAccessibilityViolations(container)
+    })
+
     it("loads the changelog", async () => {
         fetchServerApi.fetchServerApi.mockImplementation(() => Promise.resolve({ changelog: [] }))
-        const { container } = renderReportTitle()
-        expectFetch("get", "changelog/report/report_uuid/5")
-        await expectNoAccessibilityViolations(container)
+        renderReportTitle()
+        await act(async () => expectFetch("get", "changelog/report/report_uuid/5"))
     })
 })

--- a/components/frontend/src/report/ReportsOverview.test.jsx
+++ b/components/frontend/src/report/ReportsOverview.test.jsx
@@ -61,26 +61,28 @@ async function renderReportsOverview({
     return result
 }
 
-it("shows an error message if there are no reports at the specified date", async () => {
-    const { container } = await renderReportsOverview({ reportDate: new Date() })
-    expectText(/Sorry, no reports existed at/)
+it("has no accessibility violations", async () => {
+    const { container } = await renderReportsOverview()
     await expectNoAccessibilityViolations(container)
+})
+
+it("shows an error message if there are no reports at the specified date", async () => {
+    await renderReportsOverview({ reportDate: new Date() })
+    expectText(/Sorry, no reports existed at/)
 })
 
 it("shows the reports overview", async () => {
     const reports = [{ report_uuid: "report_uuid", subjects: {} }]
     const reportsOverview = { title: "Overview", permissions: {} }
-    const { container } = await renderReportsOverview({ reports: reports, reportsOverview: reportsOverview })
+    await renderReportsOverview({ reports: reports, reportsOverview: reportsOverview })
     expectText(/Overview/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the comment", async () => {
     const reports = [{ report_uuid: "report_uuid", subjects: {} }]
     const reportsOverview = { title: "Overview", comment: "Commentary", permissions: {} }
-    const { container } = await renderReportsOverview({ reports: reports, reportsOverview: reportsOverview })
+    await renderReportsOverview({ reports: reports, reportsOverview: reportsOverview })
     expectText(/Commentary/)
-    await expectNoAccessibilityViolations(container)
 })
 
 const reports = [

--- a/components/frontend/src/report/ReportsOverviewDashboard.test.jsx
+++ b/components/frontend/src/report/ReportsOverviewDashboard.test.jsx
@@ -65,76 +65,72 @@ function renderReportsOverviewDashboard({
     )
 }
 
-it("shows the reports overview dashboard", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderReportsOverviewDashboard()
-    expectText(/Legend/)
     await expectNoAccessibilityViolations(container)
+})
+
+it("shows the reports overview dashboard", async () => {
+    renderReportsOverviewDashboard()
+    expectText(/Legend/)
 })
 
 it("hides tags", async () => {
     history.push("?hidden_tags=other")
     const hiddenTags = renderHook(() => useHiddenTagsURLSearchQuery())
-    const { container } = renderReportsOverviewDashboard({ hiddenTags: hiddenTags.result.current })
+    renderReportsOverviewDashboard({ hiddenTags: hiddenTags.result.current })
     expectText(/tag/)
     expectNoText(/other/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("calls the callback on click", async () => {
     const openReport = vi.fn()
-    const { container } = renderReportsOverviewDashboard({ openReport: openReport })
+    renderReportsOverviewDashboard({ openReport: openReport })
     clickText(/Report/)
     expect(openReport).toHaveBeenCalledWith("report_uuid")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides the report cards", async () => {
     history.push("?hidden_cards=reports")
-    const { container } = renderReportsOverviewDashboard()
+    renderReportsOverviewDashboard()
     expectNoText(/Report/)
     expectText(/tag/)
     expectText(/other/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides the tag cards", async () => {
     history.push("?hidden_cards=tags")
-    const { container } = renderReportsOverviewDashboard()
+    renderReportsOverviewDashboard()
     expectText(/Report/)
     expectNoText(/tag/)
     expectNoText(/other/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides the required actions cards", async () => {
     history.push("?hidden_cards=action_required")
-    const { container } = renderReportsOverviewDashboard()
+    renderReportsOverviewDashboard()
     expectText(/Report/)
     expectNoText(/Action required/)
     expectText(/tag/)
     expectText(/other/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides metrics not requiring action", async () => {
     history.push("?metrics_to_hide=all")
-    const { container } = renderReportsOverviewDashboard()
+    renderReportsOverviewDashboard()
     clickText(/Action required/)
     expectSearch("?metrics_to_hide=no_action_required")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("unhides metrics not requiring action", async () => {
     history.push("?metrics_to_hide=no_action_required")
-    const { container } = renderReportsOverviewDashboard()
+    renderReportsOverviewDashboard()
     clickText(/Action required/)
     expectSearch("?metrics_to_hide=all")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides the legend card", async () => {
     history.push("?hidden_cards=legend")
-    const { container } = renderReportsOverviewDashboard()
+    renderReportsOverviewDashboard()
     expectNoText(/Legend/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/report/ReportsOverviewTitle.test.jsx
+++ b/components/frontend/src/report/ReportsOverviewTitle.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react"
+import { act, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import history from "history/browser"
 import { vi } from "vitest"
@@ -24,46 +24,45 @@ function renderReportsOverviewTitle() {
     )
 }
 
-it("sets the title", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderReportsOverviewTitle()
+    await expectNoAccessibilityViolations(container)
+})
+
+it("sets the title", async () => {
+    renderReportsOverviewTitle()
     await userEvent.type(screen.getByLabelText(/Report overview title/), "{Delete}New title{Enter}")
     expectFetch("post", "reports_overview/attribute/title", { title: "New title" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the subtitle", async () => {
-    const { container } = renderReportsOverviewTitle()
+    renderReportsOverviewTitle()
     await userEvent.type(screen.getByLabelText(/Report overview subtitle/), "{Delete}New subtitle{Enter}")
     expectFetch("post", "reports_overview/attribute/subtitle", { subtitle: "New subtitle" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the comment", async () => {
-    const { container } = renderReportsOverviewTitle()
+    renderReportsOverviewTitle()
     await userEvent.type(screen.getByLabelText(/Comment/), "{Delete}New comment{Shift>}{Enter}")
     expectFetch("post", "reports_overview/attribute/comment", { comment: "New comment" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the edit report permission", async () => {
     history.push("?expanded=reports_overview:1")
-    const { container } = renderReportsOverviewTitle()
+    renderReportsOverviewTitle()
     await userEvent.type(screen.getByLabelText(/Users allowed to edit reports/), "jadoe{Enter}")
     expectFetch("post", "reports_overview/attribute/permissions", { permissions: { edit_reports: ["jadoe"] } })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the edit entities permission", async () => {
     history.push("?expanded=reports_overview:1")
-    const { container } = renderReportsOverviewTitle()
+    renderReportsOverviewTitle()
     await userEvent.type(screen.getByLabelText(/Users allowed to edit measured entities/), "jodoe{Enter}")
     expectFetch("post", "reports_overview/attribute/permissions", { permissions: { edit_entities: ["jodoe"] } })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("loads the changelog", async () => {
     history.push("?expanded=reports_overview:2")
-    const { container } = renderReportsOverviewTitle()
-    expectFetch("get", "changelog/5")
-    await expectNoAccessibilityViolations(container)
+    renderReportsOverviewTitle()
+    await act(async () => expectFetch("get", "changelog/5"))
 })

--- a/components/frontend/src/report/Tags.test.jsx
+++ b/components/frontend/src/report/Tags.test.jsx
@@ -32,37 +32,36 @@ function renderTags({ tags = ["foo"] } = {}) {
     )
 }
 
-it("shows the tags", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderTags()
+    await expectNoAccessibilityViolations(container)
+})
+
+it("shows the tags", async () => {
+    renderTags()
     expectText(/Tag/)
     expectText(/Number of metrics/)
     expectText(/foo/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows an info message if there are no tags", async () => {
-    const { container } = renderTags({ tags: [] })
+    renderTags({ tags: [] })
     expectText(/None of the metrics in this report have tags/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("deletes a tag", async () => {
-    const { container } = renderTags()
+    renderTags()
     await asyncClickLabeledElement(/Expand/, 0)
-    await expectNoAccessibilityViolations(container)
     await asyncClickText(/Delete tag/)
     expectFetch("delete", "report/report_uuid/tag/foo")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renames a tag", async () => {
-    const { container } = renderTags()
+    renderTags()
     await asyncClickLabeledElement(/Expand/, 0)
-    await expectNoAccessibilityViolations(container)
     await userEvent.type(screen.getByLabelText("Tag"), "bar{Enter}", {
         initialSelectionStart: 0,
         initialSelectionEnd: 3,
     })
     expectFetch("post", "report/report_uuid/tag/foo", { tag: "bar" })
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/source/Source.test.jsx
+++ b/components/frontend/src/source/Source.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { act, fireEvent, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import history from "history/browser"
 import { vi } from "vitest"
@@ -47,17 +47,20 @@ function renderSource(metric, props) {
     )
 }
 
-it("invokes the callback on clicking delete", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderSource(metric)
-    clickText(/Delete source/)
-    expect(fetchServerApi.fetchServerApi).toHaveBeenNthCalledWith(1, "delete", "source/source_uuid", {})
     await expectNoAccessibilityViolations(container)
 })
 
+it("invokes the callback on clicking delete", async () => {
+    renderSource(metric)
+    clickText(/Delete source/)
+    expect(fetchServerApi.fetchServerApi).toHaveBeenNthCalledWith(1, "delete", "source/source_uuid", {})
+})
+
 it("changes the source type", async () => {
-    const { container } = renderSource(metric)
+    renderSource(metric)
     fireEvent.mouseDown(screen.getByLabelText(/Source type/))
-    await expectNoAccessibilityViolations(container)
     clickText(/Source type 2/)
     expectFetch("post", "source/source_uuid/attribute/type", { type: "source_type2" })
 })
@@ -69,26 +72,22 @@ it("changes the source name", async () => {
 })
 
 it("shows a connection error message", async () => {
-    const { container } = renderSource(metric, { measurementSource: { connection_error: "Oops" } })
+    renderSource(metric, { measurementSource: { connection_error: "Oops" } })
     expectText(/Connection error/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows a parse error message", async () => {
-    const { container } = renderSource(metric, { measurementSource: { parse_error: "Oops" } })
+    renderSource(metric, { measurementSource: { parse_error: "Oops" } })
     expectText(/Parse error/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows a config error message", async () => {
-    const { container } = renderSource({ type: "unsupported_metric", sources: { source_uuid: source } })
+    renderSource({ type: "unsupported_metric", sources: { source_uuid: source } })
     expectText(/Configuration error/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("loads the changelog", async () => {
     history.push("?expanded=source_uuid:1")
-    const { container } = renderSource(metric)
-    expectFetch("get", "changelog/source/source_uuid/5")
-    await expectNoAccessibilityViolations(container)
+    renderSource(metric)
+    await act(async () => expectFetch("get", "changelog/source/source_uuid/5"))
 })

--- a/components/frontend/src/source/SourceEntities.test.jsx
+++ b/components/frontend/src/source/SourceEntities.test.jsx
@@ -130,17 +130,23 @@ function renderSourceEntities({
     )
 }
 
-it("renders a message if the metric does not support measurement entities", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderSourceEntities({
+        metric: { type: "metric_type", sources: { source_uuid: { type: "source_type_without_entities" } } },
+    })
+    await expectNoAccessibilityViolations(container)
+})
+
+it("renders a message if the metric does not support measurement entities", async () => {
+    renderSourceEntities({
         metric: { type: "metric_type", sources: { source_uuid: { type: "source_type_without_entities" } } },
     })
     expectText(/Measurement details not supported/)
     expectText(/Showing individual items is not supported when using Source type without entities as source./)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a message if the metric does not support measurement entities and has no unit", async () => {
-    const { container } = renderSourceEntities({
+    renderSourceEntities({
         metric: {
             type: "metric_type_without_unit",
             sources: { source_uuid: { type: "source_type_without_entities" } },
@@ -148,48 +154,41 @@ it("renders a message if the metric does not support measurement entities and ha
     })
     expectText(/Measurement details not supported/)
     expectText(/Showing individual entities is not supported when using Source type without entities as source./)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a message if the metric does not have measurement entities", async () => {
-    const { container } = renderSourceEntities({
+    renderSourceEntities({
         measurements: [{ sources: [{ source_uuid: "source_uuid", entities: [] }] }],
     })
     expectText(/Measurement details not available/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a message if the measurements failed to load", async () => {
-    const { container } = renderSourceEntities({ loading: "failed" })
+    renderSourceEntities({ loading: "failed" })
     expectText(/Loading measurements failed/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a placeholder while the measurements are loading", async () => {
     const { container } = renderSourceEntities({ loading: "loading" })
     expect(container.firstChild.className).toContain("MuiSkeleton-rectangular")
     expectNoText("AAA")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a message if there are no measurements", async () => {
-    const { container } = renderSourceEntities({ measurements: [] })
+    renderSourceEntities({ measurements: [] })
     expectText(/No measurements/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the hide ignored entities button", async () => {
-    const { container } = renderSourceEntities()
+    renderSourceEntities()
     expectLabelText(/Hide the 0 entities that have been/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the hide ignored entities button with one ignored entity", async () => {
     const fixture = JSON.parse(JSON.stringify(sourceFixture))
     fixture.entity_user_data["2"].status_end_date = "3000-01-01"
-    const { container } = renderSourceEntities({ measurements: [{ sources: [fixture] }] })
+    renderSourceEntities({ measurements: [{ sources: [fixture] }] })
     expectLabelText(/Hide the 1 entity name that has been/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the hide ignored entities button with two ignored entities", async () => {
@@ -197,30 +196,26 @@ it("shows the hide ignored entities button with two ignored entities", async () 
     fixture.entity_user_data["1"].status = "false_positive"
     fixture.entity_user_data["1"].status_end_date = "3000-01-01"
     fixture.entity_user_data["2"].status_end_date = "3000-01-01"
-    const { container } = renderSourceEntities({ measurements: [{ sources: [fixture] }] })
+    renderSourceEntities({ measurements: [{ sources: [fixture] }] })
     expectLabelText(/Hide the 2 entities that have been/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the show ignored entities button", async () => {
     const fixture = JSON.parse(JSON.stringify(sourceFixture))
     fixture.entity_user_data["2"].status_end_date = "3000-01-01"
-    const { container } = renderSourceEntities({ measurements: [{ sources: [fixture] }] })
+    renderSourceEntities({ measurements: [{ sources: [fixture] }] })
     const hideEntitiesTooltip = screen.getByLabelText(/Hide the 1 entity name that has been/)
     await userEvent.click(hideEntitiesTooltip.firstChild) // Get the button inside the tooltip
     expect(hideEntitiesTooltip).toHaveAccessibleName(/Show the 1 entity name that has been/)
-    await expectNoAccessibilityViolations(container)
 })
 
 async function expectColumnIsSortedCorrectly(header, ascending) {
-    const { container } = renderSourceEntities()
+    renderSourceEntities()
     expectOrder(["C", "B", "A"]) // Initial order
     clickText(header)
     expectOrder(ascending)
-    await expectNoAccessibilityViolations(container)
     clickText(header)
     expectOrder(ascending.toReversed())
-    await expectNoAccessibilityViolations(container)
     clickText(header)
     expectOrder(ascending)
 }

--- a/components/frontend/src/source/SourceEntity.test.jsx
+++ b/components/frontend/src/source/SourceEntity.test.jsx
@@ -34,48 +34,47 @@ function renderSourceEntity({
     )
 }
 
-it("renders the unconfirmed status", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderSourceEntity({})
+    await expectNoAccessibilityViolations(container)
+})
+
+it("renders the unconfirmed status", async () => {
+    renderSourceEntity({})
     clickButton()
     expectText(/Unconfirmed/, 2)
     expect(screen.getAllByText(/Unconfirmed/)[0].closest("tr").className).toContain("warning_status")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders the fixed status", async () => {
-    const { container } = renderSourceEntity({ status: "fixed" })
+    renderSourceEntity({ status: "fixed" })
     expectText(/Fixed/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders the status end date", async () => {
-    const { container } = renderSourceEntity({ status: "fixed", statusEndDate: "3000-01-01" })
+    renderSourceEntity({ status: "fixed", statusEndDate: "3000-01-01" })
     const expectedDate = renderHook(() => formatDate(new Date("3000-01-01")))
     expectText(RegExp(expectedDate.result.current))
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not render the status end date if the status is unconfirmed", async () => {
-    const { container } = renderSourceEntity({ status: "unconfirmed", statusEndDate: "3000-01-01" })
+    renderSourceEntity({ status: "unconfirmed", statusEndDate: "3000-01-01" })
     const expectedDate = renderHook(() => formatDate(new Date("3000-01-01")))
     expectNoText(RegExp(expectedDate.result.current))
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders the status rationale", async () => {
-    const { container } = renderSourceEntity({ status: "fixed", rationale: "Why?" })
+    renderSourceEntity({ status: "fixed", rationale: "Why?" })
     expectText(/Why\?/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders the first seen datetime", async () => {
-    const { container } = renderSourceEntity({ firstSeen: "2023-07-17" })
+    renderSourceEntity({ firstSeen: "2023-07-17" })
     expectText(/ago/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders the status and rationale past end date", async () => {
-    const { container } = renderSourceEntity({
+    renderSourceEntity({
         status: "fixed",
         statusEndDate: "2000-01-01",
         hideIgnoredEntities: true,
@@ -84,11 +83,9 @@ it("renders the status and rationale past end date", async () => {
     const expectedDate = renderHook(() => formatDate(new Date("2000-01-01")))
     expectText(RegExp(expectedDate.result.current))
     expectText(/Because/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders nothing if the status is to be ignored", async () => {
-    const { container } = renderSourceEntity({ status: "fixed", hideIgnoredEntities: true })
+    renderSourceEntity({ status: "fixed", hideIgnoredEntities: true })
     expectNoText(/Fixed/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/source/SourceEntityAttribute.test.jsx
+++ b/components/frontend/src/source/SourceEntityAttribute.test.jsx
@@ -7,92 +7,80 @@ function renderSourceEntityAttribute(entity, entityAttribute) {
     return render(<SourceEntityAttribute entity={entity} entityAttribute={entityAttribute} />)
 }
 
-it("renders a string", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderSourceEntityAttribute({ text: "some text" }, { key: "text" })
-    expectText(/some text/)
     await expectNoAccessibilityViolations(container)
+})
+
+it("renders a string", async () => {
+    renderSourceEntityAttribute({ text: "some text" }, { key: "text" })
+    expectText(/some text/)
 })
 
 it("renders an empty string", async () => {
-    const { container } = renderSourceEntityAttribute({ other: "will not be shown" }, { key: "missing" })
+    renderSourceEntityAttribute({ other: "will not be shown" }, { key: "missing" })
     expectNoText(/will not be shown/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a float", async () => {
-    const { container } = renderSourceEntityAttribute({ number: 42.0 }, { key: "number", type: "float" })
+    renderSourceEntityAttribute({ number: 42.0 }, { key: "number", type: "float" })
     expectText(/42/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a zero float", async () => {
-    const { container } = renderSourceEntityAttribute({ number: 0.0 }, { key: "number", type: "float" })
+    renderSourceEntityAttribute({ number: 0.0 }, { key: "number", type: "float" })
     expectText(/0/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders an integer", async () => {
-    const { container } = renderSourceEntityAttribute({ number: 42.0 }, { key: "number", type: "integer" })
+    renderSourceEntityAttribute({ number: 42.0 }, { key: "number", type: "integer" })
     expectText(/42/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders an integer percentage", async () => {
-    const { container } = renderSourceEntityAttribute({ number: 42.0 }, { key: "number", type: "integer_percentage" })
+    renderSourceEntityAttribute({ number: 42.0 }, { key: "number", type: "integer_percentage" })
     expectText(/42%/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a datetime", async () => {
-    const { container } = renderSourceEntityAttribute(
-        { timestamp: "2021-10-10T10:10:10" },
-        { key: "timestamp", type: "datetime" },
-    )
+    renderSourceEntityAttribute({ timestamp: "2021-10-10T10:10:10" }, { key: "timestamp", type: "datetime" })
     expectText(/ago/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a date", async () => {
-    const { container } = renderSourceEntityAttribute({ date: "2021-10-10T10:10:10" }, { key: "date", type: "date" })
+    renderSourceEntityAttribute({ date: "2021-10-10T10:10:10" }, { key: "date", type: "date" })
     expectText(/ago/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders minutes", async () => {
-    const { container } = renderSourceEntityAttribute({ duration: "42" }, { key: "duration", type: "minutes" })
+    renderSourceEntityAttribute({ duration: "42" }, { key: "duration", type: "minutes" })
     expectText(/42/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a status icon", async () => {
-    const { container } = renderSourceEntityAttribute({ status: "target_met" }, { key: "status", type: "status" })
+    renderSourceEntityAttribute({ status: "target_met" }, { key: "status", type: "status" })
     expectLabelText("Target met")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a url", async () => {
-    const { container } = renderSourceEntityAttribute(
+    renderSourceEntityAttribute(
         { status: "target_met", url: "https://url" },
         { key: "status", type: "status", url: "url" },
     )
     expect(screen.getByLabelText("Target met").closest("a").href).toBe("https://url/")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders preformatted text", async () => {
-    const { container } = renderSourceEntityAttribute({ text: "text" }, { key: "text", pre: true })
+    renderSourceEntityAttribute({ text: "text" }, { key: "text", pre: true })
     expect(screen.getByTestId("pre-wrapped")).toBeInTheDocument()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a boolean that is true", async () => {
-    const { container } = renderSourceEntityAttribute({ boolean: "true" }, { key: "boolean", type: "boolean" })
+    renderSourceEntityAttribute({ boolean: "true" }, { key: "boolean", type: "boolean" })
     expectText(/✅/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a boolean that is false", async () => {
-    const { container } = renderSourceEntityAttribute({ boolean: "false" }, { key: "boolean", type: "boolean" })
+    renderSourceEntityAttribute({ boolean: "false" }, { key: "boolean", type: "boolean" })
     expectNoText(/✅/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/source/SourceEntityDetails.test.jsx
+++ b/components/frontend/src/source/SourceEntityDetails.test.jsx
@@ -35,8 +35,13 @@ beforeEach(() => {
     vi.spyOn(sourceApi, "setSourceEntityAttribute")
 })
 
-it("shows the default desired response times when the report has no desired response times", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderSourceEntityDetails()
+    await expectNoAccessibilityViolations(container)
+})
+
+it("shows the default desired response times when the report has no desired response times", async () => {
+    renderSourceEntityDetails()
     fireEvent.mouseDown(screen.getByText("Unconfirm"))
     const expectedMenuItemDescriptions = [
         "This violation has been reviewed and should be addressed within 180 days.",
@@ -47,12 +52,11 @@ it("shows the default desired response times when the report has no desired resp
     expectedMenuItemDescriptions.forEach((description) => {
         expectText(description)
     })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the configured desired response times", async () => {
     const report = { desired_response_times: { confirmed: "2", fixed: "4", false_positive: "600", wont_fix: "100" } }
-    const { container } = renderSourceEntityDetails({ report: report })
+    renderSourceEntityDetails({ report: report })
     fireEvent.mouseDown(screen.getByText("Unconfirm"))
     const expectedMenuItemDescriptions = [
         "This violation has been reviewed and should be addressed within 2 days.",
@@ -63,12 +67,11 @@ it("shows the configured desired response times", async () => {
     expectedMenuItemDescriptions.forEach((description) => {
         expectText(description)
     })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows no desired response times when the report has been configured to not have desired response times", async () => {
     const report = { desired_response_times: { confirmed: null, fixed: null, false_positive: null, wont_fix: null } }
-    const { container } = renderSourceEntityDetails({ report: report })
+    renderSourceEntityDetails({ report: report })
     fireEvent.mouseDown(screen.getByText("Unconfirm"))
     const expectedMenuItemDescriptions = [
         "This violation has been reviewed and should be addressed.",
@@ -79,11 +82,10 @@ it("shows no desired response times when the report has been configured to not h
     expectedMenuItemDescriptions.forEach((description) => {
         expectText(description)
     })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("changes the entity status", async () => {
-    const { container } = renderSourceEntityDetails()
+    renderSourceEntityDetails()
     fireEvent.mouseDown(screen.getByText("Unconfirm"))
     clickText(/Confirm/)
     expect(sourceApi.setSourceEntityAttribute).toHaveBeenCalledWith(
@@ -94,17 +96,15 @@ it("changes the entity status", async () => {
         "confirmed",
         reload,
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the entity status end date", async () => {
-    const { container } = renderSourceEntityDetails({ statusEndDate: "20250112" })
+    renderSourceEntityDetails({ statusEndDate: "20250112" })
     expect(screen.queryAllByDisplayValue("01/12/2025").length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("changes the entity status end date", async () => {
-    const { container } = renderSourceEntityDetails()
+    renderSourceEntityDetails()
     await userEvent.type(screen.getAllByLabelText(/Violation status end date/)[0], "01012222{Enter}")
     expect(sourceApi.setSourceEntityAttribute).toHaveBeenCalledWith(
         "metric_uuid",
@@ -114,11 +114,10 @@ it("changes the entity status end date", async () => {
         dayjs("2222-01-01"),
         reload,
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("changes the rationale", async () => {
-    const { container } = renderSourceEntityDetails()
+    renderSourceEntityDetails()
     await userEvent.type(screen.getByLabelText(/rationale/), "Rationale")
     await userEvent.tab()
     expect(sourceApi.setSourceEntityAttribute).toHaveBeenCalledWith(
@@ -129,5 +128,4 @@ it("changes the rationale", async () => {
         "Rationale",
         reload,
     )
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/source/SourceParameter.test.jsx
+++ b/components/frontend/src/source/SourceParameter.test.jsx
@@ -85,52 +85,51 @@ function renderSourceParameter({
 
 beforeEach(() => vi.spyOn(fetchServerApi, "fetchServerApi").mockResolvedValue({ ok: true }))
 
-it("renders an URL parameter", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderSourceParameter({})
+    await expectNoAccessibilityViolations(container)
+})
+
+it("renders an URL parameter", async () => {
+    renderSourceParameter({})
     expect(screen.queryAllByLabelText(/URL/).length).toBe(1)
     expect(screen.getByDisplayValue(/https:\/\/test/)).toBeValid()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders an URL parameter with warning", async () => {
-    const { container } = renderSourceParameter({ warning: true })
+    renderSourceParameter({ warning: true })
     expect(screen.queryAllByLabelText(/URL/).length).toBe(1)
     expect(screen.getByDisplayValue(/https:\/\/test/)).not.toBeValid()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a string parameter", async () => {
-    const { container } = renderSourceParameter({ parameter: { name: "String", type: "string" } })
+    renderSourceParameter({ parameter: { name: "String", type: "string" } })
     expect(screen.queryAllByLabelText(/String/).length).toBe(1)
     expect(screen.queryAllByDisplayValue(/https/).length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a password parameter", async () => {
-    const { container } = renderSourceParameter({ parameter: { name: "Password", type: "password" } })
+    renderSourceParameter({ parameter: { name: "Password", type: "password" } })
     expect(screen.queryAllByLabelText(/Password/).length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a date parameter", async () => {
-    const { container } = renderSourceParameter({
+    renderSourceParameter({
         parameter: { name: "Date", type: "date" },
         parameterValue: "2021-10-10",
     })
     expect(screen.queryAllByLabelText(/Date/, { selector: "input" }).length).toBe(1)
     expect(screen.queryAllByDisplayValue("10/10/2021").length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a date parameter without date", async () => {
-    const { container } = renderSourceParameter({ parameter: { name: "Date", type: "date" }, parameterValue: "" })
+    renderSourceParameter({ parameter: { name: "Date", type: "date" }, parameterValue: "" })
     expect(screen.queryAllByLabelText(/Date/, { selector: "input" }).length).toBe(1)
     expect(screen.queryAllByPlaceholderText(/YYYY/).length).toBe(0)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the next date one day from previous date", async () => {
-    const { container } = renderSourceParameter({
+    renderSourceParameter({
         parameter: { name: "Date", type: "date" },
         parameterValue: "2025-10-10",
         recurrenceOffset: "previous date",
@@ -140,11 +139,10 @@ it("sets the next date one day from previous date", async () => {
         edit_scope: "source",
         key1: dayjs("2025-10-10").add(1, "day"),
     })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the next date two weeks from previous date", async () => {
-    const { container } = renderSourceParameter({
+    renderSourceParameter({
         parameter: { name: "Date", type: "date" },
         parameterValue: "2025-10-10",
         recurrenceFrequency: 2,
@@ -156,12 +154,11 @@ it("sets the next date two weeks from previous date", async () => {
         edit_scope: "source",
         key1: dayjs("2025-10-10").add(2, "week"),
     })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the next date three months from current date", async () => {
     vi.useFakeTimers()
-    const { container } = renderSourceParameter({
+    renderSourceParameter({
         parameter: { name: "Date", type: "date" },
         parameterValue: "2025-10-10",
         recurrenceFrequency: 3,
@@ -173,12 +170,11 @@ it("sets the next date three months from current date", async () => {
         edit_scope: "source",
         key1: dayjs().add(3, "month"),
     })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("sets the next date a year from current date", async () => {
     vi.useFakeTimers()
-    const { container } = renderSourceParameter({
+    renderSourceParameter({
         parameter: { name: "Date", type: "date" },
         parameterValue: "2025-10-10",
         recurrenceUnit: "year",
@@ -188,72 +184,65 @@ it("sets the next date a year from current date", async () => {
         edit_scope: "source",
         key1: dayjs().add(1, "year"),
     })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("cannot set the next date if the recurrence frequency has not been set", async () => {
-    const { container } = renderSourceParameter({
+    renderSourceParameter({
         parameter: { name: "Date", type: "date" },
         parameterValue: "2025-10-10",
         recurrenceFrequency: 0,
     })
     clickButton("Set next date")
     expectNoFetch()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders an integer parameter", async () => {
-    const { container } = renderSourceParameter({
+    renderSourceParameter({
         parameter: { name: "Integer", type: "integer" },
         parameterValue: "0",
     })
     expect(screen.queryAllByLabelText(/Integer/).length).toBe(1)
     expect(screen.getByLabelText(/Integer/)).toBeValid()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not accept floats as number", async () => {
-    const { container } = renderSourceParameter({
+    renderSourceParameter({
         parameter: { name: "Integer", type: "integer" },
         parameterValue: "0.1",
     })
     expect(screen.queryAllByLabelText(/Integer/).length).toBe(1)
     expect(screen.getByLabelText(/Integer/)).not.toBeValid()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not accept negative integers as number", async () => {
-    const { container } = renderSourceParameter({
+    renderSourceParameter({
         parameter: { name: "Integer", type: "integer" },
         parameterValue: "-1",
     })
     expect(screen.queryAllByLabelText(/Integer/).length).toBe(1)
     expect(screen.getByLabelText(/Integer/)).not.toBeValid()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("doesn't change an integer parameter with mouse wheel", async () => {
-    const { container } = renderSourceParameter({
+    renderSourceParameter({
         parameter: { name: "Integer", type: "integer" },
         parameterValue: "10",
     })
     fireEvent.wheel(screen.getByLabelText(/Integer/, { target: { scrollLeft: 500 } }))
     expectNoFetch()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a single choice parameter", async () => {
-    const { container } = renderSourceParameter({
+    renderSourceParameter({
         parameter: { name: "Single choice", type: "single_choice", values: ["option 1", "option 2"] },
         parameterValue: "option 1",
     })
     expect(screen.queryAllByLabelText(/Single choice/).length).toBe(1)
     expectText(/option 1/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a multiple choice parameter with default", async () => {
-    const { container } = renderSourceParameter({
+    renderSourceParameter({
         parameter: {
             name: "Multiple choice",
             type: "multiple_choice_with_defaults",
@@ -265,11 +254,10 @@ it("renders a multiple choice parameter with default", async () => {
     expect(screen.queryAllByLabelText(/Multiple choice/).length).toBe(1)
     expectText(/option 1/)
     expectNoText(/option 2/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a multiple choice parameter without defaults", async () => {
-    const { container } = renderSourceParameter({
+    renderSourceParameter({
         parameter: {
             name: "Multiple choice",
             type: "multiple_choice_without_defaults",
@@ -280,58 +268,51 @@ it("renders a multiple choice parameter without defaults", async () => {
     expect(screen.queryAllByLabelText(/Multiple choice/).length).toBe(1)
     expectNoText(/option 1/)
     expectNoText(/option 2/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a multiple choice with addition parameter", async () => {
-    const { container } = renderSourceParameter({
+    renderSourceParameter({
         parameter: { name: "Multiple choice with addition", type: "multiple_choice_with_addition" },
         parameterValue: ["option 1", "option 2"],
     })
     expect(screen.queryAllByLabelText(/Multiple choice/).length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders nothing on unknown parameter type", async () => {
-    const { container } = renderSourceParameter({ parameter: { name: "Unknown", type: "unknown" } })
+    renderSourceParameter({ parameter: { name: "Unknown", type: "unknown" } })
     expectNoText(/Unknown/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a help url", async () => {
-    const { container } = renderSourceParameter({
+    renderSourceParameter({
         parameter: { name: "String", type: "string", help_url: "https://help" },
     })
     expect(screen.queryAllByTitle(/Opens new window/)[0].closest("a").href).toBe("https://help/")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a help text", async () => {
-    const { container } = renderSourceParameter({ parameter: { name: "String", type: "string", help: "Help text" } })
+    renderSourceParameter({ parameter: { name: "String", type: "string", help: "Help text" } })
     expectText(/Help text/)
-    await expectNoAccessibilityViolations(container)
+    vi.useRealTimers() // Prevent test timeout
 })
 
 it("changes the value", async () => {
-    const { container } = renderSourceParameter({})
+    renderSourceParameter({})
     await userEvent.type(screen.getByLabelText(/URL/), "/new{Enter}")
     expectFetch("post", "source/source_uuid/parameter/key1", { key1: "https://test/new", edit_scope: "source" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("changes the value via mass edit", async () => {
-    const { container } = renderSourceParameter({})
+    renderSourceParameter({})
     clickLabeledElement(/Edit scope/)
     clickText(/Apply change to subject/)
     await userEvent.type(screen.getByLabelText(/URL/), "/new{Enter}")
     expectFetch("post", "source/source_uuid/parameter/key1", { key1: "https://test/new", edit_scope: "subject" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("closes the mass edit menu", async () => {
-    const { container } = renderSourceParameter({})
+    renderSourceParameter({})
     clickLabeledElement(/Edit scope/)
     await userEvent.keyboard("{Escape}")
     expectNoFetch()
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/source/SourceParameters.test.jsx
+++ b/components/frontend/src/source/SourceParameters.test.jsx
@@ -62,63 +62,58 @@ function renderSourceParameters({
     )
 }
 
-it("renders a string parameter", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderSourceParameters({})
-    expect(screen.queryAllByLabelText(/Parameter/).length).toBe(1)
     await expectNoAccessibilityViolations(container)
+})
+
+it("renders a string parameter", async () => {
+    renderSourceParameters({})
+    expect(screen.queryAllByLabelText(/Parameter/).length).toBe(1)
 })
 
 it("renders a string parameter with placeholder", async () => {
-    const { container } = renderSourceParameters({ placeholder: "Placeholder" })
+    renderSourceParameters({ placeholder: "Placeholder" })
     expect(screen.queryAllByPlaceholderText(/Placeholder/).length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a default value if the source parameter has no value", async () => {
-    const { container } = renderSourceParameters({})
+    renderSourceParameters({})
     expect(screen.queryAllByDisplayValue(/Default value/).length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders the source parameter value", async () => {
-    const { container } = renderSourceParameters({ sourceParameterValue: "Value" })
+    renderSourceParameters({ sourceParameterValue: "Value" })
     expect(screen.queryAllByDisplayValue(/Value/).length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not render a warning if a mandatory parameter has a value", async () => {
-    const { container } = renderSourceParameters({ defaultValue: "Value", mandatory: true })
+    renderSourceParameters({ defaultValue: "Value", mandatory: true })
     expect(screen.getByDisplayValue(/Value/)).toBeValid()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a warning if a mandatory parameter has no value", async () => {
-    const { container } = renderSourceParameters({ defaultValue: "", placeholder: "Placeholder", mandatory: true })
+    renderSourceParameters({ defaultValue: "", placeholder: "Placeholder", mandatory: true })
     expect(screen.getByPlaceholderText(/Placeholder/)).toBeInvalid()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not render a warning if the url was reachable", async () => {
-    const { container } = renderSourceParameters({ type: "url", changedParamKeys: ["other_parameter_key"] })
+    renderSourceParameters({ type: "url", changedParamKeys: ["other_parameter_key"] })
     expect(screen.getByDisplayValue(/Default value/)).toBeValid()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders a warning if the url was not reachable", async () => {
-    const { container } = renderSourceParameters({ type: "url", changedParamKeys: ["parameter_key"] })
+    renderSourceParameters({ type: "url", changedParamKeys: ["parameter_key"] })
     expect(screen.getByDisplayValue(/Default value/)).toBeInvalid()
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders parameter groups", async () => {
-    const { container } = renderSourceParameters({})
+    renderSourceParameters({})
     expectText(/Location parameters/)
     expectText(/Other parameters/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("renders ungrouped parameters in the group without explicitly listed parameters", async () => {
-    const { container } = renderSourceParameters({})
+    renderSourceParameters({})
     expect(screen.queryAllByLabelText(/Other parameter/).length).toBe(1)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/source/SourceType.test.jsx
+++ b/components/frontend/src/source/SourceType.test.jsx
@@ -60,54 +60,51 @@ async function renderSourceType(metricType, sourceType, mockSetSourceAttribute) 
     return result
 }
 
+it("has no accessibility violations", async () => {
+    const { container } = await renderSourceType("violations", "sonarqube")
+    await expectNoAccessibilityViolations(container)
+})
+
 it("sets the source type", async () => {
     const mockSetSourceAttribute = vi.fn()
-    const { container } = await renderSourceType("violations", "sonarqube", mockSetSourceAttribute)
+    await renderSourceType("violations", "sonarqube", mockSetSourceAttribute)
     await userEvent.type(screen.getByRole("combobox"), "GitLab{Enter}")
     expect(mockSetSourceAttribute).toHaveBeenLastCalledWith("type", "gitlab")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the metric type even when not supported by the subject type", async () => {
-    const { container } = await renderSourceType("violations", "unsupported")
+    await renderSourceType("violations", "unsupported")
     expectText(/Unsupported/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the supported source versions", async () => {
-    const { container } = await renderSourceType("violations", "sonarqube")
+    await renderSourceType("violations", "sonarqube")
     expectText(/Supported SonarQube versions: >=8.2/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows sources as deprecated if they are deprecated", async () => {
-    const { container } = await renderSourceType("violations", "sonarqube")
+    await renderSourceType("violations", "sonarqube")
     fireEvent.mouseDown(screen.getByLabelText(/Source type/))
     expectText(/Deprecated/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the source type read the docs URL", async () => {
-    const { container } = await renderSourceType("violations", "sonarqube")
+    await renderSourceType("violations", "sonarqube")
     expectText(/Read the Docs/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows that the source type has extra generic documentation", async () => {
-    const { container } = await renderSourceType("violations", "gitlab")
+    await renderSourceType("violations", "gitlab")
     expectText(/additional information on how to configure this source type/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows that the source type has extra metric-specific documentation", async () => {
-    const { container } = await renderSourceType("violations", "sonarqube")
+    await renderSourceType("violations", "sonarqube")
     expectText(/additional information on how to configure this source type/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("uses the name of the source type for the documentation link", async () => {
-    const { container } = await renderSourceType("violations", "source_type")
+    await renderSourceType("violations", "source_type")
     const readTheDocsLink = screen.getByRole("link", { name: "Read the Docs" })
     expect(readTheDocsLink).toHaveAttribute("href", expect.stringContaining("#name-differs-from-key"))
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/source/Sources.test.jsx
+++ b/components/frontend/src/source/Sources.test.jsx
@@ -106,55 +106,51 @@ beforeEach(() => {
     vi.spyOn(toast, "showMessage")
 })
 
-it("shows a source", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderSources()
-    expect(screen.getAllByPlaceholderText(/Source type 1/).length).toBe(1)
     await expectNoAccessibilityViolations(container)
+})
+
+it("shows a source", async () => {
+    renderSources()
+    expect(screen.getAllByPlaceholderText(/Source type 1/).length).toBe(1)
 })
 
 it("shows a message if there are no sources", async () => {
-    const { container } = renderSources({ metric: report.subjects.subject_uuid.metrics.metric_without_sources })
+    renderSources({ metric: report.subjects.subject_uuid.metrics.metric_without_sources })
     expectText(/No sources have been configured/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("doesn't show sources not in the data model", async () => {
-    const { container } = renderSources()
+    renderSources()
     expect(screen.queryAllByDisplayValue(/Source 1/).length).toBe(1)
     expect(screen.queryAllByDisplayValue(/Source with non-existing source type/).length).toBe(0)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows errored sources", async () => {
-    const { container } = renderSources()
+    renderSources()
     expectText(/Connection error/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("creates a new source", async () => {
-    const { container } = renderSources()
+    renderSources()
     await asyncClickText(/Add source/)
-    await expectNoAccessibilityViolations(container)
     await asyncClickText(/Source type 2/)
     expect(fetchServerApi.fetchServerApi).toHaveBeenNthCalledWith(1, "post", "source/new/metric_uuid", {
         type: "source_type2",
     })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("copies a source", async () => {
-    const { container } = renderSources()
+    renderSources()
     await asyncClickText(/Copy source/)
-    await expectNoAccessibilityViolations(container)
     await asyncClickText(/Source 1/)
     expect(fetchServerApi.fetchServerApi).toHaveBeenNthCalledWith(1, "post", "source/source_uuid/copy/metric_uuid", {})
-    await expectNoAccessibilityViolations(container)
 })
 
 it("moves a source", async () => {
-    const { container } = renderSources()
+    renderSources()
     await asyncClickText(/Move source/)
-    await expectNoAccessibilityViolations(container)
     await asyncClickText(/Source 2/)
     expect(fetchServerApi.fetchServerApi).toHaveBeenNthCalledWith(
         1,
@@ -162,44 +158,38 @@ it("moves a source", async () => {
         "source/other_source_uuid/move/metric_uuid",
         {},
     )
-    await expectNoAccessibilityViolations(container)
 })
 
 it("updates a parameter of a source", async () => {
-    const { container } = renderSources()
+    renderSources()
     await userEvent.type(screen.getByDisplayValue(/https:\/\/test.nl/), "https://other{Enter}", {
         initialSelectionStart: 0,
         initialSelectionEnd: 15,
     })
-    await expectNoAccessibilityViolations(container)
     await act(async () => {
         fireEvent.click(screen.getByDisplayValue("Source 1"))
     })
     expect(screen.getAllByDisplayValue("https://other").length).toBe(1)
     expectFetch("post", "source/source_uuid/parameter/url", { edit_scope: "source", url: "https://other" })
     expect(toast.showMessage).toHaveBeenCalledTimes(0)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("mass updates a parameter of a source", async () => {
     fetchServerApi.fetchServerApi.mockResolvedValue({ ok: true, nr_sources_mass_edited: 2 })
-    const { container } = renderSources()
+    renderSources()
     clickLabeledElement(/Edit scope/)
-    await expectNoAccessibilityViolations(container)
     clickText(/Apply change to subject/)
     expectText(/Apply change to subject/)
     await userEvent.type(screen.getByDisplayValue(/https:\/\/test.nl/), "https://other{Enter}", {
         initialSelectionStart: 0,
         initialSelectionEnd: 15,
     })
-    await expectNoAccessibilityViolations(container)
     await act(async () => {
         fireEvent.click(screen.getByDisplayValue("Source 1"))
     })
     expect(screen.getAllByDisplayValue("https://other").length).toBe(1)
     expectFetch("post", "source/source_uuid/parameter/url", { edit_scope: "subject", url: "https://other" })
     expect(toast.showMessage).toHaveBeenCalledTimes(1)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("repositions a source", async () => {

--- a/components/frontend/src/subject/Subject.test.jsx
+++ b/components/frontend/src/subject/Subject.test.jsx
@@ -35,16 +35,19 @@ beforeEach(() => {
     history.push("")
 })
 
-it("shows the subject title", async () => {
-    const { container } = renderSubject({ dates: [new Date(2022, 3, 26)] })
-    expectText("Subject 1 title")
+it("has no accessibility violations", async () => {
+    const { container } = renderSubject()
     await expectNoAccessibilityViolations(container)
 })
 
+it("shows the subject title", async () => {
+    renderSubject({ dates: [new Date(2022, 3, 26)] })
+    expectText("Subject 1 title")
+})
+
 it("shows the subject title at the reports overview", async () => {
-    const { container } = renderSubject({ atReportsOverview: true, dates: [new Date(2022, 3, 26)] })
+    renderSubject({ atReportsOverview: true, dates: [new Date(2022, 3, 26)] })
     expectText("Report title ❯ Subject 1 title")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides metrics not requiring action", async () => {

--- a/components/frontend/src/subject/SubjectTable.test.jsx
+++ b/components/frontend/src/subject/SubjectTable.test.jsx
@@ -121,21 +121,24 @@ beforeEach(() => {
     vi.spyOn(fetchServerApi, "fetchServerApi").mockResolvedValue({ ok: true })
 })
 
-it("displays all the metrics", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderSubjectTable()
+    await expectNoAccessibilityViolations(container)
+})
+
+it("displays all the metrics", async () => {
+    renderSubjectTable()
     const metricNames = ["name_1", "name_2"]
     metricNames.forEach((metricName) => {
         expectText(metricName)
     })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the date columns", async () => {
-    const { container } = renderSubjectTable({ dates: dates })
+    renderSubjectTable({ dates: dates })
     dates.forEach((date) => {
         expectText(date.toLocaleDateString())
     })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the source column", () => {
@@ -213,10 +216,9 @@ it("hides the tags column", () => {
 
 it("expands the details via the button", async () => {
     const expandedItems = renderHook(() => useExpandedItemsSearchQuery())
-    const { container } = renderSubjectTable({ expandedItems: expandedItems.result.current })
+    renderSubjectTable({ expandedItems: expandedItems.result.current })
     clickButton("Expand/collapse", 0)
     expandedItems.rerender()
-    await expectNoAccessibilityViolations(container)
     expect(expandedItems.result.current.value).toStrictEqual(["1:0"])
 })
 
@@ -231,10 +233,9 @@ it("collapses the details via the button", async () => {
 
 it("expands the details via the url", async () => {
     history.push("?expanded=1:0")
-    const { container } = renderSubjectTable()
+    renderSubjectTable()
     await act(async () => {}) // Wait for hooks to finish
     expectText("Configuration")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("moves a metric", async () => {
@@ -246,11 +247,10 @@ it("moves a metric", async () => {
 
 it("adds a source", async () => {
     history.push("?expanded=1:1")
-    const { container } = renderSubjectTable()
+    renderSubjectTable()
     await asyncClickRole("tab", /Sources/)
     const addButton = await screen.findByText("Add source")
     await act(async () => fireEvent.click(addButton))
-    await expectNoAccessibilityViolations(container)
     fireEvent.click(await screen.findByText("Source type"))
     expectFetch("post", "source/new/1", { type: "source_type" })
 })

--- a/components/frontend/src/subject/SubjectTableBody.test.jsx
+++ b/components/frontend/src/subject/SubjectTableBody.test.jsx
@@ -77,10 +77,14 @@ beforeEach(() => {
 
 afterEach(() => vi.restoreAllMocks())
 
-it("shows the correct number of rows", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderSubjectTableBody()
-    expect(screen.queryAllByTestId(/^metric-row-/).length).toBe(2)
     await expectNoAccessibilityViolations(container)
+})
+
+it("shows the correct number of rows", async () => {
+    renderSubjectTableBody()
+    expect(screen.queryAllByTestId(/^metric-row-/).length).toBe(2)
 })
 
 it("shows drop indicator when dragging over a row", () => {

--- a/components/frontend/src/subject/SubjectTableFooter.test.jsx
+++ b/components/frontend/src/subject/SubjectTableFooter.test.jsx
@@ -17,14 +17,14 @@ beforeEach(() => {
 
 afterEach(() => vi.restoreAllMocks())
 
-it("shows the add metric button and adds a metric when clicked", async () => {
-    const { container } = render(
+function renderSubjectTableFooter() {
+    return render(
         <Permissions.Provider value={[EDIT_REPORT_PERMISSION]}>
             <DataModel.Provider value={dataModel}>
                 <Table>
                     <SubjectTableFooter
                         report={report}
-                        reports={[]}
+                        reports={[report]}
                         subjectUuid="subject_uuid"
                         subject={report.subjects.subject_uuid}
                         stopFilteringAndSorting={stopFilteringAndSorting}
@@ -33,56 +33,31 @@ it("shows the add metric button and adds a metric when clicked", async () => {
             </DataModel.Provider>
         </Permissions.Provider>,
     )
-    clickText(/Add metric/)
+}
+
+it("has no accessibility violations", async () => {
+    const { container } = renderSubjectTableFooter()
     await expectNoAccessibilityViolations(container)
+})
+
+it("shows the add metric button and adds a metric when clicked", async () => {
+    renderSubjectTableFooter()
+    clickText(/Add metric/)
     clickText(/Metric type/)
     expect(stopFilteringAndSorting).toHaveBeenCalled()
     expectFetch("post", "metric/new/subject_uuid", { type: "metric_type" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("copies a metric when the copy button is clicked and a metric is selected", async () => {
-    const { container } = render(
-        <Permissions.Provider value={[EDIT_REPORT_PERMISSION]}>
-            <DataModel.Provider value={dataModel}>
-                <Table>
-                    <SubjectTableFooter
-                        report={report}
-                        reports={[report]}
-                        subjectUuid="subject_uuid"
-                        subject={report.subjects.subject_uuid}
-                        stopFilteringAndSorting={stopFilteringAndSorting}
-                    />
-                </Table>
-            </DataModel.Provider>
-        </Permissions.Provider>,
-    )
+    renderSubjectTableFooter()
     clickText(/Copy metric/)
-    await expectNoAccessibilityViolations(container)
     await asyncClickText(/M1/, 0)
     expectFetch("post", "metric/metric_uuid/copy/subject_uuid", {})
-    await expectNoAccessibilityViolations(container)
 })
 
 it("moves a metric when the move button is clicked and a metric is selected", async () => {
-    const { container } = render(
-        <DataModel.Provider value={dataModel}>
-            <Permissions.Provider value={[EDIT_REPORT_PERMISSION]}>
-                <Table>
-                    <SubjectTableFooter
-                        report={report}
-                        reports={[report]}
-                        subjectUuid="subject_uuid"
-                        subject={report.subjects.subject_uuid}
-                        stopFilteringAndSorting={stopFilteringAndSorting}
-                    />
-                </Table>
-            </Permissions.Provider>
-        </DataModel.Provider>,
-    )
+    renderSubjectTableFooter()
     clickText(/Move metric/)
-    await expectNoAccessibilityViolations(container)
     await asyncClickText(/Subject 2 title/)
     expectFetch("post", "metric/metric_uuid3/move/subject_uuid", {})
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/subject/SubjectTableHeader.test.jsx
+++ b/components/frontend/src/subject/SubjectTableHeader.test.jsx
@@ -19,10 +19,15 @@ beforeEach(() => {
     history.push("")
 })
 
+it("has no accessibility violations", async () => {
+    const { container } = renderSubjectTableHeader([new Date("2023-03-03")])
+    await expectNoAccessibilityViolations(container)
+})
+
 it("shows the column dates and unit", async () => {
     const date1 = new Date("2022-02-02")
     const date2 = new Date("2022-02-03")
-    const { container } = renderSubjectTableHeader([date1, date2])
+    renderSubjectTableHeader([date1, date2])
     const headers = [
         date1.toLocaleDateString(),
         "𝚫",
@@ -36,12 +41,11 @@ it("shows the column dates and unit", async () => {
         "Tags",
     ]
     headers.forEach((header) => expectText(header))
-    await expectNoAccessibilityViolations(container)
 })
 
 it("does not show the column dates", async () => {
     const date1 = new Date("2022-02-02")
-    const { container } = renderSubjectTableHeader([date1])
+    renderSubjectTableHeader([date1])
     const headers = [
         "Trend (7 days)",
         "Status",
@@ -55,39 +59,34 @@ it("does not show the column dates", async () => {
         "Tags",
     ]
     headers.forEach((header) => expectText(header))
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides columns", async () => {
     const date1 = new Date("2022-02-02")
     const columns = ["trend", "status", "measurement", "target", "source", "comment", "issues", "tags"]
-    const { container } = renderSubjectTableHeader([date1], columns)
+    renderSubjectTableHeader([date1], columns)
     const headers = ["Trend (7 days)", "Status", "Measurement", "Target", "Sources", "Comment", "Issues", "Tags"]
     headers.forEach((header) => expectNoText(header))
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides the delta columns", async () => {
     const date1 = new Date("2022-02-02")
     const date2 = new Date("2022-02-03")
-    const { container } = renderSubjectTableHeader([date1, date2], ["delta"])
+    renderSubjectTableHeader([date1, date2], ["delta"])
     expectNoText("𝚫")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows help for column headers", async () => {
     const date1 = new Date("2022-02-02")
-    const { container } = renderSubjectTableHeader([date1])
+    renderSubjectTableHeader([date1])
     await hoverText("Metric")
     await expectTextAfterWait(/Click the column header to sort the metrics by name/)
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows help for delta column headers", async () => {
     const date1 = new Date("2022-02-02")
     const date2 = new Date("2022-02-03")
-    const { container } = renderSubjectTableHeader([date1, date2])
+    renderSubjectTableHeader([date1, date2])
     await hoverText(/𝚫/)
     await expectTextAfterWait(/shows the difference/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/subject/SubjectTableRow.test.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.test.jsx
@@ -96,62 +96,61 @@ function renderSubjectTableRow({
     )
 }
 
+it("has no accessibility violations", async () => {
+    const { container } = renderSubjectTableRow()
+    await expectNoAccessibilityViolations(container)
+})
+
 it("shows the delta column", async () => {
     history.push("?nr_dates=3&date_interval=1")
-    const { container } = renderSubjectTableRow()
+    renderSubjectTableRow()
     expectText("+1")
     expectLabelText("Metric type worsened from 11 to 12 things by +1 thing")
     expectText("-4")
     expectLabelText("Metric type improved from 12 to 8 things by -4 things")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("hides the delta column", async () => {
     history.push("?nr_dates=2&hidden_columns=delta")
-    const { container } = renderSubjectTableRow()
+    renderSubjectTableRow()
     expectNoText("+1")
     expectNoText("-4")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("takes the metric direction into account", async () => {
     history.push("?nr_dates=3&date_interval=1")
-    const { container } = renderSubjectTableRow({ direction: ">" })
+    renderSubjectTableRow({ direction: ">" })
     expectText("+1")
     expectLabelText("Metric type improved from 11 to 12 things by +1 thing")
     expectText("-4")
     expectLabelText("Metric type worsened from 12 to 8 things by -4 things")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("works for informative metrics", async () => {
     history.push("?nr_dates=3&date_interval=1")
-    const { container } = renderSubjectTableRow({ evaluateTargets: false })
+    renderSubjectTableRow({ evaluateTargets: false })
     expectText("+1")
     expectLabelText("Metric type changed from 11 to 12 things by +1 thing")
     expectText("-4")
     expectLabelText("Metric type changed from 12 to 8 things by -4 things")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("takes the date order into account", async () => {
     history.push("?nr_dates=3&date_interval=1&date_order=ascending")
-    const { container } = renderSubjectTableRow({ ascending: true })
+    renderSubjectTableRow({ ascending: true })
     expectText("+1")
     expectLabelText("Metric type worsened from 11 to 12 things by +1 thing")
     expectText("-4")
     expectLabelText("Metric type improved from 12 to 8 things by -4 things")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the delta column for the version scale", async () => {
     history.push("?nr_dates=3&date_interval=1")
-    const { container } = renderSubjectTableRow({ scale: "version_number" })
+    renderSubjectTableRow({ scale: "version_number" })
     expectText("+")
     expectLabelText("Metric type worsened from 1.0 to 1.2")
     expectText("-")
     expectLabelText("Metric type improved from 1.2 to 0.8")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the drag handle when row is not expanded and user is authenticated", () => {
@@ -196,19 +195,16 @@ it("shows no drag handle when rows are sorted", () => {
 })
 
 it("shows the metric type as name if the metric has no name", async () => {
-    const { container } = renderSubjectTableRow()
+    renderSubjectTableRow()
     expectText("Metric type")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the metric name", async () => {
-    const { container } = renderSubjectTableRow({ name: "Metric name" })
+    renderSubjectTableRow({ name: "Metric name" })
     expectText("Metric name")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("shows the metric secondary name", async () => {
-    const { container } = renderSubjectTableRow({ secondaryName: "Secondary name" })
+    renderSubjectTableRow({ secondaryName: "Secondary name" })
     expectText("Secondary name")
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/subject/SubjectTitle.test.jsx
+++ b/components/frontend/src/subject/SubjectTitle.test.jsx
@@ -67,35 +67,36 @@ async function renderSubjectTitle(subjectType = "subject_type") {
     return result
 }
 
-it("changes the subject type", async () => {
+it("has no accessibility violations", async () => {
     const { container } = await renderSubjectTitle()
+    await expectNoAccessibilityViolations(container)
+})
+
+it("changes the subject type", async () => {
+    await renderSubjectTitle()
     fireEvent.mouseDown(screen.getByLabelText(/Subject type/))
     clickText(/Other subject type/)
     expectFetch("post", "subject/subject_uuid/attribute/type", { type: "subject_type2" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("changes the subject type to a nested type", async () => {
-    const { container } = await renderSubjectTitle()
+    await renderSubjectTitle()
     fireEvent.mouseDown(screen.getByLabelText(/Subject type/))
     clickText(/Nested subject type/)
     expectFetch("post", "subject/subject_uuid/attribute/type", { type: "nested_subject_type" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("changes the subject type from a nested type", async () => {
-    const { container } = await renderSubjectTitle("nested_subject_type")
+    await renderSubjectTitle("nested_subject_type")
     fireEvent.mouseDown(screen.getByLabelText(/Subject type/))
     clickText(/Other subject type/)
     expectFetch("post", "subject/subject_uuid/attribute/type", { type: "subject_type2" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("changes the subject title", async () => {
-    const { container } = await renderSubjectTitle()
+    await renderSubjectTitle()
     await userEvent.type(screen.getByLabelText(/Subject title/), "{Delete}New title{Enter}")
     expectFetch("post", "subject/subject_uuid/attribute/name", { name: "New title" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("changes the subject subtitle", async () => {
@@ -106,38 +107,33 @@ it("changes the subject subtitle", async () => {
 })
 
 it("changes the subject comment", async () => {
-    const { container } = await renderSubjectTitle()
+    await renderSubjectTitle()
     await userEvent.type(screen.getByLabelText(/Comment/), "{Delete}New comment{Shift>}{Enter}")
     expectFetch("post", "subject/subject_uuid/attribute/comment", { comment: "New comment" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("loads the changelog", async () => {
     history.push("?expanded=subject_uuid:1")
-    const { container } = await renderSubjectTitle()
+    await renderSubjectTitle()
     expectFetch("get", "changelog/subject/subject_uuid/5")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("moves the subject", async () => {
-    const { container } = await renderSubjectTitle()
+    await renderSubjectTitle()
     await asyncClickButton(/Move subject to the next position/)
     expectFetch("post", "subject/subject_uuid/attribute/position", { position: "next" })
-    await expectNoAccessibilityViolations(container)
 })
 
 it("deletes the subject", async () => {
     history.push("?expanded=subject_uuid:0")
-    const { container } = await renderSubjectTitle()
+    await renderSubjectTitle()
     await asyncClickText(/Delete subject/)
     expectFetch("delete", "subject/subject_uuid", {})
     expectSearch("")
-    await expectNoAccessibilityViolations(container)
 })
 
 it("uses the name of the subject type for the documentation link", async () => {
-    const { container } = await renderSubjectTitle()
+    await renderSubjectTitle()
     const readTheDocsLink = screen.getByRole("link", { name: "Read the Docs" })
     expect(readTheDocsLink).toHaveAttribute("href", expect.stringContaining("#default-subject-type"))
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/subject/Subjects.test.jsx
+++ b/components/frontend/src/subject/Subjects.test.jsx
@@ -27,10 +27,14 @@ beforeEach(() => {
     history.push("")
 })
 
-it("shows the subjects", async () => {
+it("has no accessibility violations", async () => {
     const { container } = renderSubjects([report])
-    expectText(/Subject/, 2)
     await expectNoAccessibilityViolations(container)
+})
+
+it("shows the subjects", async () => {
+    renderSubjects([report])
+    expectText(/Subject/, 2)
 })
 
 it("does not render invisible subjects", async () => {
@@ -79,9 +83,8 @@ it("does not render invisible subjects", async () => {
         },
         title: "Report 2 title",
     }
-    const { container } = renderSubjects([report, report2])
+    renderSubjects([report, report2])
     expectText(/Report 2 Subject 1/)
     expectText(/Report 2 Subject 2/)
     expectNoText(/Report 2 Subject 3/)
-    await expectNoAccessibilityViolations(container)
 })

--- a/components/frontend/src/subject/SubjectsButtonRow.test.jsx
+++ b/components/frontend/src/subject/SubjectsButtonRow.test.jsx
@@ -29,10 +29,14 @@ function renderSubjectsButtonRow(permissions = []) {
     )
 }
 
-it("shows the add subject button when editable", async () => {
-    const { container } = renderSubjectsButtonRow([EDIT_REPORT_PERMISSION])
-    expectText(/Add subject/)
+it("has no accessibility violations", async () => {
+    const { container } = renderSubjectsButtonRow()
     await expectNoAccessibilityViolations(container)
+})
+
+it("shows the add subject button when editable", async () => {
+    renderSubjectsButtonRow([EDIT_REPORT_PERMISSION])
+    expectText(/Add subject/)
 })
 
 it("does not show the add subject button when not editable", () => {
@@ -41,25 +45,22 @@ it("does not show the add subject button when not editable", () => {
 })
 
 it("adds a subject", async () => {
-    const { container } = renderSubjectsButtonRow([EDIT_REPORT_PERMISSION])
+    renderSubjectsButtonRow([EDIT_REPORT_PERMISSION])
     await asyncClickText(/Add subject/)
-    await expectNoAccessibilityViolations(container)
     await asyncClickText(/Subject type/)
     expectFetch("post", "subject/new/report_uuid", { type: "subject_type" })
 })
 
 it("copies a subject", async () => {
-    const { container } = renderSubjectsButtonRow([EDIT_REPORT_PERMISSION])
+    renderSubjectsButtonRow([EDIT_REPORT_PERMISSION])
     await asyncClickText("Copy subject")
-    await expectNoAccessibilityViolations(container)
     await asyncClickText("dummy option 1")
     expectFetch("post", "subject/undefined/copy/report_uuid", {})
 })
 
 it("moves a subject", async () => {
-    const { container } = renderSubjectsButtonRow([EDIT_REPORT_PERMISSION])
+    renderSubjectsButtonRow([EDIT_REPORT_PERMISSION])
     await asyncClickText("Move subject")
-    await expectNoAccessibilityViolations(container)
     await asyncClickText("dummy option 2")
     expectFetch("post", "subject/undefined/move/report_uuid", {})
 })


### PR DESCRIPTION
Add one or a few accessibility checks per component instead of checking for accessibility problems in every unit test, which is slow.