### PR TITLE
Improve security headers

### DIFF
--- a/components/frontend/Dockerfile
+++ b/components/frontend/Dockerfile
@@ -24,3 +24,4 @@ COPY --from=compile-image /home/frontend/dist /usr/share/nginx/html
 HEALTHCHECK CMD wget --spider http://0.0.0.0:"${FRONTEND_PORT:-5000}"/favicon.ico || exit 1
 
 COPY *.template /etc/nginx/templates/
+COPY security_headers.conf /etc/nginx/snippets/security_headers.conf

--- a/components/frontend/default.conf.template
+++ b/components/frontend/default.conf.template
@@ -8,10 +8,7 @@ server {
 
     location / {
         try_files       $uri /index.html =404;
-        add_header      Strict-Transport-Security "max-age=31536000;";
-        add_header      X-XSS-Protection "1; mode=block";
-        add_header      X-Content-Type-Options "nosniff";
-        add_header      X-Frame-Options "DENY";
+        include         /etc/nginx/snippets/security_headers.conf;
         add_header      Cache-Control "no-store";
     }
 }

--- a/components/frontend/security_headers.conf
+++ b/components/frontend/security_headers.conf
@@ -1,0 +1,7 @@
+add_header Strict-Transport-Security    "max-age=31536000; includeSubDomains";
+add_header Referrer-Policy              "strict-origin-when-cross-origin";
+add_header Cross-Origin-Opener-Policy   "same-origin";
+add_header Cross-Origin-Resource-Policy "same-origin";
+add_header Permissions-Policy           "geolocation=(), camera=(), microphone=()";
+add_header X-Content-Type-Options       "nosniff";
+add_header X-Frame-Options              "DENY";

--- a/components/proxy/Dockerfile
+++ b/components/proxy/Dockerfile
@@ -18,6 +18,7 @@ ENV API_SERVER_PORT=5001
 
 COPY --from=compile-image /usr/sbin/nginx /usr/sbin/nginx
 COPY *.template /etc/nginx/templates/
+COPY security_headers.conf /etc/nginx/snippets/security_headers.conf
 
 # Use the Shell form of CMD instead of the Exec form so the environment variable is substituted
 # hadolint ignore=DL3025

--- a/components/proxy/default.conf.template
+++ b/components/proxy/default.conf.template
@@ -5,10 +5,7 @@ server {
     access_log      off;
 
     location /api/internal/nr_measurements {
-        add_header          Strict-Transport-Security "max-age=31536000;";
-        add_header          X-XSS-Protection "1; mode=block";
-        add_header          X-Content-Type-Options "nosniff";
-        add_header          X-Frame-Options "DENY";
+        include             /etc/nginx/snippets/security_headers.conf;
         gzip                off;
         proxy_http_version  1.1;
         proxy_read_timeout  24h;
@@ -16,34 +13,22 @@ server {
         proxy_pass          http://${API_SERVER_HOST}:${API_SERVER_PORT}/api/internal/nr_measurements;
     }
     location /api/internal/datamodel {
-        add_header          Strict-Transport-Security "max-age=31536000;";
-        add_header          X-XSS-Protection "1; mode=block";
-        add_header          X-Content-Type-Options "nosniff";
-        add_header          X-Frame-Options "DENY";
+        include             /etc/nginx/snippets/security_headers.conf;
         add_header          Cache-Control "no-cache";
         proxy_pass          http://${API_SERVER_HOST}:${API_SERVER_PORT}/api/internal/datamodel;
     }
     location /api/internal/logo {
-        add_header          Strict-Transport-Security "max-age=31536000;";
-        add_header          X-XSS-Protection "1; mode=block";
-        add_header          X-Content-Type-Options "nosniff";
-        add_header          X-Frame-Options "DENY";
+        include             /etc/nginx/snippets/security_headers.conf;
         add_header          Cache-Control "no-cache";
         proxy_pass          http://${API_SERVER_HOST}:${API_SERVER_PORT}/api/internal/logo;
     }
     location /api {
-        add_header          Strict-Transport-Security "max-age=31536000;";
-        add_header          X-XSS-Protection "1; mode=block";
-        add_header          X-Content-Type-Options "nosniff";
-        add_header          X-Frame-Options "DENY";
+        include             /etc/nginx/snippets/security_headers.conf;
         add_header          Cache-Control "no-store";
         proxy_pass          http://${API_SERVER_HOST}:${API_SERVER_PORT}/api;
     }
     location / {
-        add_header          Strict-Transport-Security "max-age=31536000;";
-        add_header          X-XSS-Protection "1; mode=block";
-        add_header          X-Content-Type-Options "nosniff";
-        add_header          X-Frame-Options "DENY";
+        include             /etc/nginx/snippets/security_headers.conf;
         add_header          Cache-Control "no-store";
         proxy_pass          http://${FRONTEND_HOST}:${FRONTEND_PORT}/;
     }

--- a/components/proxy/security_headers.conf
+++ b/components/proxy/security_headers.conf
@@ -1,0 +1,7 @@
+add_header Strict-Transport-Security    "max-age=31536000; includeSubDomains";
+add_header Referrer-Policy              "strict-origin-when-cross-origin";
+add_header Cross-Origin-Opener-Policy   "same-origin";
+add_header Cross-Origin-Resource-Policy "same-origin";
+add_header Permissions-Policy           "geolocation=(), camera=(), microphone=()";
+add_header X-Content-Type-Options       "nosniff";
+add_header X-Frame-Options              "DENY";


### PR DESCRIPTION
- Remove X-XSS-Protection as recommended by OWASP (https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-xss-protection).
- Add includeSubDomains to Strict-Transport-Security as recommended by OWASP (https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html#examples).