### PR TITLE
Ignore variable parts of URLs in Axe violations

### DIFF
--- a/components/collector/src/source_collectors/axe_core/violations.py
+++ b/components/collector/src/source_collectors/axe_core/violations.py
@@ -1,11 +1,12 @@
 """Axe-core accessibility violations collectors."""
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from shared.utils.functions import md5_hash
 
 from base_collectors import JSONFileSourceCollector, SourceCollector
-from collector_utilities.functions import match_string_or_regular_expression
+from collector_utilities.functions import match_string_or_regular_expression, stabilize
+from collector_utilities.type import URL
 from model import Entities, Entity
 
 if TYPE_CHECKING:
@@ -54,6 +55,11 @@ class AxeViolationsCollector(SourceCollector):
             element_exclude_filter and match_string_or_regular_expression(entity["element"], element_exclude_filter)
         )
 
+    def _stable_url(self, url: URL) -> URL:
+        """Return the url without the variable parts."""
+        reg_exps = cast(list[str], self._parameter("variable_url_regexp"))
+        return URL(stabilize(url, reg_exps, "variable-part-removed"))
+
 
 class AxeCoreViolations(JSONFileSourceCollector, AxeViolationsCollector):
     """Collector class to get accessibility violations from Axe-core JSON output."""
@@ -64,7 +70,7 @@ class AxeCoreViolations(JSONFileSourceCollector, AxeViolationsCollector):
         entity_attributes = []
         for test_result in self.__parse_test_results(json):
             violations = {result_type: test_result.get(result_type, []) for result_type in result_types}
-            url = test_result.get("url", "")
+            url = self._stable_url(URL(test_result.get("url", "")))
             entity_attributes.extend(self.__parse_violations(violations, url))
         return Entities(Entity(key=self.__create_key(attributes), **attributes) for attributes in entity_attributes)
 

--- a/components/collector/src/source_collectors/axe_csv/violations.py
+++ b/components/collector/src/source_collectors/axe_csv/violations.py
@@ -7,40 +7,34 @@ from io import StringIO
 from shared.utils.functions import md5_hash
 
 from base_collectors import CSVFileSourceCollector
-from collector_utilities.functions import match_string_or_regular_expression
+from collector_utilities.type import URL
 from model import Entities, Entity, SourceResponses
+from source_collectors.axe_core.violations import AxeViolationsCollector
 
 
-class AxeCSVViolations(CSVFileSourceCollector):
+class AxeCSVViolations(CSVFileSourceCollector, AxeViolationsCollector):
     """Collector class to get accessibility violations."""
 
     def _include_entity(self, entity: Entity) -> bool:
         """Return whether to include the violation."""
-        impact = entity["impact"]
-        if impact and impact not in self._parameter("impact"):
-            return False
-        element_include_filter = self._parameter("element_include_filter")
-        if element_include_filter and not match_string_or_regular_expression(entity["element"], element_include_filter):
-            return False
-        element_exclude_filter = self._parameter("element_exclude_filter")
-        return not bool(
-            element_exclude_filter and match_string_or_regular_expression(entity["element"], element_exclude_filter)
-        )
+        return self._include_entity_based_on_impact(entity) and self._include_entity_based_on_element_filter(entity)
 
     async def _parse_entities(self, responses: SourceResponses) -> Entities:
         """Override to parse the CSV and create the entities."""
