### PR TITLE
Deprecate the Cobertura Jenkins plugin as source

### DIFF
--- a/components/shared_code/src/shared_data_model/sources/cobertura.py
+++ b/components/shared_code/src/shared_data_model/sources/cobertura.py
@@ -27,6 +27,8 @@ COBERTURA_JENKINS_PLUGIN = Source(
     name="Cobertura Jenkins plugin",
     description="Jenkins plugin for Cobertura, a free Java tool that calculates the percentage of code accessed "
     "by tests.",
+    deprecated=True,
+    deprecation_url=HttpUrl("https://github.com/ICTU/quality-time/issues/12816"),
     documentation={
         "source_up_to_dateness": JENKINS_TOKEN_DOCS,
         "uncovered_branches": JENKINS_TOKEN_DOCS,

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -20,6 +20,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - Improve the documentation for the change failure rate metric. Fixes [#10526](https://github.com/ICTU/quality-time/issues/10526).
 
+### Changed
+
+- Support for the Cobertura Jenkins plugin as source for metrics is deprecated and marked for removal in the future, because the plugin itself is end-of-life. Closes [#12816](https://github.com/ICTU/quality-time/issues/12816).
+
 ### Added
 
 - Login submit button shows loading indicator while verifying credentials. Closes [#12670](https://github.com/ICTU/quality-time/issues/12670).


### PR DESCRIPTION
Support for the Cobertura Jenkins plugin as source for metrics is deprecated and marked for removal in the future, because the plugin itself is end-of-life.

Closes #12816.