### PR TITLE
Show trend graph on clicking spark line graph

### DIFF
--- a/components/frontend/package-lock.json
+++ b/components/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "quality-time-app",
-    "version": "5.52.0",
+    "version": "5.53.0-rc.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "quality-time-app",
-            "version": "5.52.0",
+            "version": "5.53.0-rc.0",
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",

--- a/components/frontend/src/measurement/TrendSparkline.jsx
+++ b/components/frontend/src/measurement/TrendSparkline.jsx
@@ -1,11 +1,12 @@
-import { useTheme } from "@mui/material"
+import { ButtonBase, useTheme } from "@mui/material"
+import { func } from "prop-types"
 import { useState } from "react"
 import { VictoryGroup, VictoryLine, VictoryTheme } from "victory"
 
 import { datePropType, measurementsPropType, scalePropType } from "../sharedPropTypes"
 import { pluralize } from "../utils"
 
-export function TrendSparkline({ measurements, reportDate, scale }) {
+export function TrendSparkline({ measurements, onClick, reportDate, scale }) {
     const [now] = useState(() => (reportDate ? new Date(reportDate) : new Date()))
     const [weekAgo] = useState(() => {
         let date = reportDate ? new Date(reportDate) : new Date()
@@ -29,7 +30,7 @@ export function TrendSparkline({ measurements, reportDate, scale }) {
     const ariaLabel = `sparkline graph showing ${yValues.size} different measurement ${pluralize("value", yValues.size)} in the week before ${reportDate ? now.toLocaleDateString() : "today"}`
     // The width property below is not used according to https://formidable.com/open-source/victory/docs/common-props#width,
     // but setting it prevents these messages in the console: "Warning: `Infinity` is an invalid value for the `width` css style property.""
-    return (
+    const sparkline = (
         <VictoryGroup
             aria-label={ariaLabel}
             theme={VictoryTheme.material}
@@ -51,9 +52,31 @@ export function TrendSparkline({ measurements, reportDate, scale }) {
             />
         </VictoryGroup>
     )
+    if (!onClick) {
+        return sparkline
+    }
+    return (
+        <ButtonBase
+            aria-label="Show trend graph for this metric"
+            focusRipple
+            onClick={onClick}
+            sx={{
+                display: "block",
+                height: "100%",
+                padding: 2,
+                width: "100%",
+                "&:hover, &.Mui-focusVisible": {
+                    backgroundColor: "action.hover",
+                },
+            }}
+        >
+            {sparkline}
+        </ButtonBase>
+    )
 }
 TrendSparkline.propTypes = {
     measurements: measurementsPropType,
+    onClick: func,
     reportDate: datePropType,
     scale: scalePropType,
 }

--- a/components/frontend/src/measurement/TrendSparkline.test.jsx
+++ b/components/frontend/src/measurement/TrendSparkline.test.jsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { vi } from "vitest"
 
-import { expectNoAccessibilityViolations } from "../testUtils"
+import { clickButton, expectNoAccessibilityViolations } from "../testUtils"
 import { TrendSparkline } from "./TrendSparkline"
 
 it("has no accessibility violations", async () => {
@@ -67,4 +69,51 @@ it("renders old measurements", async () => {
             `sparkline graph showing 1 different measurement value in the week before ${date.toLocaleDateString()}`,
         ).length,
     ).toBe(1)
+})
+
+it("has no accessibility violations when clickable", async () => {
+    const { container } = render(
+        <TrendSparkline
+            measurements={[{ count: { value: "1" }, start: "2019-09-29", end: "2019-09-30" }]}
+            onClick={() => {}}
+            scale="count"
+        />,
+    )
+    await expectNoAccessibilityViolations(container)
+})
+
+it("does not render a button when onClick is not provided", async () => {
+    render(<TrendSparkline measurements={[]} scale="count" />)
+    expect(screen.queryByRole("button")).toBeNull()
+})
+
+it("renders a button when onClick is provided", async () => {
+    const onClick = vi.fn()
+    render(<TrendSparkline measurements={[]} onClick={onClick} scale="count" />)
+    expect(screen.getByRole("button", { name: /show trend graph/i })).toBeInTheDocument()
+})
+
+it("invokes onClick when the button is clicked", async () => {
+    const onClick = vi.fn()
+    render(<TrendSparkline measurements={[]} onClick={onClick} scale="count" />)
+    clickButton(/show trend graph/i)
+    expect(onClick).toHaveBeenCalledTimes(1)
+})
+
+it("invokes onClick when the button is activated with the space key", async () => {
+    const onClick = vi.fn()
+    render(<TrendSparkline measurements={[]} onClick={onClick} scale="count" />)
+    const button = screen.getByRole("button", { name: /show trend graph/i })
+    button.focus()
+    await userEvent.keyboard(" ")
+    expect(onClick).toHaveBeenCalledTimes(1)
+})
+
+it("invokes onClick when the button is activated with the enter key", async () => {
+    const onClick = vi.fn()
+    render(<TrendSparkline measurements={[]} onClick={onClick} scale="count" />)
+    const button = screen.getByRole("button", { name: /show trend graph/i })
+    button.focus()
+    await userEvent.keyboard("{Enter}")
+    expect(onClick).toHaveBeenCalledTimes(1)
 })

--- a/components/frontend/src/metric/MetricDetails.jsx
+++ b/components/frontend/src/metric/MetricDetails.jsx
@@ -36,6 +36,8 @@ import { MetricConfigurationParameters } from "./MetricConfigurationParameters"
 import { MetricDebtParameters } from "./MetricDebtParameters"
 import { TrendGraph } from "./TrendGraph"
 
+export const TREND_GRAPH_TAB_INDEX = 4
+
 function RequestMeasurementButton({ metric, metricUuid, reload }) {
     const dataModel = useContext(DataModelContext)
     const configurationComplete = isSourceConfigurationComplete(dataModel, metric)

--- a/components/frontend/src/subject/SubjectTableRow.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.jsx
@@ -13,7 +13,7 @@ import { Overrun } from "../measurement/Overrun"
 import { StatusIcon } from "../measurement/StatusIcon"
 import { TimeLeft } from "../measurement/TimeLeft"
 import { TrendSparkline } from "../measurement/TrendSparkline"
-import { MetricDetails } from "../metric/MetricDetails"
+import { MetricDetails, TREND_GRAPH_TAB_INDEX } from "../metric/MetricDetails"
 import { measurementOnDate } from "../report/report_utils"
 import {
     dataModelPropType,
@@ -331,8 +331,22 @@ export function SubjectTableRow({
                 />
             )}
             {!columnsToHide.includes("trend") && (
-                <TableCell sx={{ width: "150px" }}>
-                    <TrendSparkline measurements={metric.recent_measurements} reportDate={reportDate} scale={scale} />
+                <TableCell sx={{ padding: 0, width: "150px" }}>
+                    <TrendSparkline
+                        measurements={metric.recent_measurements}
+                        onClick={() => {
+                            if (
+                                settings.expandedItems.includes(metricUuid) &&
+                                settings.expandedItems.getItem(metricUuid) === TREND_GRAPH_TAB_INDEX
+                            ) {
+                                settings.expandedItems.deleteItem(metricUuid)
+                            } else {
+                                settings.expandedItems.setItem(metricUuid, TREND_GRAPH_TAB_INDEX)
+                            }
+                        }}
+                        reportDate={reportDate}
+                        scale={scale}
+                    />
                 </TableCell>
             )}
             {!columnsToHide.includes("status") && (

--- a/components/frontend/src/subject/SubjectTableRow.test.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.test.jsx
@@ -7,10 +7,12 @@ import { useSettings } from "../app_ui_settings"
 import { DataModelContext } from "../context/DataModel"
 import { EDIT_REPORT_PERMISSION, PermissionsContext } from "../context/Permissions"
 import {
+    asyncClickButton,
     expectLabelText,
     expectNoAccessibilityViolations,
     expectNoLabelText,
     expectNoText,
+    expectSearch,
     expectText,
 } from "../testUtils"
 import { SnackbarAlerts } from "../widgets/SnackbarAlerts"
@@ -195,4 +197,24 @@ it("shows the metric name", async () => {
 it("shows the metric secondary name", async () => {
     renderSubjectTableRow({ secondaryName: "Secondary name" })
     expectText("Secondary name")
+})
+
+it("expands the metric on the trend graph tab when the sparkline is clicked", async () => {
+    renderSubjectTableRow()
+    await asyncClickButton(/show trend graph/i)
+    expectSearch("?expanded=metric_uuid%3A4")
+})
+
+it("switches to the trend graph tab when the sparkline is clicked on an expanded row with a different tab", async () => {
+    history.push("?expanded=metric_uuid:0")
+    renderSubjectTableRow()
+    await asyncClickButton(/show trend graph/i)
+    expectSearch("?expanded=metric_uuid%3A4")
+})
+
+it("collapses the metric when the sparkline is clicked on an expanded row with the trend graph tab active", async () => {
+    history.push("?expanded=metric_uuid:4")
+    renderSubjectTableRow()
+    await asyncClickButton(/show trend graph/i)
+    expectSearch("")
 })

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -10,6 +10,12 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the tools/release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Added
+
+- Make the spark line graph clickable to expand the metric on the trend graph tab, and collapse the metric when clicked again while the trend graph tab is active. Closes [#13024](https://github.com/ICTU/quality-time/issues/13024).
+
 ## v5.53.0 - 2026-04-24
 
 ### Fixed


### PR DESCRIPTION
Make the spark line graph clickable to expand the metric on the trend graph tab, and collapse the metric when clicked again while the trend graph tab is active.

Closes #13024.