### PR TITLE
Fix logging when running with docker compose

### DIFF
--- a/components/api_server/pyproject.toml
+++ b/components/api_server/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "pymongo==4.16.0",
     "python-dateutil==2.9.0.post0",
     "requests==2.32.5",
-    "rich==14.3.3",
     "shared-code",
 ]
 

--- a/components/api_server/src/quality_time_server.py
+++ b/components/api_server/src/quality_time_server.py
@@ -4,13 +4,12 @@ from gevent import monkey
 
 monkey.patch_all()
 
-import logging
 import os
 
 from bottle import run
-from rich.logging import RichHandler
 
 from shared.initialization.database import get_database, mongo_client
+from shared.utils.log import init_logging
 
 from initialization.database import init_database, set_feature_compatibility_version
 from initialization.bottle import init_bottle
@@ -18,9 +17,7 @@ from initialization.bottle import init_bottle
 
 def serve() -> None:  # pragma: no feature-test-cover
     """Connect to the database and start the application server."""
-    logging.basicConfig(datefmt="%Y-%m-%d %H:%M:%S", format="%(message)s", handlers=[RichHandler()])
-    logger = logging.getLogger()
-    logger.setLevel(str(os.getenv("API_SERVER_LOG_LEVEL", "WARNING")))
+    logger = init_logging(str(os.getenv("API_SERVER_LOG_LEVEL", "WARNING")))
     with mongo_client() as client:
         admin_database = get_database(client, "admin")
         set_feature_compatibility_version(admin_database)

--- a/components/api_server/uv.lock
+++ b/components/api_server/uv.lock
@@ -35,7 +35,6 @@ dependencies = [
     { name = "pymongo" },
     { name = "python-dateutil" },
     { name = "requests" },
-    { name = "rich" },
     { name = "shared-code" },
 ]
 
@@ -61,7 +60,6 @@ requires-dist = [
     { name = "pymongo", specifier = "==4.16.0" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
     { name = "requests", specifier = "==2.32.5" },
-    { name = "rich", specifier = "==14.3.3" },
     { name = "shared-code", directory = "../shared_code" },
 ]
 
@@ -1061,6 +1059,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pymongo" },
     { name = "python-dateutil" },
+    { name = "rich" },
 ]
 
 [package.metadata]
@@ -1070,6 +1069,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pymongo", specifier = "==4.16.0" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
+    { name = "rich", specifier = "==14.3.3" },
 ]
 
 [package.metadata.requires-dev]

--- a/components/collector/pyproject.toml
+++ b/components/collector/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "packaging==26.0",
     "pymongo==4.16.0",
     "python-dateutil==2.9.0.post0",
-    "rich==14.3.3",
     "shared-code",
     "typing-extensions==4.15.0",
 ]

--- a/components/collector/src/quality_time_collector.py
+++ b/components/collector/src/quality_time_collector.py
@@ -1,12 +1,10 @@
 """Measurement collector."""
 
 import asyncio
-import logging
 from typing import NoReturn
 
-from rich.logging import RichHandler
-
 from shared.initialization.database import get_database, mongo_client
+from shared.utils.log import init_logging
 
 # Make sure subclasses are registered
 import metric_collectors  # noqa: F401
@@ -16,8 +14,7 @@ from base_collectors import Collector, config
 
 async def collect() -> NoReturn:
     """Collect the measurements indefinitely."""
-    logging.basicConfig(datefmt="%Y-%m-%d %H:%M:%S", format="%(message)s", handlers=[RichHandler()])
-    logging.getLogger().setLevel(config.LOG_LEVEL)
+    init_logging(config.LOG_LEVEL)
     with mongo_client() as client:
         await Collector(get_database(client)).start()
 

--- a/components/collector/uv.lock
+++ b/components/collector/uv.lock
@@ -260,7 +260,6 @@ dependencies = [
     { name = "packaging" },
     { name = "pymongo" },
     { name = "python-dateutil" },
-    { name = "rich" },
     { name = "shared-code" },
     { name = "typing-extensions" },
 ]
@@ -284,7 +283,6 @@ requires-dist = [
     { name = "packaging", specifier = "==26.0" },
     { name = "pymongo", specifier = "==4.16.0" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
-    { name = "rich", specifier = "==14.3.3" },
     { name = "shared-code", directory = "../shared_code" },
     { name = "typing-extensions", specifier = "==4.15.0" },
 ]
@@ -1102,6 +1100,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pymongo" },
     { name = "python-dateutil" },
+    { name = "rich" },
 ]
 
 [package.metadata]
