### PR TITLE
Suppress repeated changelogs

### DIFF
--- a/update_dependencies/src/log.py
+++ b/update_dependencies/src/log.py
@@ -16,12 +16,14 @@ class Logger:
     def __init__(self, name: str) -> None:
         """Initialize the logger."""
         self.log = logging.getLogger(name)
+        self.logged_changes: set[tuple[str, DependencyVersion]] = set()
 
     def new_version(self, dependency: str, version: DependencyVersion) -> None:
         """Log the availability of a new version."""
-        self.log.warning(
-            "New version available for %s: %s\n%s", dependency, version.version, version.changes, stacklevel=2
-        )
+        suppression_message = "Suppressing changelog already shown, see above"
+        changes = suppression_message if (dependency, version) in self.logged_changes else version.changes
+        self.logged_changes.add((dependency, version))
+        self.log.warning("New version available for %s: %s\n%s", dependency, version.version, changes, stacklevel=2)
 
     def invalid_version(self, dependency: str, invalid_version: str) -> None:
         """Log an invalid version."""

--- a/update_dependencies/src/update_github_action.py
+++ b/update_dependencies/src/update_github_action.py
@@ -31,7 +31,7 @@ def get_latest_version(action: str, current_version_string: str) -> DependencyVe
         LOG.invalid_version(f"{organization}/{repository}", f"'{latest_tag}'")
         latest_version = Version("0.0.0")
     changes = json.get("body", "")
-    return DependencyVersion(version=str(max(latest_version, current_version)), changes=changes)
+    return DependencyVersion(str(max(latest_version, current_version)), changes)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/update_dependencies/src/update_package_json.py
+++ b/update_dependencies/src/update_package_json.py
@@ -22,9 +22,7 @@ def update_package_json(package_json: Path) -> int:
     npm_outdated = ["npm", "outdated", "--silent", "--json", "--include=dev"]
     outdated_packages = json.loads(run(npm_outdated, cwd=package_json.parent))
     for package, version in outdated_packages.items():
-        LOG.new_version(
-            package, DependencyVersion(version=version["latest"], changes=get_changes(package, version["latest"]))
-        )
+        LOG.new_version(package, DependencyVersion(version["latest"], get_changes(package, version["latest"])))
     npm_update = ["npm", "update", "--save", "--fund=false", "--ignore-scripts", "--silent", "--include=dev"]
     run(npm_update, cwd=package_json.parent)
     return 0

--- a/update_dependencies/src/update_pyproject_toml.py
+++ b/update_dependencies/src/update_pyproject_toml.py
@@ -54,7 +54,7 @@ def update_pyproject_toml(pyproject_toml: Path) -> None:
     for line in lines_with_updates:
         package = line.split()[1]
         version = line.split()[-1].lstrip("v").rstrip(")")
-        dependency_version = DependencyVersion(version=version, changes=get_changes(package, version))
+        dependency_version = DependencyVersion(version, get_changes(package, version))
         LOG.new_version(package, dependency_version)
     latest_versions = Versions(
         {line.split()[1]: line.split()[-1].lstrip("v").rstrip(")") for line in lines_with_updates}

--- a/update_dependencies/src/version.py
+++ b/update_dependencies/src/version.py
@@ -3,14 +3,14 @@
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(frozen=True)
 class DependencyVersion:
     """A version of a dependency."""
 
     version: str
-    changes: str = ""
+    _changes: str = ""
 
-    def __post_init__(self) -> None:
-        """Fix an empty change log."""
-        if not self.changes:
-            self.changes = "No changelog available!"
+    @property
+    def changes(self) -> str:
+        """Return the changelog."""
+        return self._changes or "No changelog available!"

--- a/update_dependencies/tests/test_log.py
+++ b/update_dependencies/tests/test_log.py
@@ -1,0 +1,28 @@
+"""Logger unit tests."""
+
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from log import Logger
+from version import DependencyVersion
+
+
+class LoggerTests(TestCase):
+    """Unit tests for the logger class."""
+
+    @patch("logging.Logger.warning")
+    def test_suppress_repeated_changelog(self, mock_warning: Mock):
+        """Test that a repeated changelog is suppressed."""
+        logger = Logger("suppress changelog")
+        logger.new_version("dependency", DependencyVersion("1.0", "Changelog"))
+        mock_warning.assert_called_once_with(
+            "New version available for %s: %s\n%s", "dependency", "1.0", "Changelog", stacklevel=2
+        )
+        logger.new_version("dependency", DependencyVersion("1.0", "Changelog"))
+        mock_warning.assert_called_with(
+            "New version available for %s: %s\n%s",
+            "dependency",
+            "1.0",
+            "Suppressing changelog already shown, see above",
+            stacklevel=2,
+        )


### PR DESCRIPTION
When logging updated dependencies (while running `just update-deps`) suppress repeated changelogs.