### PR TITLE
Fix active "set next date" button

### DIFF
--- a/components/frontend/src/source/SourceParameter.jsx
+++ b/components/frontend/src/source/SourceParameter.jsx
@@ -207,7 +207,7 @@ export function SourceParameter({
                     timezone="default"
                 />
                 <Button
-                    disabled={!value || Number.parseInt(source.parameters?.["recurrence_frequency"]) === 0}
+                    disabled={disabled || !value || Number.parseInt(source.parameters?.["recurrence_frequency"]) === 0}
                     onClick={() => {
                         setSourceParameter(
                             sourceUuid,

--- a/components/frontend/src/source/SourceParameter.test.jsx
+++ b/components/frontend/src/source/SourceParameter.test.jsx
@@ -50,6 +50,7 @@ function renderSourceParameter({
     parameterKey = "key1",
     parameterValue = "https://test",
     parameterValues = [],
+    permissions = [EDIT_REPORT_PERMISSION],
     placeholder = "placeholder",
     recurrenceFrequency = null,
     recurrenceOffset = null,
@@ -58,7 +59,7 @@ function renderSourceParameter({
 }) {
     return render(
         <LocalizationProvider dateAdapter={AdapterDayjs}>
-            <PermissionsContext value={[EDIT_REPORT_PERMISSION]}>
+            <PermissionsContext value={permissions}>
                 <SourceParameter
                     parameter={parameter}
                     parameterKey={parameterKey}
@@ -191,6 +192,17 @@ it("cannot set the next date if the recurrence frequency has not been set", asyn
         parameter: { name: "Date", type: "date" },
         parameterValue: "2025-10-10",
         recurrenceFrequency: 0,
+    })
+    clickButton("Set next date")
+    expectNoFetch()
+})
+
+it("cannot set the next date if the user is not logged in", async () => {
+    renderSourceParameter({
+        parameter: { name: "Date", type: "date" },
+        parameterValue: "2025-10-10",
+        permissions: [],
+        recurrenceFrequency: "year",
     })
     clickButton("Set next date")
     expectNoFetch()

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ## [Unreleased]
 
+### Fixed
+
+- Deactivate the "set next date" button of calendar sources if the user is not logged in. Fixes [#12955](https://github.com/ICTU/quality-time/issues/12955).
+
 ### Added
 
 - Add a 'manual version' source type for metrics that measure versions. Closes [#12423](https://github.com/ICTU/quality-time/issues/12423).


### PR DESCRIPTION
Deactivate the "set next date" button of calendar sources if the user is not logged in.

Fixes #12955.