### PR TITLE
Filter outdated npm dependencies

### DIFF
--- a/components/collector/src/source_collectors/npm/dependencies.py
+++ b/components/collector/src/source_collectors/npm/dependencies.py
@@ -2,6 +2,8 @@
 
 from typing import TypedDict, cast
 
+from packaging.version import InvalidVersion, Version
+
 from base_collectors import JSONFileSourceCollector
 from collector_utilities.type import JSON, JSONDict
 from model import Entities, Entity
@@ -43,3 +45,19 @@ class NpmDependencies(JSONFileSourceCollector):
             wanted=version.get("wanted", "unknown"),
             latest=version.get("latest", "unknown"),
         )
+
+    def _include_entity(self, entity: Entity) -> bool:
+        """Return whether the entity's update type is in the selected updates to include."""
+        updates_to_include = self._parameter("updates_to_include")
+        try:
+            current = Version(entity["current"])
+            latest = Version(entity["latest"])
+        except InvalidVersion:
+            return True  # If versions can't be parsed as semver, don't filter the entity out
+        if latest.major > current.major:
+            update_type = "major"
+        elif latest.minor > current.minor:
+            update_type = "minor"
+        else:
+            update_type = "patch"
+        return update_type in updates_to_include

--- a/components/collector/tests/source_collectors/npm/test_dependencies.py
+++ b/components/collector/tests/source_collectors/npm/test_dependencies.py
@@ -9,6 +9,14 @@ class NpmDependenciesTest(SourceCollectorTestCase):
     SOURCE_TYPE = "npm"
     METRIC_TYPE = "dependencies"
 
+    def create_npm_json(self):
+        """Create a npm JSON fixture."""
+        return {
+            "zod": {"current": "3.25.76", "wanted": "3.25.76", "latest": "4.2.1", "location": ""},
+            "react-dom": {"current": "16.12.0", "wanted": "16.13.1", "latest": "16.13.1", "location": ""},
+            "lodash": {"current": "4.17.20", "wanted": "4.17.21", "latest": "4.17.21", "location": ""},
+        }
+
     async def test_dependencies(self):
         """Test that the number of dependencies is returned."""
         npm_json = {
@@ -54,3 +62,60 @@ class NpmDependenciesTest(SourceCollectorTestCase):
         ]
         response = await self.collect(get_request_json_return_value=npm_json)
         self.assert_measurement(response, value="2", total="2", entities=expected_entities)
+
+    async def test_filter_major_updates_only(self):
+        """Test that only major updates are included when the user selects 'major'."""
+        self.set_source_parameter("updates_to_include", ["major"])
+        expected_entities = [
+            {"key": "zod@3_25_76", "name": "zod", "current": "3.25.76", "wanted": "3.25.76", "latest": "4.2.1"},
+        ]
+        response = await self.collect(get_request_json_return_value=self.create_npm_json())
+        self.assert_measurement(response, value="1", total="3", entities=expected_entities)
+
+    async def test_filter_minor_updates_only(self):
+        """Test that only minor updates are included when the user selects 'minor'."""
+        self.set_source_parameter("updates_to_include", ["minor"])
+        expected_entities = [
+            {
+                "key": "react-dom@16_12_0",
+                "name": "react-dom",
+                "current": "16.12.0",
+                "wanted": "16.13.1",
+                "latest": "16.13.1",
+            },
+        ]
+        response = await self.collect(get_request_json_return_value=self.create_npm_json())
+        self.assert_measurement(response, value="1", total="3", entities=expected_entities)
+
+    async def test_filter_patch_updates_only(self):
+        """Test that only patch updates are included when the user selects 'patch'."""
+        self.set_source_parameter("updates_to_include", ["patch"])
+        expected_entities = [
+            {
+                "key": "lodash@4_17_20",
+                "name": "lodash",
+                "current": "4.17.20",
+                "wanted": "4.17.21",
+                "latest": "4.17.21",
+            },
+        ]
+        response = await self.collect(get_request_json_return_value=self.create_npm_json())
+        self.assert_measurement(response, value="1", total="3", entities=expected_entities)
+
+    async def test_non_semver_version_is_kept(self):
+        """Test that dependencies with non-semver versions are not filtered out."""
+        self.set_source_parameter("updates_to_include", ["major"])
+        npm_json = {
+            "weird-pkg": {"current": "not-a-version", "wanted": "not-a-version", "latest": "latest", "location": ""},
+        }
+        expected_entities = [
+            {
+                "key": "weird-pkg@not-a-version",
+                "name": "weird-pkg",
+                "current": "not-a-version",
+                "wanted": "not-a-version",
+                "latest": "latest",
+            },
+        ]
+        response = await self.collect(get_request_json_return_value=npm_json)
+        self.assert_measurement(response, value="1", total="1", entities=expected_entities)