-        entity_attributes = [
-            {
-                "url": str(row["URL"]),
-                "violation_type": row["Violation Type"],
-                "impact": row["Impact"],
-                "element": row["DOM Element"],
-                "page": re.sub(r"https?://[^/]+", "", row["URL"]),
-                "description": row["Messages"],
-                "help": row["Help"],
-            }
-            for row in await self.__parse_csv(responses)
-        ]
+        entity_attributes = []
+        for row in await self.__parse_csv(responses):
+            url = self._stable_url(URL(row["URL"]))
+            entity_attributes.append(
+                {
+                    "url": str(url),
+                    "violation_type": row["Violation Type"],
+                    "impact": row["Impact"],
+                    "element": row["DOM Element"],
+                    "page": re.sub(r"https?://[^/]+", "", str(url)),
+                    "description": row["Messages"],
+                    "help": row["Help"],
+                }
+            )
         return Entities(
             Entity(key=md5_hash(",".join(str(value) for value in attributes.values())), **attributes)
             for attributes in entity_attributes

--- a/components/collector/src/source_collectors/axe_html_reporter/violations.py
+++ b/components/collector/src/source_collectors/axe_html_reporter/violations.py
@@ -7,6 +7,7 @@ from bs4 import Tag
 from shared.utils.functions import md5_hash
 
 from base_collectors import HTMLFileSourceCollector
+from collector_utilities.type import URL
 from model import Entities, Entity, SourceResponses
 from source_collectors.axe_core.violations import AxeViolationsCollector
 
@@ -26,7 +27,7 @@ class AxeHTMLReporterViolations(HTMLFileSourceCollector, AxeViolationsCollector)
 
     def __parse_html_soup(self, soup: Tag) -> Iterator[dict[str, str]]:
         """Parse the entity attributes from the HTML."""
-        page_url = cast(str, cast(Tag, soup.select_one("div.summary > a"))["href"])
+        page_url = self._stable_url(URL(cast(str, cast(Tag, soup.select_one("div.summary > a"))["href"])))
         for result_type in self._parameter("result_types"):
             if result_type == "violations":
                 yield from self.__parse_violations_from_html_soup(soup, page_url)

--- a/components/collector/tests/source_collectors/axe_core/test_violations.py
+++ b/components/collector/tests/source_collectors/axe_core/test_violations.py
@@ -186,6 +186,16 @@ class AxeCoreViolationsTest(AxeCoreTestCase):
         response = await self.collect(get_request_json_return_value=self.json)
         self.assert_measurement(response, value="3", entities=self.expected_entities)
 
+    async def test_variable_url_regexp(self):
+        """Test that parts of URLs can be ignored."""
+        self.set_source_parameter("variable_url_regexp", ["https://tested_url"])
+        for entity in self.expected_entities:
+            entity["page"] = "variable-part-removed"
+            entity["url"] = "variable-part-removed"
+        self.set_expected_entity_keys()
+        response = await self.collect(get_request_json_return_value=self.json)
+        self.assert_measurement(response, value="2", entities=self.expected_entities)
+
     async def test_result_type_without_nodes(self):
         """Test that result types without nodes can be counted as well."""
         self.set_source_parameter("result_types", ["violations", "inapplicable"])

--- a/components/collector/tests/source_collectors/axe_csv/test_violations.py
+++ b/components/collector/tests/source_collectors/axe_csv/test_violations.py
@@ -104,6 +104,22 @@ class AxeCSVViolationsTest(SourceCollectorTestCase):
         response = await self.collect(get_request_text=self.csv + "\n\n")
         self.assert_measurement(response, value="2", entities=self.expected_entities)
 
+    async def test_variable_url_regexp(self):
+        """Test that parts of URLs can be ignored."""
+        self.set_source_parameter("variable_url_regexp", ["url1"])
+        expected_entity = {
+            "url": "variable-part-removed",
+            "violation_type": "aria-input-field-name",
+            "impact": "serious",
+            "element": None,
+            "page": "variable-part-removed",
+            "description": None,
+            "help": "help1",
+        }
+        expected_entity["key"] = self.entity_key(expected_entity)
+        response = await self.collect(get_request_text=self.csv)
+        self.assert_measurement(response, value="2", entities=[expected_entity, self.expected_entities[1]])
+
     async def test_embedded_newlines(self):
         """Test that embedded newlines are ignored."""
         violation_with_newline = 'url3,aria-hidden-focus,moderate,help3,html3,"messages3\nsecond line",dom3\n'

--- a/components/collector/tests/source_collectors/axe_html_reporter/test_violations.py
+++ b/components/collector/tests/source_collectors/axe_html_reporter/test_violations.py
@@ -127,6 +127,12 @@ class AxeHTMLViolationsTest(SourceCollectorTestCase):
         response = await self.collect(get_request_text=self.html)
         self.assert_measurement(response, value="68")
 
+    async def test_variable_url_regexp(self):
+        """Test that parts of URLs can be ignored."""
+        self.set_source_parameter("variable_url_regexp", ["example\\.com"])
+        response = await self.collect(get_request_text=self.html)
+        self.assert_measurement(response, value="6")
+
     async def test_incomplete_rules(self):
         """Test that incomplete rules can be counted as well."""
         self.set_source_parameter("result_types", ["incomplete"])

--- a/components/shared_code/src/shared_data_model/parameters.py
+++ b/components/shared_code/src/shared_data_model/parameters.py
@@ -339,6 +339,17 @@ class TransactionSpecificTargetResponseTimes(MultipleChoiceWithAdditionParameter
     metrics: list[str] = ["slow_transactions"]
 
 
+class VariableURLRegExp(MultipleChoiceWithAdditionParameter):
+    """Parameter for specifying parts of URLs to ignore."""
+
+    name: str = "Parts of URLs to ignore (regular expressions)"
+    help: str | None = (
+        "Parts of URLs to ignore can be specified by regular expression. The parts of URLs that match one "
+        "or more of the regular expressions are removed. If, after applying the regular expressions, multiple "
+        "violations are the same only one is reported."
+    )
+
+
 def access_parameters(
     metrics: list[str],
     include: dict[str, bool] | None = None,

--- a/components/shared_code/src/shared_data_model/sources/axe.py
+++ b/components/shared_code/src/shared_data_model/sources/axe.py
@@ -8,6 +8,7 @@ from shared_data_model.parameters import (
     GitHubPersonalAccessToken,
     MultipleChoiceWithAdditionParameter,
     MultipleChoiceWithDefaultsParameter,
+    VariableURLRegExp,
     access_parameters,
 )
 
@@ -124,6 +125,7 @@ When combining results objects, make sure the `testEngine` field is retained in 
         "element_exclude_filter": ELEMENT_EXCLUDE_FILTER,
         "impact": IMPACT,
         "result_types": RESULT_TYPES,
+        "variable_url_regexp": VariableURLRegExp(metrics=["violations"]),
         "github_pat": GitHubPersonalAccessToken(metrics=["source_version"]),
         **access_parameters(ALL_AXE_CORE_METRICS, source_type="an Axe-core report", source_type_format="JSON"),
     },
@@ -141,6 +143,7 @@ AXE_HTML_REPORTER = Source(
         "element_exclude_filter": ELEMENT_EXCLUDE_FILTER,
         "impact": IMPACT,
         "result_types": RESULT_TYPES,
+        "variable_url_regexp": VariableURLRegExp(metrics=["violations"]),
         **access_parameters(["violations"], source_type="an Axe report", source_type_format="HTML"),
     },
     entities=ENTITIES,
@@ -154,6 +157,7 @@ AXE_CSV = Source(
         "element_include_filter": ELEMENT_INCLUDE_FILTER,
         "element_exclude_filter": ELEMENT_EXCLUDE_FILTER,
         "impact": IMPACT,
+        "variable_url_regexp": VariableURLRegExp(metrics=["violations"]),
         **access_parameters(["violations"], source_type="an Axe report", source_type_format="CSV"),
     },
     entities={

--- a/components/shared_code/src/shared_data_model/sources/owasp_zap.py
+++ b/components/shared_code/src/shared_data_model/sources/owasp_zap.py
@@ -6,9 +6,9 @@ from shared_data_model.meta.entity import Color, Entity, EntityAttribute
 from shared_data_model.meta.source import Source
 from shared_data_model.parameters import (
     GitHubPersonalAccessToken,
-    MultipleChoiceWithAdditionParameter,
     MultipleChoiceWithDefaultsParameter,
     SingleChoiceParameter,
+    VariableURLRegExp,
     access_parameters,
 )
 
@@ -37,8 +37,7 @@ OWASP_ZAP = Source(
             api_values={"informational": "0", "low": "1", "medium": "2", "high": "3"},
             metrics=["security_warnings"],
         ),
-        "variable_url_regexp": MultipleChoiceWithAdditionParameter(
-            name="Parts of URLs to ignore (regular expressions)",
+        "variable_url_regexp": VariableURLRegExp(
             help="Parts of URLs to ignore can be specified by regular expression. The parts of URLs that match one "
             "or more of the regular expressions are removed. If, after applying the regular expressions, multiple "
             "warnings are the same only one is reported.",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -10,6 +10,12 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the tools/release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Added
+
+- When measuring violations with Axe-core, Axe HTML reporter or Axe CSV as source, allow for specifying regular expressions to remove variable parts of URLs. Closes [#12881](https://github.com/ICTU/quality-time/issues/12881).
+
 ## v5.50.1 - 2026-04-01
 
 ### Fixed


### PR DESCRIPTION
When measuring violations with Axe-core, Axe HTML reporter or Axe CSV as source, allow for specifying regular expressions to remove variable parts of URLs.

Closes #12881.