### PR TITLE
Fix zipped download from GitLab v18

### DIFF
--- a/components/collector/src/base_collectors/file_source_collector.py
+++ b/components/collector/src/base_collectors/file_source_collector.py
@@ -49,7 +49,7 @@ class FileSourceCollector(SourceCollector, ABC):
         responses = await super()._get_source_responses(*urls)
         unzipped_responses = []
         for url, response in zip(urls, responses, strict=True):
-            if self.__is_zipped(url, response):
+            if await self.is_zipped(url, response):
                 unzipped_responses.extend(await self.__unzip(response))
             else:
                 unzipped_responses.append(response)
@@ -76,12 +76,13 @@ class FileSourceCollector(SourceCollector, ABC):
         return cast(Responses, responses)
 
     @staticmethod
-    def __is_zipped(url: URL, response: Response) -> bool:
+    async def is_zipped(url: URL, response: Response) -> bool:
         """Return whether the responses are zipped."""
         return (
             urlparse(str(url)).path.endswith(".zip")
             or response.content_type == "application/zip"
             or ".zip" in str(response.content_disposition)
+            or zipfile.is_zipfile(io.BytesIO(await response.read()))
         )
 
 

--- a/components/collector/tests/base_collectors/test_collector.py
+++ b/components/collector/tests/base_collectors/test_collector.py
@@ -50,13 +50,17 @@ class CollectorTest(unittest.IsolatedAsyncioTestCase):
         self.database["reports"].insert_one(create_report())
 
     @staticmethod
-    def _patched_get(mock_async_get_request: AsyncMock, side_effect=None) -> _patch[AsyncMock]:
+    def _patched_get(mock_async_get_request: AsyncMock | None, side_effect=None) -> _patch[AsyncMock]:
         """Return a patched version of aiohttp.ClientSession.get()."""
         mock = AsyncMock(side_effect=side_effect) if side_effect else AsyncMock(return_value=mock_async_get_request)
         return patch("aiohttp.ClientSession.get", mock)
 
-    async def _fetch_measurements(self, mock_async_get_request, number=1, side_effect=None) -> None:
+    async def _fetch_measurements(
+        self, mock_async_get_request: AsyncMock | None, number: int = 1, side_effect=None
+    ) -> None:
         """Fetch the measurements with patched get method."""
+        if mock_async_get_request is not None:
+            mock_async_get_request.read = AsyncMock(return_value=b"")
         with self._patched_get(mock_async_get_request, side_effect):
             async with aiohttp.ClientSession() as session:
                 for _ in range(number):

