### PR TITLE
Remove unused subject description field

### DIFF
--- a/components/api_server/src/example-reports/example-report-quality-time.json
+++ b/components/api_server/src/example-reports/example-report-quality-time.json
@@ -6,7 +6,6 @@
         "8cd7fc6e-5a65-4958-83c3-8afcc461b628": {
             "type": "software",
             "name": "Quality-time",
-            "description": "A custom software application or component.",
             "metrics": {
                 "f51c0391-0a51-43f1-9bd1-69046d1acc06": {
                     "type": "tests",

--- a/components/api_server/src/example-reports/example-report.json
+++ b/components/api_server/src/example-reports/example-report.json
@@ -6,7 +6,6 @@
         "ee220264-9e66-49a4-981e-4dfe37a86a2c": {
             "type": "software",
             "name": "Demo application",
-            "description": "A custom software application or component.",
             "metrics": {
                 "3ddbacd8-882c-4c0c-8f63-7f9fb00ade27": {
                     "type": "loc",

--- a/components/api_server/src/initialization/migrations.py
+++ b/components/api_server/src/initialization/migrations.py
@@ -15,7 +15,15 @@ def perform_migrations(database: Database) -> None:
     for report in database.reports.find(filter={"last": True, "deleted": {"$exists": False}}):
         report_uuid = report["report_uuid"]
         logger.info("Checking report %s for necessary updates", report_uuid)
-        changes = [change for change in (remove_metric_addition(report), remove_checkmarx(report)) if change]
+        changes = [
+            change
+            for change in (
+                remove_metric_addition(report),
+                remove_checkmarx(report),
+                remove_subject_description(report),
+            )
+            if change
+        ]
         if any(changes):
             logger.info("Updating report %s to %s", report_uuid, " and ".join(change for change in changes if change))
             replace_document(database.reports, report)
@@ -42,6 +50,17 @@ def remove_checkmarx(report) -> str:
             change_description = "remove the Checkmarx source from metrics"
             for source_id in source_ids_to_remove:
                 del metric["sources"][source_id]
+    return change_description
+
+
+def remove_subject_description(report) -> str:
+    """Remove the description field from all subjects."""
+    # Added after Quality-time v5.50.0, see https://github.com/ICTU/quality-time/issues/12799
+    change_description = ""
+    for subject in report.get("subjects", {}).values():
+        if "description" in subject:
+            change_description = "remove the description field from subjects"
+            del subject["description"]
     return change_description
 
 

--- a/components/api_server/src/model/defaults.py
+++ b/components/api_server/src/model/defaults.py
@@ -38,5 +38,4 @@ def default_report_attributes() -> dict[str, str | dict]:
 
 def default_subject_attributes(subject_type: str) -> dict[str, Any]:
     """Return the default attributes with their default values for the specified subject type."""
-    subject = DATA_MODEL.all_subjects[subject_type]
-    return {"type": subject_type, "name": None, "description": subject.description, "metrics": {}}
+    return {"type": subject_type, "name": None, "metrics": {}}

--- a/components/api_server/tests/initialization/test_migrations.py
+++ b/components/api_server/tests/initialization/test_migrations.py
@@ -87,3 +87,27 @@ class RemoveCheckmarxTest(MigrationTestCase):
         inserted_report = self.inserted_report()
         del inserted_report["subjects"][SUBJECT_ID]["metrics"][METRIC_ID2]["sources"][SOURCE_ID]
         self.check_inserted_report(inserted_report)
+
+
+class RemoveSubjectDescriptionTest(MigrationTestCase):
+    """Unit tests for the migration to remove description fields from subjects."""
+
+    def existing_report(self, **kwargs):
+        """Extend to add description to subject."""
+        report = super().existing_report(**kwargs)
+        report["subjects"][SUBJECT_ID]["description"] = "A custom software application or component."
+        return report
+
+    def test_report_without_subject_description(self):
+        """Test that the migration succeeds with reports without subject descriptions."""
+        self.database.reports.find.return_value = [super().existing_report()]
+        perform_migrations(self.database)
+        self.database.reports.replace_one.assert_not_called()
+
+    def test_report_with_subject_description(self):
+        """Test that the migration succeeds with reports that have subject descriptions."""
+        self.database.reports.find.return_value = [self.existing_report()]
+        perform_migrations(self.database)
+        inserted_report = self.inserted_report()
+        del inserted_report["subjects"][SUBJECT_ID]["description"]
+        self.check_inserted_report(inserted_report)

--- a/components/api_server/tests/model/test_defaults.py
+++ b/components/api_server/tests/model/test_defaults.py
@@ -46,7 +46,6 @@ class DefaultAttributesTest(DataModelTestCase):
         self.assertEqual(
             {
                 "name": None,
-                "description": "A custom software application or component.",
                 "type": "software",
                 "metrics": {},
             },

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - Allow for configuring a regular expression to extract a valid version number from non-standard version strings reported by sources, for the software version metric. Fixes [#12484](https://github.com/ICTU/quality-time/issues/12484).
 - Suppress Trivy security warnings based on vulnerability ID, package name, and installed version instead of including the target, which can change between scans due to e.g. commit hashes. Fixes [#12746](https://github.com/ICTU/quality-time/issues/12746).
+- Remove unused subject description field from reports. Fixes [#12799](https://github.com/ICTU/quality-time/issues/12799).
 - If importing a report fails, show a toast message with the error. Fixes [#12800](https://github.com/ICTU/quality-time/issues/12800).
 - Update help URL for finding the id of a GitLab project. Fixes [#12813](https://github.com/ICTU/quality-time/issues/12813).
 - Allow for configuring a GitHub personal access token to prevent being rate limited by GitHub when checking for new source versions. Fixes [#12853](https://github.com/ICTU/quality-time/issues/12853).


### PR DESCRIPTION
Remove unused subject description field from reports. It was never used, so no need to add in to the versioning table.

Fixes #12799.