### PR TITLE
Make default values editable

### DIFF
--- a/components/frontend/src/fields/TextField.test.jsx
+++ b/components/frontend/src/fields/TextField.test.jsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { vi } from "vitest"
+
+import { expectNoAccessibilityViolations } from "../testUtils"
+import { TextField } from "./TextField"
+
+function renderTextField({ onChange = vi.fn(), placeholder = null, required = false, type = null, value = null } = {}) {
+    return render(
+        <TextField onChange={onChange} placeholder={placeholder} required={required} type={type} value={value} />,
+    )
+}
+
+async function typeInField(text, confirm = "Enter") {
+    const element = screen.queryAllByRole("textbox")[0] ?? screen.getByRole("spinbutton")
+    await userEvent.type(element, `${text}{${confirm}}`, {
+        initialSelectionStart: 0,
+        initialSelectionEnd: 100,
+    })
+}
+
+it("has no accessibility violations", async () => {
+    const { container } = renderTextField({ placeholder: "placeholder" })
+    await expectNoAccessibilityViolations(container)
+})
+
+it("sets the value on enter", async () => {
+    const onChange = vi.fn()
+    renderTextField({ onChange: onChange })
+    await typeInField("New value")
+    expect(onChange).toHaveBeenCalledWith("New value")
+})
+
+it("sets the value on tab", async () => {
+    const onChange = vi.fn()
+    renderTextField({ onChange: onChange })
+    await typeInField("New value", "Tab")
+    expect(onChange).toHaveBeenCalledWith("New value")
+})
+
+it("sets an empty value", async () => {
+    const onChange = vi.fn()
+    renderTextField({ onChange: onChange, value: "Some value" })
+    await typeInField("{Delete}", "Enter")
+    expect(onChange).toHaveBeenCalledWith("")
+})
+
+it("doesn't set the value if it's unchanged", async () => {
+    const onChange = vi.fn()
+    renderTextField({ onChange: onChange })
+    await typeInField("")
+    expect(onChange).not.toHaveBeenCalled()
+})
+
+it("doesn't set an empty value if a non-empty value is required", async () => {
+    const onChange = vi.fn()
+    renderTextField({ onChange: onChange, required: true })
+    await typeInField("")
+    expect(onChange).not.toHaveBeenCalled()
+})
+
+it("resets the value on escape", async () => {
+    const onChange = vi.fn()
+    renderTextField({ onChange: onChange })
+    await typeInField("New value{Escape}")
+    await typeInField("{Enter}")
+    expect(onChange).not.toHaveBeenCalled()
+})
+
+it("doesn't set an invalid number value", async () => {
+    const onChange = vi.fn()
+    renderTextField({ onChange: onChange, required: true, type: "number" })
+    await typeInField("not a number")
+    expect(onChange).not.toHaveBeenCalled()
+})

--- a/components/frontend/src/metric/MetricConfigurationParameters.jsx
+++ b/components/frontend/src/metric/MetricConfigurationParameters.jsx
@@ -52,7 +52,7 @@ function MetricName({ metric, metricUuid, reload }) {
             label="Metric name"
             placeholder={metricType.name}
             onChange={(value) => setMetricAttribute(metricUuid, "name", value, reload)}
-            value={metric.name}
+            value={metric.name || metricType.name}
         />
     )
 }
@@ -184,7 +184,7 @@ function UnitPlural({ metric, metricUuid, reload }) {
             placeholder={metricType.unit}
             startAdornment={formatMetricScale(metric, dataModel, "2")}
             onChange={(value) => setMetricAttribute(metricUuid, "unit", value, reload)}
-            value={metric.unit}
+            value={metric.unit || metricType.unit}
         />
     )
 }
@@ -206,7 +206,7 @@ function UnitSingular({ metric, metricUuid, reload }) {
             placeholder={metricType.unit_singular}
             startAdornment={formatMetricScale(metric, dataModel, "1")}
             onChange={(value) => setMetricAttribute(metricUuid, "unit_singular", value, reload)}
-            value={metric.unit_singular}
+            value={metric.unit_singular || metricType.unit_singular}
         />
     )
 }

--- a/components/frontend/src/source/Source.jsx
+++ b/components/frontend/src/source/Source.jsx
@@ -120,7 +120,7 @@ function Parameters({
                     label="Source name"
                     placeholder={sourceType.name}
                     onChange={(value) => setSourceAttribute(sourceUuid, "name", value, reload)}
-                    value={source.name}
+                    value={source.name || sourceType.name}
                 />
             </Grid>
             <Grid size={{ xs: 1, sm: 2, md: 2 }}>

--- a/components/frontend/src/source/Source.test.jsx
+++ b/components/frontend/src/source/Source.test.jsx
@@ -66,7 +66,10 @@ it("changes the source type", async () => {
 
 it("changes the source name", async () => {
     renderSource(metric)
-    await userEvent.type(screen.getByLabelText(/Source name/), "New source name{Enter}")
+    await userEvent.type(screen.getByLabelText(/Source name/), "New source name{Enter}", {
+        initialSelectionStart: 0,
+        initialSelectionEnd: 100,
+    })
     expectFetch("post", "source/source_uuid/attribute/name", { name: "New source name" })
 })
 

--- a/components/frontend/src/subject/SubjectParameters.jsx
+++ b/components/frontend/src/subject/SubjectParameters.jsx
@@ -28,7 +28,7 @@ export function SubjectParameters({ subject, subjectUuid, subjectName, reload })
                     label="Subject title"
                     placeholder={subjectName}
                     onChange={(value) => setSubjectAttribute(subjectUuid, "name", value, reload)}
-                    value={subject.name}
+                    value={subject.name || subjectName}
                 />
             </Grid>
             <Grid size={{ xs: 1, sm: 1, md: 1 }}>

--- a/components/frontend/src/subject/SubjectTitle.test.jsx
+++ b/components/frontend/src/subject/SubjectTitle.test.jsx
@@ -99,7 +99,10 @@ it("changes the subject type from a nested type", async () => {
 
 it("changes the subject title", async () => {
     await renderSubjectTitle()
-    await userEvent.type(screen.getByLabelText(/Subject title/), "{Delete}New title{Enter}")
+    await userEvent.type(screen.getByLabelText(/Subject title/), "New title{Enter}", {
+        initialSelectionStart: 0,
+        initialSelectionEnd: 100,
+    })
     expectFetch("post", "subject/subject_uuid/attribute/name", { name: "New title" })
 })
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,6 +19,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ### Added
 
+- Make default values of subject names, metric names and units, and source names editable. Closes [#3420](https://github.com/ICTU/quality-time/issues/3420).
 - Keep track of the measurement entity sort column and direction per metric in the URL, so that the sort order is preserved when collapsing and re-expanding a metric and when exporting the report as PDF. Closes [#6644](https://github.com/ICTU/quality-time/issues/6644).
 - When copying or moving subjects, metrics, or sources, allow for filtering the dropdown lists. Closes [#10689](https://github.com/ICTU/quality-time/issues/10689).
 - Add Grafana k6 summary.json reports as source for the 'tests' metric. Closes [#11173](https://github.com/ICTU/quality-time/issues/11173).


### PR DESCRIPTION
Make default values of subject names, metric names and units, and source names editable.

Closes #3420.