### PR TITLE
Fix warning when running application tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,10 +68,11 @@ jobs:
           export PROXY_PORT=8080
           export QUALITY_TIME_VERSION=v5.51.0
           export COMPOSE_PATH_SEPARATOR=':'
+          export COLUMNS=${COLUMNS:-120}
           export COMPOSE_FILE=docker/docker-compose.yml:docker/docker-compose.ci.yml
-          docker compose build && docker compose up -d
+          docker compose --progress quiet build && docker compose up -d
           docker ps
-          docker run -it -w `pwd` -v `pwd`:`pwd` --network=container:quality-time-www-1 \
+          docker run --quiet -it -w `pwd` -v `pwd`:`pwd` --network=container:quality-time-www-1 \
             ghcr.io/astral-sh/uv:python3.14-bookworm tests/application_tests/test.sh
           docker ps
           docker compose logs > build/containers.log

--- a/.github/workflows/application-tests.yml
+++ b/.github/workflows/application-tests.yml
@@ -19,11 +19,12 @@ jobs:
           QUALITY_TIME_VERSION: v5.51.0
           ENV: ci
           PROXY_PORT: 8080
+          COLUMNS: 120
         run: |
           mkdir -p build
-          docker compose --file docker/docker-compose.yml --file docker/docker-compose.ci.yml \
+          docker compose --progress quiet --file docker/docker-compose.yml --file docker/docker-compose.ci.yml \
             --project-name quality-time up --build --detach --wait
-          docker run -t -w `pwd` -v `pwd`:`pwd` --network=container:quality-time-www-1 \
+          docker run --quiet -t -w `pwd` -v `pwd`:`pwd` --network=container:quality-time-www-1 \
             ghcr.io/astral-sh/uv:python3.14-bookworm tests/application_tests/test.sh
       - name: Save container logs
         if: always()

--- a/tests/application_tests/test.sh
+++ b/tests/application_tests/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 cd tests/application_tests
-uv sync --locked --all-groups
+uv sync --no-progress --quiet --locked --all-groups
 .venv/bin/python -m unittest discover --start-directory .


### PR DESCRIPTION
Prevent Docker Compose warning about unset `COLUMNS` variable when running application tests in CI.

Fixes #12951.