@@ -1111,6 +1110,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pymongo", specifier = "==4.16.0" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
+    { name = "rich", specifier = "==14.3.3" },
 ]
 
 [package.metadata.requires-dev]

--- a/components/notifier/pyproject.toml
+++ b/components/notifier/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "aiohttp==3.13.3",
     "pymsteams==0.2.5",
     "python-dateutil==2.9.0.post0",
-    "rich==14.3.3",
     "shared-code",
 ]
 

--- a/components/notifier/src/quality_time_notifier.py
+++ b/components/notifier/src/quality_time_notifier.py
@@ -1,21 +1,18 @@
 """Notifier."""
 
 import asyncio
-import logging
 import os
 from typing import NoReturn
 
-from rich.logging import RichHandler
-
 from shared.initialization.database import get_database, mongo_client
+from shared.utils.log import init_logging
 
 from notifier.notifier import notify
 
 
 def start_notifications() -> NoReturn:
     """Notify indefinitely."""
-    logging.basicConfig(datefmt="%Y-%m-%d %H:%M:%S", format="%(message)s", handlers=[RichHandler()])
-    logging.getLogger().setLevel(str(os.getenv("NOTIFIER_LOG_LEVEL", "WARNING")))
+    init_logging(str(os.getenv("NOTIFIER_LOG_LEVEL", "WARNING")))
     sleep_duration = int(os.getenv("NOTIFIER_SLEEP_DURATION", "60"))
     with mongo_client() as client:
         asyncio.run(notify(get_database(client), sleep_duration))

--- a/components/notifier/uv.lock
+++ b/components/notifier/uv.lock
@@ -652,7 +652,6 @@ dependencies = [
     { name = "aiohttp" },
     { name = "pymsteams" },
     { name = "python-dateutil" },
-    { name = "rich" },
     { name = "shared-code" },
 ]
 
@@ -669,7 +668,6 @@ requires-dist = [
     { name = "aiohttp", specifier = "==3.13.3" },
     { name = "pymsteams", specifier = "==0.2.5" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
-    { name = "rich", specifier = "==14.3.3" },
     { name = "shared-code", directory = "../shared_code" },
 ]
 
@@ -1075,6 +1073,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pymongo" },
     { name = "python-dateutil" },
+    { name = "rich" },
 ]
 
 [package.metadata]
@@ -1084,6 +1083,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pymongo", specifier = "==4.16.0" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
+    { name = "rich", specifier = "==14.3.3" },
 ]
 
 [package.metadata.requires-dev]

--- a/components/shared_code/pyproject.toml
+++ b/components/shared_code/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pydantic==2.12.5",
     "pymongo==4.16.0",
     "python-dateutil==2.9.0.post0",
+    "rich==14.3.3",
 ]
 
 [dependency-groups]

--- a/components/shared_code/src/shared/utils/log.py
+++ b/components/shared_code/src/shared/utils/log.py
@@ -3,9 +3,20 @@
 import logging
 import sys
 
+from rich.logging import RichHandler
+
 
 def get_logger(component_name: str, call_stack_depth: int = 0) -> logging.Logger:
     """Return the logger for the given component and the caller's module."""
     # Get the module name from the caller's stack frame so we can add it to the logger name:
     module_name = sys._getframe(call_stack_depth + 1).f_globals["__name__"]  # noqa: SLF001
     return logging.getLogger(f"quality_time.{component_name}.{module_name}")
+
+
+def init_logging(level: str) -> logging.Logger:
+    """Initialize the logging and return the root logger."""
+    handler = RichHandler(omit_repeated_times=False)
+    logging.basicConfig(datefmt="%Y-%m-%d %H:%M:%S", format="%(message)s", handlers=[handler])
+    logger = logging.getLogger()
+    logger.setLevel(level)
+    return logger

--- a/components/shared_code/tests/shared/utils/test_log.py
+++ b/components/shared_code/tests/shared/utils/test_log.py
@@ -1,9 +1,12 @@
 """Unit tests for the logging utilities."""
 
+import logging
 import unittest
 from typing import TYPE_CHECKING
 
-from shared.utils.log import get_logger
+from rich.logging import RichHandler
+
+from shared.utils.log import get_logger, init_logging
 
 if TYPE_CHECKING:
     from logging import Logger
@@ -24,3 +27,8 @@ class LogTest(unittest.TestCase):
             return get_logger("component", call_stack_depth=1)
 
         self.assertEqual("quality_time.component.tests.shared.utils.test_log", get_logger_indirectly().name)
