### PR TITLE
Improve documentation for exporting reports

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -150,7 +150,7 @@ Replace the username and password with the username and password you use to logi
 The exporting endpoint is available via `https://quality-time.source.org/api/v3/report/<report-uuid>/json?public_key=<public-key>`.
 The exporting endpoint returns JSON content only.
 
-For example, using curl, and assuming you have logged in as shown above:
+For example, using curl, and assuming **you have logged in as shown above**:
 
 ```console
 curl --cookie cookie.txt --output report.json https://quality-time.source.org/api/v3/report/97b2f341-45ce-4f2b-9a71-3675f2f54cf7/json
@@ -191,6 +191,12 @@ This prints the public key, looking something like:
 
 ```console
 -----BEGIN+PUBLIC+KEY----- ... encoded public key ... -----END+PUBLIC+KEY-----%0A
+```
+
+Copy the public key and pass it to the export endpoint, for example:
+
+```console
+curl --cookie cookie.txt --output report.json https://quality-time.source.org/api/v3/report/97b2f341-45ce-4f2b-9a71-3675f2f54cf7/json?public_key=----BEGIN+PUBLIC+KEY----- ... encoded public key ... -----END+PUBLIC+KEY-----%0A
 ```
 
 ### Importing reports

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -20,6 +20,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - Improve the documentation for the change failure rate metric. Fixes [#10526](https://github.com/ICTU/quality-time/issues/10526).
 - GitLab v18 does not mark zip files as zipped in the response headers, which Quality-time uses to detect zip files. Add a magic number check to detect zip files. Fixes [#12735](https://github.com/ICTU/quality-time/issues/12735).
+- Document how to use the public key of the destination Quality-time instance when exporting a quality report. Fixes [#12801](https://github.com/ICTU/quality-time/issues/12801).
 - The UI would crash when expanding a metric with accepted technical debt but no measurement value. Fixes [#12824](https://github.com/ICTU/quality-time/issues/12824).
 
 ### Changed


### PR DESCRIPTION
Document how to use the public key of the destination Quality-time instance when exporting a quality report.

Fixes #12801.