### PR TITLE
Add a "today" button to date pickers

### DIFF
--- a/components/frontend/src/metric/MetricDebtParameters.jsx
+++ b/components/frontend/src/metric/MetricDebtParameters.jsx
@@ -75,7 +75,11 @@ function TechnicalDebtEndDate({ metric, metricUuid, reload }) {
             disabled={disabled}
             label="Technical debt end date"
             onChange={(value) => setMetricAttribute(metricUuid, "debt_end_date", value, reload)}
-            slotProps={{ field: { clearable: true }, textField: { helperText: helperText } }}
+            slotProps={{
+                actionBar: { actions: ["today"] },
+                field: { clearable: true },
+                textField: { helperText: helperText },
+            }}
             sx={{ width: "100%" }}
             timezone="default"
         />

--- a/components/frontend/src/metric/MetricDebtParameters.test.jsx
+++ b/components/frontend/src/metric/MetricDebtParameters.test.jsx
@@ -8,7 +8,14 @@ import { vi } from "vitest"
 import * as fetchServerApi from "../api/fetch_server_api"
 import { DataModelContext } from "../context/DataModel"
 import { EDIT_REPORT_PERMISSION, PermissionsContext } from "../context/Permissions"
-import { expectFetch, expectNoAccessibilityViolations, expectNoFetch, expectText } from "../testUtils"
+import {
+    clickButton,
+    clickLabeledElement,
+    expectFetch,
+    expectNoAccessibilityViolations,
+    expectNoFetch,
+    expectText,
+} from "../testUtils"
 import { MetricDebtParameters } from "./MetricDebtParameters"
 
 const dataModel = {
@@ -102,6 +109,15 @@ it("sets the technical debt end date", async () => {
     renderMetricDebtParameters()
     await userEvent.type(screen.getAllByLabelText(/Technical debt end date/)[0], "12312022{Enter}")
     expectFetch("post", "metric/metric_uuid/attribute/debt_end_date", { debt_end_date: dayjs("2022-12-31") })
+})
+
+it("sets the technical debt end date to today", async () => {
+    renderMetricDebtParameters()
+    clickLabeledElement(/Choose date/)
+    clickButton("Today")
+    expectFetch("post", "metric/metric_uuid/attribute/debt_end_date", {
+        debt_end_date: dayjs().startOf("day"),
+    })
 })
 
 it("shows days ago for the technical debt end date", async () => {

--- a/components/frontend/src/report/IssueTracker.test.jsx
+++ b/components/frontend/src/report/IssueTracker.test.jsx
@@ -68,7 +68,7 @@ it("sets the issue tracker type", async () => {
     fireEvent.mouseDown(screen.getByLabelText(/Issue tracker type/))
     clickText("Jira")
     expect(reportApi.setReportIssueTrackerAttribute).toHaveBeenLastCalledWith("report_uuid", "type", "jira", reload)
-    fireEvent.click(screen.getByText("None"))
+    clickText("None")
     expect(reportApi.setReportIssueTrackerAttribute).toHaveBeenLastCalledWith("report_uuid", "type", "", reload)
 })
 

--- a/components/frontend/src/source/SourceParameter.jsx
+++ b/components/frontend/src/source/SourceParameter.jsx
@@ -201,6 +201,7 @@ export function SourceParameter({
                     {...parameterProps}
                     value={value ? dayjs(value) : null}
                     slotProps={{
+                        actionBar: { actions: ["today"] },
                         textField: { helperText: helperText, slotProps: { input: { startAdornment: startAdornment } } },
                     }}
                     sx={{ width: "100%" }}

--- a/components/frontend/src/source/SourceParameter.test.jsx
+++ b/components/frontend/src/source/SourceParameter.test.jsx
@@ -129,6 +129,16 @@ it("renders a date parameter without date", async () => {
     expect(screen.queryAllByPlaceholderText(/YYYY/).length).toBe(0)
 })
 
+it("sets the date to today", async () => {
+    renderSourceParameter({ parameter: { name: "Date", type: "date" }, parameterValue: "2021-10-10" })
+    clickLabeledElement(/Choose date/)
+    clickButton("Today")
+    expectFetch("post", "source/source_uuid/parameter/key1", {
+        edit_scope: "source",
+        key1: dayjs().startOf("day"),
+    })
+})
+
 it("sets the next date one day from previous date", async () => {
     renderSourceParameter({
         parameter: { name: "Date", type: "date" },

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -23,6 +23,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 - Don't insert line breaks between comparison operators (<= or >=) and target values to save space. Closes [#4613](https://github.com/ICTU/quality-time/issues/4613).
 - Keep track of the measurement entity sort column and direction per metric in the URL, so that the sort order is preserved when collapsing and re-expanding a metric and when exporting the report as PDF. Closes [#6644](https://github.com/ICTU/quality-time/issues/6644).
 - When copying or moving subjects, metrics, or sources, allow for filtering the dropdown lists. Closes [#10689](https://github.com/ICTU/quality-time/issues/10689).
+- Add a "today" button to the technical debt end date and the calendar source date pickers. Closes [#10956](https://github.com/ICTU/quality-time/issues/10956).
 - Add Grafana k6 summary.json reports as source for the 'tests' metric. Closes [#11173](https://github.com/ICTU/quality-time/issues/11173).
 - Allow for using Grafana k6 summary.json reports as source for the 'source up-to-dateness' metric. Closes [#11174](https://github.com/ICTU/quality-time/issues/11174).
 - Allow for using Grafana k6 summary.json reports as source for the 'source version' metric. Closes [#11373](https://github.com/ICTU/quality-time/issues/11373).


### PR DESCRIPTION
Add a "today" button to the technical debt end date and the calendar source date pickers.

Closes #10956.