### PR TITLE
Hide ingnored measurement entities per metric

### DIFF
--- a/components/frontend/src/app_ui_settings.js
+++ b/components/frontend/src/app_ui_settings.js
@@ -34,7 +34,8 @@ export function useHideEmptyColumnsURLSearchQuery(reportUuid) {
 }
 
 export function useHideIgnoredEntitiesURLSearchQuery(reportUuid) {
-    return useBooleanURLSearchQuery(urlSearchQueryKey("hide_ignored_entities", reportUuid))
+    // Stores the set of metric UUIDs for which entities marked as fixed, false positive, or won't fix are hidden.
+    return useArrayURLSearchQuery(urlSearchQueryKey("hide_ignored_entities", reportUuid))
 }
 
 export function useHiddenTagsURLSearchQuery(reportUuid) {

--- a/components/frontend/src/header_footer/buttons/ResetSettingsButton.test.jsx
+++ b/components/frontend/src/header_footer/buttons/ResetSettingsButton.test.jsx
@@ -33,7 +33,7 @@ it("has no accessibility violations", async () => {
 
 it("resets the settings", async () => {
     history.push(
-        "?date_interval=2&date_order=ascending&hidden_columns=comment&hide_ignored_entities=true&hidden_tags=tag&" +
+        "?date_interval=2&date_order=ascending&hidden_columns=comment&hide_ignored_entities=metric_uuid&hidden_tags=tag&" +
             "metrics_to_hide=no_action_required&nr_dates=2&show_issue_creation_date=true&show_issue_summary=true&" +
             "show_issue_update_date=true&show_issue_due_date=true&show_issue_release=true&show_issue_sprint=true&" +
             "sort_column=status&sort_direction=descending&expanded=tab:0&hidden_cards=tags",

--- a/components/frontend/src/hooks/url_search_query.js
+++ b/components/frontend/src/hooks/url_search_query.js
@@ -113,9 +113,7 @@ export function useIntegerMappingURLSearchQuery(key) {
 export function useBooleanURLSearchQuery(key) {
     const parsedValue = parseURLSearchQuery().get(key) === "true"
     const [value, setValue] = useState(parsedValue)
-    let hook = createHook(key, value, false, setValue)
-    hook.toggle = () => hook.set(!value)
-    return hook
+    return createHook(key, value, false, setValue)
 }
 
 export function useIntegerURLSearchQuery(key, defaultValue) {

--- a/components/frontend/src/sharedPropTypes.js
+++ b/components/frontend/src/sharedPropTypes.js
@@ -87,7 +87,7 @@ export const settingsPropType = shape({
     dateOrder: sortDirectionURLSearchQueryPropType,
     expandedItems: stringsURLSearchQueryPropType,
     hiddenColumns: stringsURLSearchQueryPropType,
-    hideIgnoredEntities: boolURLSearchQueryPropType,
+    hideIgnoredEntities: stringsURLSearchQueryPropType,
     hiddenTags: stringsURLSearchQueryPropType,
     metricsToHide: metricsToHideURLSearchQueryPropType,
     nrDates: integerURLSearchQueryPropType,

--- a/components/frontend/src/source/SourceEntities.jsx
+++ b/components/frontend/src/source/SourceEntities.jsx
@@ -12,13 +12,12 @@ import {
     TableRow,
     Tooltip,
 } from "@mui/material"
-import { func, number, object, string } from "prop-types"
+import { bool, func, number, object, string } from "prop-types"
 import { useContext, useState } from "react"
 
 import { DataModelContext } from "../context/DataModel"
 import { zIndexInnerTableHeader } from "../defaults"
 import {
-    boolURLSearchQueryPropType,
     entityAttributePropType,
     entityAttributesPropType,
     entityAttributeTypePropType,
@@ -83,6 +82,7 @@ function sourceEntitiesHeaders(
     hideIgnoredEntities,
     metricEntities,
     nrIgnoredEntities,
+    toggleHideIgnoredEntities,
     sortProps,
 ) {
     function handleSort(column, columnType) {
@@ -93,7 +93,7 @@ function sourceEntitiesHeaders(
             sortProps.setSortColumn(column)
         }
     }
-    const action = hideIgnoredEntities.value ? "Show" : "Hide"
+    const action = hideIgnoredEntities ? "Show" : "Hide"
     const entityNameSingular = metricEntities.name
     const entityNamePlural = metricEntities.name_plural
     const entityNameOrNames = nrIgnoredEntities === 1 ? entityNameSingular : entityNamePlural
@@ -104,9 +104,9 @@ function sourceEntitiesHeaders(
             <TableCell sx={{ paddingRight: "6px" }}>
                 <Tooltip title={tooltip}>
                     <span /* https://mui.com/material-ui/react-tooltip/#disabled-elements */>
-                        <IconButton disabled={nrIgnoredEntities === 0} onClick={hideIgnoredEntities.toggle}>
+                        <IconButton disabled={nrIgnoredEntities === 0} onClick={toggleHideIgnoredEntities}>
                             <Badge badgeContent={nrIgnoredEntities} color={"entity_status_count_badge"} showZero>
-                                {hideIgnoredEntities.value ? <ShowIcon /> : <IgnoreIcon />}
+                                {hideIgnoredEntities ? <ShowIcon /> : <IgnoreIcon />}
                             </Badge>
                         </IconButton>
                     </span>
@@ -153,9 +153,10 @@ function sourceEntitiesHeaders(
 sourceEntitiesHeaders.propTypes = {
     columnsToHide: stringsPropType,
     entityAttributes: entityAttributesPropType,
-    hideIgnoredEntities: boolURLSearchQueryPropType,
+    hideIgnoredEntities: bool,
     metricEntities: object,
     nrIgnoredEntities: number,
+    toggleHideIgnoredEntities: func,
     sortProps: object,
 }
 
@@ -247,13 +248,14 @@ export function SourceEntities({ loading, measurements, metric, metricUuid, relo
     }
     const entities = sortedEntities(columnType, sortColumn, sortDirection, source)
     const columnsToHide = determineColumnsToHide(settings, source, entities)
+    const hideIgnoredEntities = settings.hideIgnoredEntities.includes(metricUuid)
     const rows = entities.map((entity) => (
         <SourceEntity
             columnsToHide={columnsToHide}
             entity={entity}
             entityAttributes={entityAttributes}
             entityName={metricEntities.name}
-            hideIgnoredEntities={settings.hideIgnoredEntities.value}
+            hideIgnoredEntities={hideIgnoredEntities}
             key={entity.key}
             metricUuid={metricUuid}
             reload={reload}
@@ -270,9 +272,10 @@ export function SourceEntities({ loading, measurements, metric, metricUuid, relo
     const headers = sourceEntitiesHeaders(
         columnsToHide,
         entityAttributes,
-        settings.hideIgnoredEntities,
+        hideIgnoredEntities,
         metricEntities,
         nrIgnoredEntities,
+        () => settings.hideIgnoredEntities.toggle(metricUuid),
         sortProps,
     )
     return (

--- a/components/frontend/src/source/SourceEntities.test.jsx
+++ b/components/frontend/src/source/SourceEntities.test.jsx
@@ -207,20 +207,20 @@ it("shows the hide ignored entities button with two ignored entities", async () 
 })
 
 it("shows the show ignored entities button", async () => {
-    history.push("?hide_ignored_entities=true")
+    history.push("?hide_ignored_entities=metric_uuid")
     const fixture = JSON.parse(JSON.stringify(sourceFixture))
     fixture.entity_user_data["2"].status_end_date = "3000-01-01"
     renderSourceEntities({ measurements: [{ sources: [fixture] }] })
     expectLabelText(/Show the 1 entity name that has been/)
 })
 
-it("hides ignored entities by storing the setting in the URL", async () => {
+it("hides ignored entities for the metric by storing the metric uuid in the URL", async () => {
     const fixture = JSON.parse(JSON.stringify(sourceFixture))
     fixture.entity_user_data["2"].status_end_date = "3000-01-01"
     renderSourceEntities({ measurements: [{ sources: [fixture] }] })
     const hideEntitiesTooltip = screen.getByLabelText(/Hide the 1 entity name that has been/)
     await userEvent.click(hideEntitiesTooltip.firstChild) // Get the button inside the tooltip
-    expectSearch("?hide_ignored_entities=true")
+    expectSearch("?hide_ignored_entities=metric_uuid")
 })
 
 async function expectColumnIsSortedCorrectly(header, ascending) {


### PR DESCRIPTION
Keep track of the hide ignored measurement entities setting per metric.

Completes #12976.