### PR TITLE
Fix suppressed Trivy security warnings reappearing

### DIFF
--- a/components/collector/src/model/entity.py
+++ b/components/collector/src/model/entity.py
@@ -15,8 +15,10 @@ QUOTED_SLASH = re.compile("%2f", re.IGNORECASE)
 class Entity(dict):
     """Class to hold information about an individual measurement entity, e.g. one violation, or one security warning."""
 
-    def __init__(self, key: str, **attributes) -> None:
+    def __init__(self, key: str, old_key: str = "", **attributes) -> None:
         kwargs = {"key": self.safe_entity_key(key), "first_seen": iso_timestamp()}
+        if old_key:
+            kwargs["old_key"] = self.safe_entity_key(old_key)
         kwargs.update(**attributes)
         super().__init__(**kwargs)
 

--- a/components/collector/src/source_collectors/trivy/security_warnings.py
+++ b/components/collector/src/source_collectors/trivy/security_warnings.py
@@ -29,17 +29,19 @@ class TrivyJSONSecurityWarnings(SecurityWarningsSourceCollector, JSONFileSourceC
             for vulnerability in result.get("Vulnerabilities") or []:
                 vulnerability_id = vulnerability["VulnerabilityID"]
                 package_name = vulnerability["PkgName"]
+                installed_version = vulnerability["InstalledVersion"]
                 references = vulnerability.get("References", [])
                 url = references[0] if references else ""  # Assume the 1st link is at least as relevant as the others
                 entities.append(
                     Entity(
-                        key=f"{vulnerability_id}@{package_name}@{target}",
+                        key=f"{vulnerability_id}@{package_name}@{installed_version}",
+                        old_key=f"{vulnerability_id}@{package_name}@{target}",  # Key changed after v5.50.0 due to https://github.com/ICTU/quality-time/issues/12746
                         vulnerability_id=vulnerability_id,
                         title=vulnerability.get("Title", vulnerability_id),
                         description=vulnerability.get("Description", ""),
                         level=vulnerability["Severity"],
                         package_name=package_name,
-                        installed_version=vulnerability["InstalledVersion"],
+                        installed_version=installed_version,
                         fixed_version=vulnerability.get("FixedVersion", ""),
                         url=url,
                     ),

--- a/components/collector/tests/source_collectors/trivy/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/trivy/test_security_warnings.py
@@ -12,7 +12,8 @@ class TrivyJSONSecurityWarningsTest(TrivyJSONTestCase):
         """Return the expected entities."""
         return [
             {
-                "key": "CVE-2018-16840@curl@trivy-ci-test (alpine 3_7_1)",
+                "key": "CVE-2018-16840@curl@7_61_0-r0",
+                "old_key": "CVE-2018-16840@curl@trivy-ci-test (alpine 3_7_1)",
                 "vulnerability_id": "CVE-2018-16840",
                 "title": 'curl: Use-after-free when closing "easy" handle in Curl_close()',
                 "description": "A heap use-after-free flaw was found in curl versions from 7.59.0 through ...",
@@ -23,7 +24,8 @@ class TrivyJSONSecurityWarningsTest(TrivyJSONTestCase):
                 "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16840",
             },
             {
-                "key": "CVE-2019-3822@curl@trivy-ci-test (alpine 3_7_1)",
+                "key": "CVE-2019-3822@curl@7_61_1-r0",
+                "old_key": "CVE-2019-3822@curl@trivy-ci-test (alpine 3_7_1)",
                 "vulnerability_id": "CVE-2019-3822",
                 "title": "curl: NTLMv2 type-3 header stack buffer overflow",
                 "description": "libcurl versions from 7.36.0 to before 7.64.0 are vulnerable to ...",
@@ -34,7 +36,8 @@ class TrivyJSONSecurityWarningsTest(TrivyJSONTestCase):
                 "url": "https://curl.haxx.se/docs/CVE-2019-3822.html",
             },
             {
-                "key": "CVE-2024-5432@python@trivy-ci-test (alpine 3_7_1)",
+                "key": "CVE-2024-5432@python@3_13_1",
+                "old_key": "CVE-2024-5432@python@trivy-ci-test (alpine 3_7_1)",
                 "vulnerability_id": "CVE-2024-5432",
                 "title": "Vulnerability without fixed version",
                 "description": "This vulnerability has no fixed version field.",
@@ -45,7 +48,8 @@ class TrivyJSONSecurityWarningsTest(TrivyJSONTestCase):
                 "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-5432",
             },
             {
-                "key": "CVE-2025-6298@This vulnerability has no optional fields@trivy-ci-test (alpine 3_7_1)",
+                "key": "CVE-2025-6298@This vulnerability has no optional fields@3_4_1",
+                "old_key": "CVE-2025-6298@This vulnerability has no optional fields@trivy-ci-test (alpine 3_7_1)",
                 "vulnerability_id": "CVE-2025-6298",
                 "title": "CVE-2025-6298",
                 "description": "",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,6 +14,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ### Fixed
 
+- Suppress Trivy security warnings based on vulnerability ID, package name, and installed version instead of including the target, which can change between scans due to e.g. commit hashes. Fixes [#12746](https://github.com/ICTU/quality-time/issues/12746).
 - If importing a report fails, show a toast message with the error. Fixes [#12800](https://github.com/ICTU/quality-time/issues/12800).
 - Allow for configuring a GitHub personal access token to prevent being rate limited by GitHub when checking for new source versions. Fixes [#12853](https://github.com/ICTU/quality-time/issues/12853).
 


### PR DESCRIPTION
Suppress Trivy security warnings based on vulnerability ID, package name, and installed version instead of including the target, which can change between scans due to e.g. commit hashes.

Fixes #12746.