### PR TITLE
Fix deleting and renaming empty tags

### DIFF
--- a/components/api_server/src/routes/report.py
+++ b/components/api_server/src/routes/report.py
@@ -245,8 +245,9 @@ def get_report_issue_tracker_options(database: Database, report: Report):  # noq
 
 
 @bottle.delete("/api/internal/report/<report_uuid>/tag/<tag>", permissions_required=[EDIT_REPORT_PERMISSION])
+@bottle.delete("/api/internal/report/<report_uuid>/tag/", permissions_required=[EDIT_REPORT_PERMISSION])
 @with_report(pass_report_uuid=False)
-def delete_tag(database: Database, report: Report, tag: str):
+def delete_tag(database: Database, report: Report, tag: str = ""):
     """Delete a tag from all metrics in a report."""
     if changed_uuids := report.delete_tag(tag):
         delta_description = f"{{user}} deleted tag '{tag}' from all metrics in report '{report.name}'."
@@ -255,8 +256,9 @@ def delete_tag(database: Database, report: Report, tag: str):
 
 
 @bottle.post("/api/internal/report/<report_uuid>/tag/<tag>", permissions_required=[EDIT_REPORT_PERMISSION])
+@bottle.post("/api/internal/report/<report_uuid>/tag/", permissions_required=[EDIT_REPORT_PERMISSION])
 @with_report(pass_report_uuid=False)
-def rename_tag(database: Database, report: Report, tag: str):
+def rename_tag(database: Database, report: Report, tag: str = ""):
     """Rename a tag for all metrics in a report."""
     new_value = dict(bottle.request.json)["tag"]
     if changed_uuids := report.rename_tag(tag, new_value):

--- a/components/api_server/tests/routes/test_report.py
+++ b/components/api_server/tests/routes/test_report.py
@@ -712,3 +712,26 @@ class ReportTagsTest(ReportTestCase):
             rename_tag(self.database, REPORT_ID, "non-existing tag"),
         )
         self.database.reports.insert_one.assert_not_called()
+
+
+class ReportEmptyTagsTest(ReportTestCase):
+    """Unit tests for deleting and renaming empty tags."""
+
+    def setUp(self):
+        """Extend to add an empty tag to the test fixture."""
+        super().setUp()
+        self.report["subjects"][SUBJECT_ID]["metrics"][METRIC_ID]["tags"].append("")
+
+    def test_delete_empty_tag(self):
+        """Test that an empty tag can be deleted."""
+        self.assertEqual({"ok": True}, delete_tag(self.database, REPORT_ID))
+        inserted = self.database.reports.insert_one.call_args_list[0][0][0]
+        self.assertEqual(["security"], inserted["subjects"][SUBJECT_ID]["metrics"][METRIC_ID]["tags"])
+
+    @patch("bottle.request")
+    def test_rename_empty_tag(self, request):
+        """Test that an empty tag can be renamed."""
+        request.json = {"tag": "safety"}
+        self.assertEqual({"ok": True}, rename_tag(self.database, REPORT_ID))
+        inserted = self.database.reports.insert_one.call_args_list[0][0][0]
+        self.assertEqual(["security", "safety"], inserted["subjects"][SUBJECT_ID]["metrics"][METRIC_ID]["tags"])

--- a/tests/feature_tests/src/features/report.feature
+++ b/tests/feature_tests/src/features/report.feature
@@ -106,6 +106,20 @@ Feature: report
     When the client renames the tag "security" to "safety"
     Then the metric tags is "maintainability"
 
+  Scenario: remove an empty tag from all metrics in a report
+    Given an existing report with title "Scenario: remove empty tag"
+    And an existing subject
+    And an existing metric with tags ", maintainability"
+    When the client removes the tag "" from the report
+    Then the metric tags is "maintainability"
+
+  Scenario: rename an empty tag for all metrics in a report
+    Given an existing report with title "Scenario: rename empty tag"
+    And an existing subject
+    And an existing metric with tags ", maintainability"
+    When the client renames the tag "" to "safety"
+    Then the metric tags is "maintainability, safety"
+
   Scenario: export report as PDF
     When the client creates a report
     And the client downloads the report as PDF

--- a/tests/feature_tests/src/steps/report.py
+++ b/tests/feature_tests/src/steps/report.py
@@ -203,14 +203,16 @@ def set_technical_debt_desired_response_time(context: Context, status: str, time
 
 
 @when('the client removes the tag "{tag}" from the report')
-def remove_tag(context: Context, tag: str) -> None:
+@when('the client removes the tag "" from the report')
+def remove_tag(context: Context, tag: str = "") -> None:
     """Remove the tag from all metrics in the report."""
     report_uuid = context.uuid["report"]
     context.delete(f"report/{report_uuid}/tag/{tag}")
 
 
 @when('the client renames the tag "{tag}" to "{new_tag}"')
-def rename_tag(context: Context, tag: str, new_tag: str) -> None:
+@when('the client renames the tag "" to "{new_tag}"')
+def rename_tag(context: Context, tag: str = "", new_tag: str = "") -> None:
     """Rename a tag for all metric in the report."""
     report_uuid = context.uuid["report"]
     context.post(f"report/{report_uuid}/tag/{tag}", {"tag": new_tag})


### PR DESCRIPTION
When a tag was changed to an empty string, the DELETE and POST endpoints for /report/{report_uuid}/tag/{tag} returned 404 because an empty tag produced a URL ending in /tag/, which didn't match any route.

Fixes #12825.