### PR TITLE
Ignore notification destinations without webhook

### DIFF
--- a/components/notifier/src/strategies/notification_strategy.py
+++ b/components/notifier/src/strategies/notification_strategy.py
@@ -38,6 +38,7 @@ class NotificationFinder:
                     [
                         Notification(report, destination.get("report_url", "").strip("/"), notable_metrics, destination)
                         for destination in destinations
+                        if destination["webhook"]
                     ],
                 )
         return notifications

--- a/components/notifier/tests/strategies/test_notification_strategy.py
+++ b/components/notifier/tests/strategies/test_notification_strategy.py
@@ -49,7 +49,11 @@ class StrategiesTests(unittest.TestCase):
                 "title": "Title",
                 "subjects": {SUBJECT_ID: {"metrics": {METRIC_ID: self.red_metric}, "type": "software"}},
                 "notification_destinations": {
-                    "destination_uuid": {"name": "destination", "report_url": "https://report"}
+                    "destination_uuid": {
+                        "name": "destination",
+                        "report_url": "https://report",
+                        "webhook": "https://xxxxx.webhook.office.com/xxxxxxxxx",
+                    }
                 },
             },
         ]
@@ -175,10 +179,13 @@ class StrategiesTests(unittest.TestCase):
         report2 = {
             "title": "Title",
             "report_uuid": REPORT_ID2,
-            "webhook": "webhook",
             "subjects": {SUBJECT_ID: subject2},
             "notification_destinations": {
-                NOTIFICATION_DESTINATION_ID: {"report_url": "https://report2", "name": "destination2"},
+                NOTIFICATION_DESTINATION_ID: {
+                    "report_url": "https://report2",
+                    "name": "destination2",
+                    "webhook": "https://xxxxx.webhook.office.com/xxxxxxxxx",
+                },
             },
         }
         self.reports.append(Report({}, report2))
@@ -203,6 +210,13 @@ class StrategiesTests(unittest.TestCase):
     def test_no_notification_destinations_configured(self):
         """Test that no notification is to be sent if there are no configurations in notification destinations."""
         self.reports[0]["notification_destinations"] = {}
+        self.assertEqual([], self.get_notifications())
+
+    def test_notification_destination_without_webhook(self):
+        """Test that no notification is to be sent if there are no notification destinations with a webhook."""
+        self.reports[0]["notification_destinations"] = {
+            "destination_uuid": {"name": "destination", "report_url": "https://report"}
+        }
         self.assertEqual([], self.get_notifications())
 
     def test_no_notification_destinations_in_json(self):

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't attempt to send notifications to notification destinations without a webhook. Fixes [#12906](https://github.com/ICTU/quality-time/issues/12906).
+
 ### Added
 
 - Document what data is preserved when copying or moving subjects, metrics, and sources. Closes [#6337](https://github.com/ICTU/quality-time/issues/6337).


### PR DESCRIPTION
Don't attempt to send notifications to notification destinations without a webhook.

Fixes #12906.