### PR TITLE
Improve frontend unit test performance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
+    resource_class: large
     parallelism: 11
     steps:
       - checkout

--- a/components/frontend/vite.config.ts
+++ b/components/frontend/vite.config.ts
@@ -29,6 +29,13 @@ export default defineConfig({
             reporter: ["text", "lcov", "html"],
             skipFull: true,
         },
+        deps: {
+            optimizer: {
+                web: {
+                    enabled: true,
+                },
+            },
+        },
         environment: "jsdom",
         mockReset: true,
         setupFiles: "./src/setupTests.js",


### PR DESCRIPTION
- Enable Vitest's dependency pre-bundling optimizer (deps.optimizer.web) in the test configuration. This uses esbuild to bundle heavy dependencies (MUI, emotion, Victory, etc.) into single files before tests run, reducing the time spent resolving deep import trees during the import phase. Local test duration dropped from ~147s to ~76-82s.

Closes #12953.