### PR TITLE
Keep track of measurement entity sorting

### DIFF
--- a/components/frontend/src/__fixtures__/fixtures.js
+++ b/components/frontend/src/__fixtures__/fixtures.js
@@ -5,6 +5,8 @@ import {
     resetSettings,
     useDateIntervalURLSearchQuery,
     useDateOrderURLSearchQuery,
+    useEntitySortColumnURLSearchQuery,
+    useEntitySortDirectionURLSearchQuery,
     useExpandedItemsSearchQuery,
     useHiddenCardsURLSearchQuery,
     useHiddenColumnsURLSearchQuery,
@@ -123,6 +125,8 @@ export function createTestableSettings() {
     return {
         dateInterval: testableQuery(useDateIntervalURLSearchQuery),
         dateOrder: testableQuery(useDateOrderURLSearchQuery),
+        entitySortColumn: testableQuery(useEntitySortColumnURLSearchQuery),
+        entitySortDirection: testableQuery(useEntitySortDirectionURLSearchQuery),
         expandedItems: testableQuery(useExpandedItemsSearchQuery),
         hiddenCards: testableQuery(useHiddenCardsURLSearchQuery),
         hiddenColumns: testableQuery(useHiddenColumnsURLSearchQuery),

--- a/components/frontend/src/app_ui_settings.js
+++ b/components/frontend/src/app_ui_settings.js
@@ -3,6 +3,7 @@ import {
     useBooleanURLSearchQuery,
     useIntegerMappingURLSearchQuery,
     useIntegerURLSearchQuery,
+    useStringMappingURLSearchQuery,
     useStringURLSearchQuery,
 } from "./hooks/url_search_query"
 import { adapterLocale } from "./locale"
@@ -62,6 +63,16 @@ export function useSortDirectionURLSearchQuery(reportUuid, defaultValue = "ascen
     return useStringURLSearchQuery(urlSearchQueryKey("sort_direction", reportUuid), defaultValue)
 }
 
+export function useEntitySortColumnURLSearchQuery(reportUuid) {
+    // Stores entity sort column per metric UUID, as ?key=metric_uuid:column,metric_uuid:column
+    return useStringMappingURLSearchQuery(urlSearchQueryKey("entity_sort_column", reportUuid))
+}
+
+export function useEntitySortDirectionURLSearchQuery(reportUuid) {
+    // Stores entity sort direction per metric UUID, as ?key=metric_uuid:direction,metric_uuid:direction
+    return useStringMappingURLSearchQuery(urlSearchQueryKey("entity_sort_direction", reportUuid), "ascending")
+}
+
 export function useExpandedItemsSearchQuery(reportUuid) {
     // Use useIntegerMappingURLSearchQuery to handle expanded items and tabs. Key is the item, value is the tab index.
     return useIntegerMappingURLSearchQuery(urlSearchQueryKey("expanded", reportUuid))
@@ -95,6 +106,8 @@ export function useSettings(reportUuid) {
     return {
         dateInterval: useDateIntervalURLSearchQuery(reportUuid),
         dateOrder: useDateOrderURLSearchQuery(reportUuid),
+        entitySortColumn: useEntitySortColumnURLSearchQuery(reportUuid),
+        entitySortDirection: useEntitySortDirectionURLSearchQuery(reportUuid),
         expandedItems: useExpandedItemsSearchQuery(reportUuid),
         hiddenCards: useHiddenCardsURLSearchQuery(reportUuid),
         hiddenColumns: useHiddenColumnsURLSearchQuery(reportUuid),
@@ -124,6 +137,8 @@ export function useSettings(reportUuid) {
 export function resetSettings(settings) {
     settings.dateInterval.reset()
     settings.dateOrder.reset()
+    settings.entitySortColumn.reset()
+    settings.entitySortDirection.reset()
     settings.expandedItems.reset()
     settings.hiddenCards.reset()
     settings.hiddenColumns.reset()
@@ -147,6 +162,8 @@ export function allSettingsAreDefault(settings) {
     return (
         settings.dateInterval.isDefault() &&
         settings.dateOrder.isDefault() &&
+        settings.entitySortColumn.isDefault() &&
+        settings.entitySortDirection.isDefault() &&
         settings.expandedItems.isDefault() &&
         settings.hiddenCards.isDefault() &&
         settings.hiddenColumns.isDefault() &&

--- a/components/frontend/src/header_footer/buttons/ResetSettingsButton.test.jsx
+++ b/components/frontend/src/header_footer/buttons/ResetSettingsButton.test.jsx
@@ -33,10 +33,12 @@ it("has no accessibility violations", async () => {
 
 it("resets the settings", async () => {
     history.push(
-        "?date_interval=2&date_order=ascending&hidden_columns=comment&hide_ignored_entities=metric_uuid&hidden_tags=tag&" +
-            "metrics_to_hide=no_action_required&nr_dates=2&show_issue_creation_date=true&show_issue_summary=true&" +
-            "show_issue_update_date=true&show_issue_due_date=true&show_issue_release=true&show_issue_sprint=true&" +
-            "sort_column=status&sort_direction=descending&expanded=tab:0&hidden_cards=tags",
+        "?date_interval=2&date_order=ascending&entity_sort_column=metric_uuid:status&" +
+            "entity_sort_direction=metric_uuid:descending&hidden_columns=comment&" +
+            "hide_ignored_entities=metric_uuid&hidden_tags=tag&metrics_to_hide=no_action_required&nr_dates=2&" +
+            "show_issue_creation_date=true&show_issue_summary=true&show_issue_update_date=true&" +
+            "show_issue_due_date=true&show_issue_release=true&show_issue_sprint=true&sort_column=status&" +
+            "sort_direction=descending&expanded=tab:0&hidden_cards=tags",
     )
     const settings = createTestableSettings()
     const handleDateChange = vi.fn()

--- a/components/frontend/src/hooks/url_search_query.js
+++ b/components/frontend/src/hooks/url_search_query.js
@@ -74,8 +74,8 @@ export function useArrayURLSearchQuery(key) {
     return hook
 }
 
-export function useIntegerMappingURLSearchQuery(key) {
-    // URL search queries of the form ?key=item_key:item_value,item_key:item_value, where item_value is an integer
+function useMappingURLSearchQuery(key, parseValue, missingItemValue) {
+    // URL search queries of the form ?key=item_key:item_value,item_key:item_value
     let hook = useArrayURLSearchQuery(key)
     hook._findItem = (itemKey) => {
         return hook.value.find((eachItem) => eachItem.split(":")[0] === itemKey)
@@ -88,7 +88,7 @@ export function useIntegerMappingURLSearchQuery(key) {
     }
     hook.getItem = (itemKey) => {
         const item = hook._findItem(itemKey)
-        return item ? Number.parseInt(item.split(":")[1], 10) : 0
+        return item ? parseValue(item.split(":")[1]) : missingItemValue
     }
     hook._allItemsExcept = (itemKey) => {
         return hook.value.filter((eachItem) => eachItem.split(":")[0] !== itemKey)
@@ -100,6 +100,11 @@ export function useIntegerMappingURLSearchQuery(key) {
         const newValue = [...hook._allItemsExcept(itemKey), `${itemKey}:${itemValue}`]
         setURLSearchQuery(key, newValue, hook.defaultValue, hook.set)
     }
+    return hook
+}
+
+export function useIntegerMappingURLSearchQuery(key) {
+    let hook = useMappingURLSearchQuery(key, (value) => Number.parseInt(value, 10), 0)
     hook.toggle = (itemKey) => {
         if (hook.includes(itemKey)) {
             hook.deleteItem(itemKey)
@@ -108,6 +113,10 @@ export function useIntegerMappingURLSearchQuery(key) {
         }
     }
     return hook
+}
+
+export function useStringMappingURLSearchQuery(key, missingItemValue = "") {
+    return useMappingURLSearchQuery(key, (value) => value, missingItemValue)
 }
 
 export function useBooleanURLSearchQuery(key) {

--- a/components/frontend/src/sharedPropTypes.js
+++ b/components/frontend/src/sharedPropTypes.js
@@ -52,6 +52,14 @@ export const stringsURLSearchQueryPropType = shape({
     value: stringsPropType,
 })
 
+export const mappingURLSearchQueryPropType = shape({
+    isDefault: func,
+    reset: func,
+    getItem: func,
+    setItem: func,
+    value: stringsPropType,
+})
+
 export const labelPropType = oneOfType([object, string])
 
 export const popupContentPropType = oneOfType([element, string])
@@ -85,6 +93,8 @@ export const metricsToHideURLSearchQueryPropType = shape({
 export const settingsPropType = shape({
     dateInterval: integerURLSearchQueryPropType,
     dateOrder: sortDirectionURLSearchQueryPropType,
+    entitySortColumn: mappingURLSearchQueryPropType,
+    entitySortDirection: mappingURLSearchQueryPropType,
     expandedItems: stringsURLSearchQueryPropType,
     hiddenColumns: stringsURLSearchQueryPropType,
     hideIgnoredEntities: stringsURLSearchQueryPropType,

--- a/components/frontend/src/source/SourceEntities.jsx
+++ b/components/frontend/src/source/SourceEntities.jsx
@@ -13,7 +13,7 @@ import {
     Tooltip,
 } from "@mui/material"
 import { bool, func, number, object, string } from "prop-types"
-import { useContext, useState } from "react"
+import { useContext } from "react"
 
 import { DataModelContext } from "../context/DataModel"
 import { zIndexInnerTableHeader } from "../defaults"
@@ -41,18 +41,10 @@ import { entityStatus, entityStatusEndDate, entityStatusRationale } from "./sour
 import { entityCanBeIgnored, SourceEntity } from "./SourceEntity"
 
 function EntityAttributeHeaderCell({ entityAttribute, ...sortProps }) {
-    function handleSort(column) {
-        sortProps.setColumnType(entityAttribute.type || "text")
-        if (column === sortProps.sortColumn) {
-            sortProps.setSortDirection(sortProps.sortDirection === "ascending" ? "descending" : "ascending")
-        } else {
-            sortProps.setSortColumn(column)
-        }
-    }
     return (
         <SortableTableHeaderCell
             column={entityAttribute.key}
-            handleSort={handleSort}
+            handleSort={sortProps.handleSort}
             textAlign={alignment(entityAttribute.type, entityAttribute.alignment)}
             {...sortProps}
         >
@@ -69,9 +61,7 @@ function EntityAttributeHeaderCell({ entityAttribute, ...sortProps }) {
 }
 EntityAttributeHeaderCell.propTypes = {
     entityAttribute: entityAttributePropType,
-    setColumnType: func,
-    setSortColumn: func,
-    setSortDirection: func,
+    handleSort: func,
     sortColumn: string,
     sortDirection: sortDirectionPropType,
 }
@@ -85,14 +75,6 @@ function sourceEntitiesHeaders(
     toggleHideIgnoredEntities,
     sortProps,
 ) {
-    function handleSort(column, columnType) {
-        sortProps.setColumnType(columnType)
-        if (column === sortProps.sortColumn) {
-            sortProps.setSortDirection(sortProps.sortDirection === "ascending" ? "descending" : "ascending")
-        } else {
-            sortProps.setSortColumn(column)
-        }
-    }
     const action = hideIgnoredEntities ? "Show" : "Hide"
     const entityNameSingular = metricEntities.name
     const entityNamePlural = metricEntities.name_plural
@@ -112,36 +94,20 @@ function sourceEntitiesHeaders(
                     </span>
                 </Tooltip>
             </TableCell>
-            <SortableTableHeaderCell
-                column="entity_status"
-                handleSort={(column) => handleSort(column, "text")}
-                {...sortProps}
-            >
+            <SortableTableHeaderCell column="entity_status" {...sortProps}>
                 {`${capitalize(entityNameSingular)} status`}
             </SortableTableHeaderCell>
             {!columnsToHide.includes("status_end_date") && (
-                <SortableTableHeaderCell
-                    column="status_end_date"
-                    handleSort={(column) => handleSort(column, "date")}
-                    {...sortProps}
-                >
+                <SortableTableHeaderCell column="status_end_date" {...sortProps}>
                     Status end date
                 </SortableTableHeaderCell>
             )}
             {!columnsToHide.includes("rationale") && (
-                <SortableTableHeaderCell
-                    column="rationale"
-                    handleSort={(column) => handleSort(column, "text")}
-                    {...sortProps}
-                >
+                <SortableTableHeaderCell column="rationale" {...sortProps}>
                     Status rationale
                 </SortableTableHeaderCell>
             )}
-            <SortableTableHeaderCell
-                column="first_seen"
-                handleSort={(column) => handleSort(column, "datetime")}
-                {...sortProps}
-            >
+            <SortableTableHeaderCell column="first_seen" {...sortProps}>
                 {capitalize(entityNameSingular)} first seen
             </SortableTableHeaderCell>
             {entityAttributes.map((entityAttribute) => (
@@ -198,11 +164,21 @@ sortedEntities.propTypes = {
     source: sourcePropType,
 }
 
+const builtInEntityColumnTypes = {
+    entity_status: "text",
+    status_end_date: "date",
+    rationale: "text",
+    first_seen: "datetime",
+}
+
+function entityColumnType(column, entityAttributes) {
+    return builtInEntityColumnTypes[column] ?? entityAttributes.find((a) => a.key === column)?.type ?? "text"
+}
+
 export function SourceEntities({ loading, measurements, metric, metricUuid, reload, report, settings, sourceUuid }) {
     const dataModel = useContext(DataModelContext)
-    const [sortColumn, setSortColumn] = useState(null)
-    const [columnType, setColumnType] = useState("text")
-    const [sortDirection, setSortDirection] = useState("ascending")
+    const sortColumn = settings.entitySortColumn.getItem(metricUuid) || null
+    const sortDirection = settings.entitySortDirection.getItem(metricUuid)
 
     const sourceType = metric.sources[sourceUuid].type
     const metricEntities = dataModel.sources[sourceType]?.entities?.[metric.type]
@@ -239,13 +215,20 @@ export function SourceEntities({ loading, measurements, metric, metricUuid, relo
         )
     }
     const entityAttributes = metricEntities.attributes.filter((attribute) => attribute?.visible ?? true)
+    function handleSort(column) {
+        if (column === sortColumn) {
+            const newDirection = sortDirection === "ascending" ? "descending" : "ascending"
+            settings.entitySortDirection.setItem(metricUuid, newDirection)
+        } else {
+            settings.entitySortColumn.setItem(metricUuid, column)
+        }
+    }
     const sortProps = {
-        setColumnType: setColumnType,
-        setSortColumn: setSortColumn,
-        setSortDirection: setSortDirection,
+        handleSort: handleSort,
         sortColumn: sortColumn,
         sortDirection: sortDirection,
     }
+    const columnType = sortColumn ? entityColumnType(sortColumn, entityAttributes) : "text"
     const entities = sortedEntities(columnType, sortColumn, sortDirection, source)
     const columnsToHide = determineColumnsToHide(settings, source, entities)
     const hideIgnoredEntities = settings.hideIgnoredEntities.includes(metricUuid)

--- a/components/frontend/src/source/SourceEntities.test.jsx
+++ b/components/frontend/src/source/SourceEntities.test.jsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import history from "history/browser"
 
-import { createTestableSettings } from "../__fixtures__/fixtures"
+import { useSettings } from "../app_ui_settings"
 import { DataModelContext } from "../context/DataModel"
 import {
     clickText,
@@ -116,6 +116,21 @@ function expectOrder(expected) {
     }
 }
 
+function SourceEntitiesWrapper({ loading, measurements, metric }) {
+    const settings = useSettings("")
+    return (
+        <SourceEntities
+            loading={loading}
+            measurements={measurements}
+            metric={metric}
+            metricUuid="metric_uuid"
+            report={{ issue_tracker: null }}
+            settings={settings}
+            sourceUuid="source_uuid"
+        />
+    )
+}
+
 function renderSourceEntities({
     loading = "loaded",
     measurements = [{ sources: [sourceFixture] }],
@@ -123,15 +138,7 @@ function renderSourceEntities({
 } = {}) {
     return render(
         <DataModelContext value={dataModel}>
-            <SourceEntities
-                loading={loading}
-                measurements={measurements}
-                metric={metric}
-                metricUuid="metric_uuid"
-                report={{ issue_tracker: null }}
-                settings={createTestableSettings()}
-                sourceUuid="source_uuid"
-            />
+            <SourceEntitiesWrapper loading={loading} measurements={measurements} metric={metric} />
         </DataModelContext>,
     )
 }
@@ -221,6 +228,20 @@ it("hides ignored entities for the metric by storing the metric uuid in the URL"
     const hideEntitiesTooltip = screen.getByLabelText(/Hide the 1 entity name that has been/)
     await userEvent.click(hideEntitiesTooltip.firstChild) // Get the button inside the tooltip
     expectSearch("?hide_ignored_entities=metric_uuid")
+})
+
+it("stores the entity sort column and direction in the URL", async () => {
+    renderSourceEntities()
+    clickText(/text/)
+    expectSearch("?entity_sort_column=metric_uuid%3Atext")
+    clickText(/text/)
+    expectSearch("?entity_sort_column=metric_uuid%3Atext&entity_sort_direction=metric_uuid%3Adescending")
+})
+
+it("restores the entity sort order from the URL", async () => {
+    history.push("?entity_sort_column=metric_uuid:text&entity_sort_direction=metric_uuid:descending")
+    renderSourceEntities()
+    expectOrder(["C", "B", "A"])
 })
 
 async function expectColumnIsSortedCorrectly(header, ascending) {

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - When hiding measurement entities marked as fixed, false positive, or won't fix, preserve that setting when exporting the report as PDF. Fixes [#12976](https://github.com/ICTU/quality-time/issues/12976).
 
+### Added
+
+- Keep track of the measurement entity sort column and direction per metric in the URL, so that the sort order is preserved when collapsing and re-expanding a metric and when exporting the report as PDF. Closes [#6644](https://github.com/ICTU/quality-time/issues/6644).
+
 ## v5.52.0 - 2026-04-17
 
 ### Fixed


### PR DESCRIPTION
Keep track of the measurement entity sort column and direction per metric in the URL, so that the sort order is preserved when collapsing and re-expanding a metric and when exporting the report as PDF.

Closes #6644.