### PR TITLE
12559 helm chart proxy

### DIFF
--- a/helm/templates/api_server.yaml
+++ b/helm/templates/api_server.yaml
@@ -61,6 +61,10 @@ spec:
                   optional: true
             - name: LDAP_SEARCH_FILTER  # override to make sure that double dollar signs are processed like in docker
               value: {{ .Values.api_server.env.LDAP_SEARCH_FILTER }}
+          {{- if .Values.api_server.extraVolumeMounts }}
+          volumeMounts:
+            {{- .Values.api_server.extraVolumeMounts | nindent 12 }}
+          {{- end }}
 {{- with .Values.api_server.resources }}
           resources: {{- toYaml . | nindent 12 }}
 {{- end }}
@@ -69,6 +73,9 @@ spec:
               drop:
                 - ALL
       restartPolicy: Always
+      {{- if .Values.api_server.extraVolumes }}
+      {{- .Values.api_server.extraVolumes | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm/templates/api_server.yaml
+++ b/helm/templates/api_server.yaml
@@ -63,7 +63,7 @@ spec:
               value: {{ .Values.api_server.env.LDAP_SEARCH_FILTER }}
           {{- if .Values.api_server.extraVolumeMounts }}
           volumeMounts:
-            {{- .Values.api_server.extraVolumeMounts | nindent 12 }}
+            {{- toYaml .Values.api_server.extraVolumeMounts | nindent 12 }}
           {{- end }}
 {{- with .Values.api_server.resources }}
           resources: {{- toYaml . | nindent 12 }}
@@ -74,7 +74,8 @@ spec:
                 - ALL
       restartPolicy: Always
       {{- if .Values.api_server.extraVolumes }}
-      {{- .Values.api_server.extraVolumes | nindent 8 }}
+      volumes:
+        {{- toYaml .Values.api_server.extraVolumes | nindent 8 }}
       {{- end }}
 ---
 apiVersion: v1

--- a/helm/templates/api_server.yaml
+++ b/helm/templates/api_server.yaml
@@ -61,19 +61,15 @@ spec:
                   optional: true
             - name: LDAP_SEARCH_FILTER  # override to make sure that double dollar signs are processed like in docker
               value: {{ .Values.api_server.env.LDAP_SEARCH_FILTER }}
-          {{- if .Values.api_server.extraVolumeMounts }}
           securityContext:
             {{- toYaml .Values.api_server.securityContext | nindent 12 }}
+          {{- if .Values.api_server.extraVolumeMounts }}
           volumeMounts:
             {{- toYaml .Values.api_server.extraVolumeMounts | nindent 12 }}
           {{- end }}
 {{- with .Values.api_server.resources }}
           resources: {{- toYaml . | nindent 12 }}
 {{- end }}
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
       restartPolicy: Always
       {{- if .Values.api_server.extraVolumes }}
       volumes:

--- a/helm/templates/api_server.yaml
+++ b/helm/templates/api_server.yaml
@@ -62,6 +62,8 @@ spec:
             - name: LDAP_SEARCH_FILTER  # override to make sure that double dollar signs are processed like in docker
               value: {{ .Values.api_server.env.LDAP_SEARCH_FILTER }}
           {{- if .Values.api_server.extraVolumeMounts }}
+          securityContext:
+            {{- toYaml .Values.api_server.securityContext | nindent 12 }}
           volumeMounts:
             {{- toYaml .Values.api_server.extraVolumeMounts | nindent 12 }}
           {{- end }}

--- a/helm/templates/collector.yaml
+++ b/helm/templates/collector.yaml
@@ -49,9 +49,7 @@ spec:
           resources: {{- toYaml . | nindent 12 }}
 {{- end }}
           securityContext:
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.collector.securityContext | nindent 12 }}
       restartPolicy: Always
 ---
 apiVersion: v1

--- a/helm/templates/database.yaml
+++ b/helm/templates/database.yaml
@@ -57,14 +57,7 @@ spec:
           resources: {{- toYaml . | nindent 12 }}
 {{- end }}
           securityContext:
