### PR TITLE
When copying or moving items, allow for filtering

### DIFF
--- a/components/frontend/src/report/ReportsOverview.test.jsx
+++ b/components/frontend/src/report/ReportsOverview.test.jsx
@@ -78,14 +78,14 @@ it("shows an error message if there are no reports at the specified date", async
 })
 
 it("shows the reports overview", async () => {
-    const reports = [{ report_uuid: "report_uuid", subjects: {} }]
+    const reports = [{ title: "Report title", report_uuid: "report_uuid", subjects: {} }]
     const reportsOverview = { title: "Overview", permissions: {} }
     await renderReportsOverview({ reports: reports, reportsOverview: reportsOverview })
     expectText(/Overview/)
 })
 
 it("shows the comment", async () => {
-    const reports = [{ report_uuid: "report_uuid", subjects: {} }]
+    const reports = [{ title: "Report title", report_uuid: "report_uuid", subjects: {} }]
     const reportsOverview = { title: "Overview", comment: "Commentary", permissions: {} }
     await renderReportsOverview({ reports: reports, reportsOverview: reportsOverview })
     expectText(/Commentary/)
@@ -93,6 +93,7 @@ it("shows the comment", async () => {
 
 const reports = [
     {
+        title: "Report title",
         report_uuid: "report_uuid",
         subjects: {
             subject_uuid: {

--- a/components/frontend/src/widgets/buttons/ActionAndItemPickerButton.jsx
+++ b/components/frontend/src/widgets/buttons/ActionAndItemPickerButton.jsx
@@ -1,5 +1,5 @@
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown"
-import { Button, Menu, MenuItem, Tooltip, Typography } from "@mui/material"
+import { Button, MenuItem, MenuList, Popover, TextField, Tooltip, Typography } from "@mui/material"
 import { element, func, string } from "prop-types"
 import { useState } from "react"
 
@@ -7,11 +7,14 @@ import { ItemBreadcrumb } from "../ItemBreadcrumb"
 
 export function ActionAndItemPickerButton({ action, itemType, onChange, getOptions, icon }) {
     const [anchorEl, setAnchorEl] = useState()
+    const [query, setQuery] = useState("") // Search query to filter items
     const handleMenu = (event) => setAnchorEl(event.currentTarget)
     const onClick = (value) => {
         onChange(value)
         setAnchorEl(null)
     }
+
+    const options = getOptions().filter((option) => option.text.toLowerCase().includes(query.toLowerCase()))
 
     const breadcrumbProps = { report: "report" }
     if (itemType !== "report") {
@@ -31,30 +34,30 @@ export function ActionAndItemPickerButton({ action, itemType, onChange, getOptio
                     <ArrowDropDownIcon />
                 </Button>
             </Tooltip>
-            <Menu
-                id="action-menu"
-                anchorEl={anchorEl}
-                onClose={() => setAnchorEl(null)}
-                open={Boolean(anchorEl)}
-                slotProps={{
-                    paper: {
-                        style: {
-                            maxHeight: 250,
-                        },
-                    },
-                }}
-            >
-                <MenuItem disabled divider>
-                    <Typography variant="button">
-                        <ItemBreadcrumb {...breadcrumbProps} />
-                    </Typography>
-                </MenuItem>
-                {getOptions().map((option) => (
-                    <MenuItem key={option.key} onClick={() => onClick(option.value)}>
-                        {option.content}
+            <Popover id="dropdown-menu" anchorEl={anchorEl} onClose={() => setAnchorEl(null)} open={Boolean(anchorEl)}>
+                <TextField
+                    autoFocus
+                    fullWidth
+                    label={`Filter ${itemType}s`}
+                    onChange={(event) => setQuery(event.target.value)}
+                    value={query}
+                    variant="outlined"
+                    sx={{ ml: "10px", mt: "10px", pr: "20px" }}
+                    type="search"
+                />
+                <MenuList sx={{ height: "30vh", width: "50vw" }}>
+                    <MenuItem disabled divider>
+                        <Typography variant="button">
+                            <ItemBreadcrumb {...breadcrumbProps} />
+                        </Typography>
                     </MenuItem>
-                ))}
-            </Menu>
+                    {options.map((option) => (
+                        <MenuItem key={option.key} onClick={() => onClick(option.value)}>
+                            {option.content}
+                        </MenuItem>
+                    ))}
+                </MenuList>
+            </Popover>
         </>
     )
 }

--- a/components/frontend/src/widgets/buttons/CopyButton.test.jsx
+++ b/components/frontend/src/widgets/buttons/CopyButton.test.jsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { vi } from "vitest"
 
@@ -57,5 +57,16 @@ Array("report", "subject", "metric", "source").forEach((itemType) => {
         clickText(/Item/)
         await asyncClickText(new RegExp(`Copy ${itemType}`))
         expect(getOptionsCalled).toBe(4)
+    })
+
+    test("CopyButton can be used to filter items", async () => {
+        const mockCallback = vi.fn()
+        renderCopyButton(itemType, mockCallback)
+        await asyncClickText(new RegExp(`Copy ${itemType}`))
+        fireEvent.change(screen.getByLabelText(/Filter/), { target: { value: "No such thing" } })
+        expectNoText("Item")
+        fireEvent.change(screen.getByLabelText(/Filter/), { target: { value: "It" } })
+        expectText("Item")
+        expect(mockCallback).not.toHaveBeenCalled()
     })
 })

--- a/components/frontend/src/widgets/menu_options.jsx
+++ b/components/frontend/src/widgets/menu_options.jsx
@@ -22,7 +22,7 @@ export function metricOptions(reports, dataModel, currentSubjectType, currentSub
                 options.push({
                     content: <ItemBreadcrumb report={report.title} subject={subjectName} metric={metricName} />,
                     key: metricUuid,
-                    text: report.title + subjectName + metricName,
+                    text: report.title + " " + subjectName + " " + metricName,
                     value: metricUuid,
                 })
             }
@@ -68,7 +68,7 @@ export function sourceOptions(reports, dataModel, currentMetricType, currentMetr
                             />
                         ),
                         key: sourceUuid,
-                        text: report.title + subjectName + metricName + sourceName,
+                        text: report.title + " " + subjectName + " " + metricName + " " + sourceName,
                         value: sourceUuid,
                     })
                 })
@@ -89,7 +89,7 @@ export function subjectOptions(reports, dataModel, currentReportUuid) {
             options.push({
                 content: <ItemBreadcrumb report={report.title} subject={subjectName} />,
                 key: subjectUuid,
-                text: report.title + subjectName,
+                text: report.title + " " + subjectName,
                 value: subjectUuid,
             })
         })

--- a/components/frontend/src/widgets/menu_options.test.jsx
+++ b/components/frontend/src/widgets/menu_options.test.jsx
@@ -26,7 +26,7 @@ it("contains the subjects, except for the excluded report", () => {
     ).toStrictEqual([
         {
             key: "subject1",
-            text: "AS",
+            text: "A S",
             value: "subject1",
             content: <ItemBreadcrumb report="A" subject="S" />,
         },
@@ -64,7 +64,7 @@ it("contains the metrics, except for the excluded subject", () => {
     ).toStrictEqual([
         {
             key: "metric1",
-            text: "AS1M1",
+            text: "A S1 M1",
             value: "metric1",
             content: <ItemBreadcrumb report="A" subject="S1" metric="M1" />,
         },
@@ -109,7 +109,7 @@ it("contains the sources, except for the excluded metric", () => {
     ).toStrictEqual([
         {
             key: "source1",
-            text: "AS1M2S1",
+            text: "A S1 M2 S1",
             value: "source1",
             content: <ItemBreadcrumb report="A" subject="S1" metric="M2" source="S1" />,
         },

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,6 +19,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Added
 
 - Keep track of the measurement entity sort column and direction per metric in the URL, so that the sort order is preserved when collapsing and re-expanding a metric and when exporting the report as PDF. Closes [#6644](https://github.com/ICTU/quality-time/issues/6644).
+- When copying or moving subjects, metrics, or sources, allow for filtering the dropdown lists. Closes [#10689](https://github.com/ICTU/quality-time/issues/10689).
 
 ## v5.52.0 - 2026-04-17
 


### PR DESCRIPTION
When copying or moving subjects, metrics, or sources, allow for filtering the dropdown lists.

Closes #10689.