--- a/components/collector/tests/base_collectors/test_file_source_collector.py
+++ b/components/collector/tests/base_collectors/test_file_source_collector.py
@@ -1,0 +1,55 @@
+"""Unit tests for file source collectors."""
+
+import io
+import unittest
+from unittest.mock import Mock
+from zipfile import ZipFile
+
+import aiohttp
+
+from base_collectors.file_source_collector import FileSourceCollector
+from collector_utilities.type import URL
+
+
+class FileSourceCollectorTest(unittest.IsolatedAsyncioTestCase):
+    """Unit tests for the file source collector."""
+
+    async def test_is_zip_when_path_ends_with_zip(self):
+        """Test that a response with a zip file is detected by path."""
+        response = Mock(spec=aiohttp.ClientResponse)
+        self.assertTrue(await FileSourceCollector.is_zipped(URL("https://url/download.zip"), response))
+
+    async def test_is_zip_when_content_type_is_zip(self):
+        """Test that a response with a zip file is detected by content type."""
+        response = Mock(spec=aiohttp.ClientResponse)
+        response.content_type = "application/zip"
+        self.assertTrue(await FileSourceCollector.is_zipped(URL("https://url/download"), response))
+
+    async def test_is_zip_when_zip_in_content_disposition(self):
+        """Test that a response with a zip file is detected by content disposition."""
+        response = Mock(spec=aiohttp.ClientResponse)
+        response.content_disposition = 'attachment; filename="filename.zip"'
+        self.assertTrue(await FileSourceCollector.is_zipped(URL("https://url/download"), response))
+
+    async def test_is_zip_when_checked_by_magic_number(self):
+        """Test that a response with a zip file is detected by magic number."""
+        response = Mock(spec=aiohttp.ClientResponse)
+        zip_buffer = io.BytesIO()
+        with ZipFile(zip_buffer, "w") as zipfile:
+            zipfile.writestr("dummy.txt", "Dummy data")
+        response.read.return_value = zip_buffer.getvalue()
+        self.assertTrue(await FileSourceCollector.is_zipped(URL("https://url/download"), response))
+
+    async def test_is_not_zip_when_random_bytes(self):
+        """Test that a response with random bytes is not detected as zip."""
+        response = Mock(spec=aiohttp.ClientResponse)
+        zip_buffer = io.BytesIO(b"Dummy data")
+        response.read.return_value = zip_buffer.getvalue()
+        self.assertFalse(await FileSourceCollector.is_zipped(URL("https://url/download"), response))
+
+    async def test_is_not_zip_when_no_contents(self):
+        """Test that a response without contents is not detected as zip."""
+        response = Mock(spec=aiohttp.ClientResponse)
+        zip_buffer = io.BytesIO(b"")
+        response.read.return_value = zip_buffer.getvalue()
+        self.assertFalse(await FileSourceCollector.is_zipped(URL("https://url/download"), response))

--- a/components/collector/tests/metric_collectors/test_test_cases.py
+++ b/components/collector/tests/metric_collectors/test_test_cases.py
@@ -68,6 +68,7 @@ class TestCasesTest(unittest.IsolatedAsyncioTestCase):
         self.session = AsyncMock()
         self.session.timeout.total = config.MEASUREMENT_TIMEOUT
         self.response = self.session.get.return_value = AsyncMock()
+        self.response.read = AsyncMock(return_value=b"")
         self.test_cases_json = {"total": 2, "issues": [self.jira_issue(), self.jira_issue("key-2")]}
         self.response.json = AsyncMock(side_effect=[[], self.test_cases_json, self.test_cases_json])
         self.jira_url = "https://jira"

--- a/components/collector/tests/source_collectors/source_collector_test_case.py
+++ b/components/collector/tests/source_collectors/source_collector_test_case.py
@@ -46,7 +46,7 @@ class SourceCollectorTestCase(unittest.IsolatedAsyncioTestCase):
         get_request_json_return_value: dict | list | None = None,
         get_request_json_side_effect=None,
         get_request_side_effect=None,
-        get_request_content="",
+        get_request_content: bytes = b"",
         get_request_text: str = "",
         get_request_headers=None,
         get_request_links: dict[str, dict[str, str]] | None = None,
@@ -76,7 +76,7 @@ class SourceCollectorTestCase(unittest.IsolatedAsyncioTestCase):
     def __get_response(  # noqa: PLR0913
         json_return_value: dict | list | None,
         json_side_effect,
-        content,
+        content: bytes,
         text: str,
         headers,
         links: dict[str, dict[str, str]] | None,

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,6 +19,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Fixed
 
 - Improve the documentation for the change failure rate metric. Fixes [#10526](https://github.com/ICTU/quality-time/issues/10526).
+- GitLab v18 does not mark zip files as zipped in the response headers, which Quality-time uses to detect zip files. Add a magic number check to detect zip files. Fixes [#12735](https://github.com/ICTU/quality-time/issues/12735).
 - The UI would crash when expanding a metric with accepted technical debt but no measurement value. Fixes [#12824](https://github.com/ICTU/quality-time/issues/12824).
 
 ### Changed


### PR DESCRIPTION
GitLab v18 does not mark zip files as zipped in the response headers, which Quality-time uses to detect zip files. Add a magic number check to detect zip files.

Fixes #12735.