+
+    def test_init_log(self):
+        """Test log initialization."""
+        init_logging("INFO")
+        self.assertEqual(RichHandler, logging.getLogger().handlers[0].__class__)

--- a/components/shared_code/uv.lock
+++ b/components/shared_code/uv.lock
@@ -820,6 +820,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pymongo" },
     { name = "python-dateutil" },
+    { name = "rich" },
 ]
 
 [package.dev-dependencies]
@@ -836,6 +837,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pymongo", specifier = "==4.16.0" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
+    { name = "rich", specifier = "==14.3.3" },
 ]
 
 [package.metadata.requires-dev]

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -9,6 +9,7 @@ services:
   collector:
     environment:
       - COLLECTOR_LOG_LEVEL=${COLLECTOR_LOG_LEVEL:-INFO}
+      - COLUMNS=${COLUMNS}  # Tell the Rich logging handler the terminal width
     build:
       context: ..
       dockerfile: components/collector/Dockerfile
@@ -17,12 +18,14 @@ services:
   notifier:
     environment:
       - NOTIFIER_LOG_LEVEL=${NOTIFIER_LOG_LEVEL:-INFO}
+      - COLUMNS=${COLUMNS}  # Tell the Rich logging handler the terminal width
     build:
       context: ..
       dockerfile: components/notifier/Dockerfile
   api_server:
     environment:
       - API_SERVER_LOG_LEVEL=${API_SERVER_LOG_LEVEL:-INFO}
+      - COLUMNS=${COLUMNS}  # Tell the Rich logging handler the terminal width
     build:
       context: ..
       dockerfile: components/api_server/Dockerfile

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -40,6 +40,10 @@ To run *Quality-time* in Docker completely, open a terminal and start all contai
 docker compose up # or 'just start' if you have Just installed
 ```
 
+```{note}
+When running the containers with `docker compose up`, the logging of the Python containers defaults to a width of 80 columns and doesn't take the available width into account. To fix this, run the containers with `just start`. The Just recipe calculates the available width and passes it to the Python containers. 
+```
+
 #### Scenario 2: run bespoke component from shells and other components in Docker
 
 In this scenario, we run the [bespoke components](software.md#bespoke-components) from shells and the [standard components](software.md#standard-components) and [test components](software.md#test-components) as Docker containers. The proxy component does not need to be started as the frontend component functions as proxy.

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -1004,6 +1004,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pymongo" },
     { name = "python-dateutil" },
+    { name = "rich" },
 ]
 
 [package.metadata]
@@ -1013,6 +1014,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pymongo", specifier = "==4.16.0" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
+    { name = "rich", specifier = "==14.3.3" },
 ]
 
 [package.metadata.requires-dev]

--- a/justfile
+++ b/justfile
@@ -27,6 +27,7 @@ src_folder := if src_folder_exists == "true" { "src" } else { "" }
 tests_folder := if tests_folder_exists == "true" { "tests" } else { "" }
 code := if trim(src_folder + " " + tests_folder) == "" { ".?*.py" } else { src_folder + " " + tests_folder }
 random_string := uuid()
+term_width := shell("uv run python -c 'import shutil; print(shutil.get_terminal_size().columns)'")
 
 # === Update dependencies ===
 
@@ -136,7 +137,7 @@ start-js-component: install-js-dependencies
 # Start one or more component(s). Run `just start-help` for more information.
 [no-cd]
 start *components:
-    {{ if pyproject_toml_exists == "true" { "just start-py-component" } else if has_js_start_script == "true" { "just start-js-component" } else if docker_folder_exists == "true" { f"docker compose up {{components}}" } else { "echo 'Nothing to start in this folder'" } }}
+    {{ if pyproject_toml_exists == "true" { "just start-py-component" } else if has_js_start_script == "true" { "just start-js-component" } else if docker_folder_exists == "true" { f"COLUMNS=$(uv run python -c 'w = {{term_width}}; import subprocess; s = subprocess.run([\"docker\", \"compose\", \"config\", \"--services\"], capture_output=True, text=True).stdout; print(w - max(len(line.strip()) for line in s.splitlines()) - 6)') docker compose up {{components}}" } else { "echo 'Nothing to start in this folder'" } }}
 
 [private]
 start-help:


### PR DESCRIPTION
The logging of the Python components would be too narrow when running them with docker compose. Fixed by calculating the available width and setting the COLUMNS environment variable before starting the containers with `just start`.