-            capabilities:
-              add:
-                - CHOWN
-                - DAC_OVERRIDE
-                - SETGID
-                - SETUID
-              drop:
-                - ALL
+            {{- toYaml .Values.database.securityContext | nindent 12 }}
           volumeMounts:
             - mountPath: /data/db
               name: {{ .Release.Name }}-{{ template "database_name" . }}

--- a/helm/templates/frontend.yaml
+++ b/helm/templates/frontend.yaml
@@ -34,9 +34,7 @@ spec:
           resources: {{- toYaml . | nindent 12 }}
 {{- end }}
           securityContext:
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.notifier.securityContext | nindent 12 }}
       restartPolicy: Always
 ---
 apiVersion: v1

--- a/helm/templates/notifier.yaml
+++ b/helm/templates/notifier.yaml
@@ -49,9 +49,7 @@ spec:
           resources: {{- toYaml . | nindent 12 }}
 {{- end }}
           securityContext:
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.notifier.securityContext | nindent 12 }}
       restartPolicy: Always
 ---
 apiVersion: v1

--- a/helm/templates/renderer.yaml
+++ b/helm/templates/renderer.yaml
@@ -39,9 +39,7 @@ spec:
           resources: {{- toYaml . | nindent 12 }}
 {{- end }}
           securityContext:
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.renderer.securityContext | nindent 12 }}
       restartPolicy: Always
 ---
 apiVersion: v1

--- a/helm/templates/www.yaml
+++ b/helm/templates/www.yaml
@@ -100,14 +100,6 @@ spec:
       http:
         {{- if .Values.www.directlyToService }}
         paths:
-          - path: /
-            pathType: {{ .Values.www.ingress.pathType }}
-            backend:
-              service:
-                name: {{ .Release.Name }}-{{ template "frontend_name" . }}
-                port:
-                  number: 5000
-        paths:
           - path: /api
             pathType: {{ .Values.www.ingress.pathType }}
             backend:
@@ -115,6 +107,13 @@ spec:
                 name: {{ .Release.Name }}-{{ template "api_server_name" . }}
                 port:
                   number: 5001
+          - path: /
+            pathType: {{ .Values.www.ingress.pathType }}
+            backend:
+              service:
+                name: {{ .Release.Name }}-{{ template "frontend_name" . }}
+                port:
+                  number: 5000
         {{- else }}
         paths:
           - path: /

