### PR TITLE
Fix Jira sprint names

### DIFF
--- a/components/collector/src/source_collectors/jira/issues.py
+++ b/components/collector/src/source_collectors/jira/issues.py
@@ -12,7 +12,7 @@ from .base import JiraBase
 class JiraIssues(JiraBase):
     """Jira collector for issues."""
 
-    SPRINT_NAME_RE = re.compile(r",name=(.*),\w+=")
+    SPRINT_NAME_RE = re.compile(r",name=(.*?),\w+=")
     DEFAULT_MAX_RESULTS: int = 500  # Fallback for maximum number of issues to retrieve per page from Jira
     max_results: int | None = None
 

--- a/components/collector/tests/source_collectors/jira/test_user_story_points.py
+++ b/components/collector/tests/source_collectors/jira/test_user_story_points.py
@@ -32,7 +32,15 @@ class JiraUserStoryPointsTest(JiraTestCase):
         """Test that the number of story points and the sprints are returned, when sprint field is in text format."""
         user_stories_json = {
             "issues": [
-                self.issue(key="1", field=10, custom_field_001=["...,state=CLOSED,name=Sprint 1,rapidViewId=..."]),
+                self.issue(
+                    key="1",
+                    field=10,
+                    custom_field_001=[
+                        "com.atlassian.greenhopper.service.sprint.Sprint@2d1e5c"
+                        "[id=1,rapidViewId=186,state=CLOSED,name=Sprint 1,"
+                        "startDate=2026-03-01T11:27:00.000+01:00,sequence=5335,goal=]"
+                    ],
+                ),
                 self.issue(key="2", field=32, custom_field_001=None),
             ],
         }
@@ -86,8 +94,24 @@ class JiraUserStoryPointsTest(JiraTestCase):
         """Test that the number of story points and the sprints are returned, when there are mixed sprint fields."""
         user_stories_json = {
             "issues": [
-                self.issue(key="1", field=1, custom_field_001=["...,state=CLOSED,name=Sprint 1,rapidViewId=..."]),
-                self.issue(key="2", field=2, custom_field_001=["...,state=CLOSED,name=Sprint 1,someOtherAttr=..."]),
+                self.issue(
+                    key="1",
+                    field=1,
+                    custom_field_001=[
+                        "com.atlassian.greenhopper.service.sprint.Sprint@2d1e5c"
+                        "[id=1,rapidViewId=186,state=CLOSED,name=Sprint 1,"
+                        "startDate=2026-03-01T11:27:00.000+01:00,sequence=5335,goal=]"
+                    ],
+                ),
+                self.issue(
+                    key="2",
+                    field=2,
+                    custom_field_001=[
+                        "com.atlassian.greenhopper.service.sprint.Sprint@3e2f6d"
+                        "[id=2,rapidViewId=186,state=CLOSED,name=Sprint 1,"
+                        "startDate=2026-03-08T11:27:00.000+01:00,sequence=5336,goal=]"
+                    ],
+                ),
                 self.issue(key="3", field=3, custom_field_001=[{"id": 1, "name": "Sprint 2", "state": "closed"}]),
                 self.issue(key="4", field=5, custom_field_001=[{"id": 1, "name": "Sprint 2", "state": "closed"}]),
                 self.issue(key="5", field=8, custom_field_001=None),

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -21,6 +21,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 - If importing a report fails, show a toast message with the error. Fixes [#12800](https://github.com/ICTU/quality-time/issues/12800).
 - Update help URL for finding the id of a GitLab project. Fixes [#12813](https://github.com/ICTU/quality-time/issues/12813).
 - Allow for configuring a GitHub personal access token to prevent being rate limited by GitHub when checking for new source versions. Fixes [#12853](https://github.com/ICTU/quality-time/issues/12853).
+- When measuring user story points, issues, or average issue lead time with Jira as source, correctly parse the sprint name from the Jira sprint text field. Fixes [#12884](https://github.com/ICTU/quality-time/issues/12884).
 
 ## v5.50.0 - 2026-03-27
 


### PR DESCRIPTION
When measuring user story points, issues, or average issue lead time with Jira as source, correctly parse the sprint name from the Jira sprint text field.

Fixes #12884.