### PR TITLE
Remove JUnit old_key

### DIFF
--- a/components/collector/src/source_collectors/junit/tests.py
+++ b/components/collector/src/source_collectors/junit/tests.py
@@ -48,11 +48,9 @@ class JUnitTests(XMLFileSourceCollector):
         host_name = case_node.get("hostname", "")
         name = case_node.get("name", "unknown")
         key = f"{class_name}:{host_name}:{name}"
-        old_key = f"{class_name}:{name}"  # Key was changed after v5.25.0, enable migration of user entity data
         suite_names = cls.parent_names(case_node, parent_map)
         return Entity(
             key=key,
-            old_key=old_key,
             name=name,
             class_name=class_name,
             host_name=host_name,

--- a/components/collector/tests/source_collectors/junit/test_tests.py
+++ b/components/collector/tests/source_collectors/junit/test_tests.py
@@ -13,7 +13,6 @@ class JUnitTestsTest(JUnitCollectorTestCase):
         return {
             "suite_names": suite_names,
             "key": f"cn:{host_name}:{name}",
-            "old_key": f"cn:{name}",
             "name": name,
             "class_name": "cn",
             "host_name": host_name,


### PR DESCRIPTION
Remove the old_key from the JUnit collector. The old_key was introduced in v5.26.0 to enable migration of user entity data. Since upgrading to the latest Quality-time requires an installation of v5.47.0, the old_key is no longer needed.

Closes #12869.