--- a/components/shared_code/src/shared_data_model/sources/npm.py
+++ b/components/shared_code/src/shared_data_model/sources/npm.py
@@ -4,7 +4,7 @@ from pydantic import HttpUrl
 
 from shared_data_model.meta.entity import Entity, EntityAttribute
 from shared_data_model.meta.source import Source
-from shared_data_model.parameters import access_parameters
+from shared_data_model.parameters import MultipleChoiceWithDefaultsParameter, access_parameters
 
 NPM = Source(
     name="npm",
@@ -13,22 +13,34 @@ NPM = Source(
         "dependencies": """````{tip}
 To generate the list of outdated dependencies, run:
 ```bash
-npm outdated --all --long --json > npm-outdated.json
+npm outdated --long --json > npm-outdated.json
 ```
 To run `npm outdated` with Docker, use:
 ```bash
-docker run --rm -v "$SRC":/work -w /work node:lts npm outdated --all --long --json > outdated.json"
+docker run --rm -v "$SRC":/work -w /work node:lts npm outdated --long --json > outdated.json"
 ```
 ````
 """,
     },
     url=HttpUrl("https://docs.npmjs.com/"),
-    parameters=access_parameters(
-        ["dependencies"],
-        source_type="npm 'outdated' report",
-        source_type_format="JSON",
-        kwargs={"url": {"help_url": HttpUrl("https://docs.npmjs.com/cli-commands/outdated.html")}},
-    ),
+    parameters={
+        "updates_to_include": MultipleChoiceWithDefaultsParameter(
+            name="Updates to include",
+            placeholder="all updates",
+            help="Limit which updates to include based on the semantic version difference between the current and "
+            "latest version. Select 'major' to include updates where the major version changes, 'minor' to include "
+            "updates where the major version stays the same but the minor version changes, and 'patch' to include "
+            "updates where the major and minor versions stay the same but the patch version changes.",
+            values=["major", "minor", "patch"],
+            metrics=["dependencies"],
+        ),
+        **access_parameters(
+            ["dependencies"],
+            source_type="npm 'outdated' report",
+            source_type_format="JSON",
+            kwargs={"url": {"help_url": HttpUrl("https://docs.npmjs.com/cli-commands/outdated.html")}},
+        ),
+    },
     entities={
         "dependencies": Entity(
             name="dependency",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,6 +19,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Added
 
 - Add a 'manual version' source type for metrics that measure versions. Closes [#12423](https://github.com/ICTU/quality-time/issues/12423).
+- When measuring outdated dependencies with npm as source, allow for filtering major, minor, or patch updates. Closes [#12441](https://github.com/ICTU/quality-time/issues/12441).
 - When importing a report with credentials that are encrypted for another Quality-time instance, import the report without credentials and warn the user via a toast message that the credentials have been ignored. Closes [#12904](https://github.com/ICTU/quality-time/issues/12904).
 
 ## v5.51.0 - 2026-04-10


### PR DESCRIPTION
When measuring outdated dependencies with npm as source, allow for filtering on major, minor, or patch updates.

Closes #12441.