--- a/helm/templates/www.yaml
+++ b/helm/templates/www.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if not .Values.www.directlyToService }}
+{{- if .Values.www.deployProxy }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -55,7 +55,7 @@ spec:
       restartPolicy: Always
 {{- end }}
 ---
-{{- if not .Values.www.directlyToService }}
+{{- if .Values.www.deployProxy }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -98,7 +98,16 @@ spec:
     {{- if .Values.www.ingress.hostname }}
     - host: {{ .Values.www.ingress.hostname | quote }}
       http:
-        {{- if .Values.www.directlyToService }}
+        {{- if .Values.www.deployProxy }}
+        paths:
+          - path: /
+            pathType: {{ .Values.www.ingress.pathType }}
+            backend:
+              service:
+                name: {{ .Release.Name }}-{{ template "www_name" . }}
+                port:
+                  number: 8080
+        {{- else }}
         paths:
           - path: /api
             pathType: {{ .Values.www.ingress.pathType }}
@@ -114,15 +123,6 @@ spec:
                 name: {{ .Release.Name }}-{{ template "frontend_name" . }}
                 port:
                   number: 5000
-        {{- else }}
-        paths:
-          - path: /
-            pathType: {{ .Values.www.ingress.pathType }}
-            backend:
-              service:
-                name: {{ .Release.Name }}-{{ template "www_name" . }}
-                port:
-                  number: 8080
         {{- end }}
     {{- end }}
   {{- if .Values.www.ingress.tls }}

--- a/helm/templates/www.yaml
+++ b/helm/templates/www.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if not .Values.www.directlyToService }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -52,7 +53,9 @@ spec:
               drop:
                 - ALL
       restartPolicy: Always
+{{- end }}
 ---
+{{- if not .Values.www.directlyToService }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -72,8 +75,9 @@ spec:
       port: 8080
       targetPort: 8080
   sessionAffinity: None
+{{- end }}
 ---
-{{- if .Values.www.ingress -}}
+{{ if .Values.www.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -82,27 +86,56 @@ metadata:
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: {{ template "www_name" . }}
+  {{- with .Values.www.ingress.annotations }}
   annotations:
-    {{- range $key, $value := .Values.www.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  ingressClassName: {{ .Values.www.ingress.ingressClassName }}
+  {{- if .Values.www.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.www.ingress.ingressClassName | quote }}
+  {{- end }}
   rules:
-    - host: {{ printf "%s" $.Values.www.ingress.hostname }}
+    {{- if .Values.www.ingress.hostname }}
+    - host: {{ .Values.www.ingress.hostname | quote }}
       http:
+        {{- if .Values.www.directlyToService }}
         paths:
-          - backend:
+          - path: /
+            pathType: {{ .Values.www.ingress.pathType }}
+            backend:
+              service:
+                name: {{ .Release.Name }}-{{ template "frontend_name" . }}
+                port:
+                  number: 5000
+        paths:
+          - path: /api
+            pathType: {{ .Values.www.ingress.pathType }}
+            backend:
+              service:
+                name: {{ .Release.Name }}-{{ template "api_server_name" . }}
+                port:
+                  number: 5001
+        {{- else }}
+        paths:
+          - path: /
+            pathType: {{ .Values.www.ingress.pathType }}
+            backend:
               service:
                 name: {{ .Release.Name }}-{{ template "www_name" . }}
                 port:
                   number: 8080
-            path: /
-            pathType: ImplementationSpecific
-{{- if .Values.www.ingress.tls }}
+        {{- end }}
+    {{- end }}
+  {{- if .Values.www.ingress.tls }}
   tls:
-{{ toYaml .Values.www.ingress.tls | indent 4 }}
-{{- end }}
+    {{- range .Values.www.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 ---
 apiVersion: v1

--- a/helm/templates/www.yaml
+++ b/helm/templates/www.yaml
@@ -44,14 +44,7 @@ spec:
           resources: {{- toYaml . | nindent 12 }}
 {{- end }}
           securityContext:
-            capabilities:
-              add:
-                - CHOWN
-                - SETGID
-                - SETUID
-                - NET_BIND_SERVICE
-              drop:
-                - ALL
+            {{- toYaml .Values.www.securityContext | nindent 12 }}
       restartPolicy: Always
 {{- end }}
 ---
@@ -86,16 +79,16 @@ metadata:
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: {{ template "www_name" . }}
-  {{- with .Values.www.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- range $key, $value := .Values.www.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   {{- if .Values.www.ingress.ingressClassName }}
   ingressClassName: {{ .Values.www.ingress.ingressClassName | quote }}
   {{- end }}
+  {{- if .Values.www.ingress.hostname }}
   rules:
-    {{- if .Values.www.ingress.hostname }}
     - host: {{ .Values.www.ingress.hostname | quote }}
       http:
         {{- if .Values.www.deployProxy }}
@@ -124,16 +117,10 @@ spec:
                 port:
                   number: 5000
         {{- end }}
-    {{- end }}
+  {{- end }}
   {{- if .Values.www.ingress.tls }}
   tls:
-    {{- range .Values.www.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+    {{ toYaml .Values.www.ingress.tls | indent 4 }}
   {{- end }}
 {{- end }}
 ---

--- a/helm/templates/www.yaml
+++ b/helm/templates/www.yaml
@@ -70,7 +70,7 @@ spec:
   sessionAffinity: None
 {{- end }}
 ---
-{{ if .Values.www.ingress.enabled -}}
+{{- if .Values.www.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -53,8 +53,8 @@ renderer:
     TZ: "Europe/Amsterdam"
 
 www:
-  # -- When www.directlyToService is true the quality-time_proxy is not used and ingress is pointed directly to the backend api and frontend.
-  directlyToService: false
+  # -- When www.deployProxy is false the quality-time_proxy is not used and ingress is pointed directly to the backend api and frontend.
+  deployProxy: true
   image:
     repository: "ictu/quality-time_proxy"
   ingress:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,6 +4,8 @@ secrets:
   ldapCredential: "quality-time-ldap-secret"
 
 api_server:
+  extraVolumes: []
+  extraVolumeMounts: []
   image:
     repository: "ictu/quality-time_api_server"
   env:
@@ -16,6 +18,15 @@ collector:
     repository: "ictu/quality-time_collector"
 
 database:
+  securityContext:
+    capabilities:
+      add:
+        - CHOWN
+        - DAC_OVERRIDE
+        - SETGID
+        - SETUID
+      drop:
+        - ALL
   image:
     repository: "ictu/quality-time_database"
   resources:
@@ -42,5 +53,17 @@ renderer:
     TZ: "Europe/Amsterdam"
 
 www:
+  # -- When www.directlyToService is true the quality-time_proxy is not used and ingress is point directly to the backend api and frontend.
+  directlyToService: false
   image:
     repository: "ictu/quality-time_proxy"
+  ingress:
+    enabled: false
+    ingressClassName: ""
+    hostname: ""
+    pathType: "ImplementationSpecific"
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+    annotations: {}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -53,7 +53,7 @@ renderer:
     TZ: "Europe/Amsterdam"
 
 www:
-  # -- When www.directlyToService is true the quality-time_proxy is not used and ingress is point directly to the backend api and frontend.
+  # -- When www.directlyToService is true the quality-time_proxy is not used and ingress is pointed directly to the backend api and frontend.
   directlyToService: false
   image:
     repository: "ictu/quality-time_proxy"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,10 @@ secrets:
   ldapCredential: "quality-time-ldap-secret"
 
 api_server:
-  securityContext: {}
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
   extraVolumes: []
 #    - name: cert-config-map
 #      configMap:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,8 +4,16 @@ secrets:
   ldapCredential: "quality-time-ldap-secret"
 
 api_server:
+  securityContext: {}
   extraVolumes: []
+#    - name: cert-config-map
+#      configMap:
+#        name: cert-config-map
   extraVolumeMounts: []
+#    - name: cert-config-map
+#      subPath: ca-certificates.crt
+#      mountPath: "/etc/ssl/certs/ca-certificates.crt"
+#      readOnly: true
   image:
     repository: "ictu/quality-time_api_server"
   env:
@@ -14,6 +22,10 @@ api_server:
     LDAP_SEARCH_FILTER: "(|(uid=$$username)(cn=$$username))"
 
 collector:
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
   image:
     repository: "ictu/quality-time_collector"
 
@@ -38,14 +50,26 @@ database:
       memory: "1Gi"
 
 frontend:
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
   image:
     repository: "ictu/quality-time_frontend"
 
 notifier:
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
   image:
     repository: "ictu/quality-time_notifier"
 
 renderer:
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
   image:
     repository: "ictu/quality-time_renderer"
   env:
@@ -53,6 +77,15 @@ renderer:
     TZ: "Europe/Amsterdam"
 
 www:
+  securityContext:
+    capabilities:
+      add:
+        - CHOWN
+        - SETGID
+        - SETUID
+        - NET_BIND_SERVICE
+      drop:
+        - ALL
   # -- When www.deployProxy is false the quality-time_proxy is not used and ingress is pointed directly to the backend api and frontend.
   deployProxy: true
   image:
@@ -62,8 +95,4 @@ www:
     ingressClassName: ""
     hostname: ""
     pathType: "ImplementationSpecific"
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
     annotations: {}


### PR DESCRIPTION
In this pull request, I implemented the necessary changes for #12559 and #12560.

- The www.deployProxy property has been added. When set to `false`, the proxy is bypassed, allowing direct access to the API and frontend 
- An option has been included to add extra volumes to the `api_server`.
- An option to modify the `securityContext` in the database has been introduced.

Closes #12559. Closes #12560.

--@tijder