### PR TITLE
Clicking the metric name expands the metric

### DIFF
--- a/components/frontend/package-lock.json
+++ b/components/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "quality-time-app",
-    "version": "5.53.0-rc.0",
+    "version": "5.53.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "quality-time-app",
-            "version": "5.53.0-rc.0",
+            "version": "5.53.0",
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",

--- a/components/frontend/src/hooks/url_search_query.js
+++ b/components/frontend/src/hooks/url_search_query.js
@@ -100,6 +100,14 @@ function useMappingURLSearchQuery(key, parseValue, missingItemValue) {
         const newValue = [...hook._allItemsExcept(itemKey), `${itemKey}:${itemValue}`]
         setURLSearchQuery(key, newValue, hook.defaultValue, hook.set)
     }
+    hook.setOrDeleteItem = (itemKey, itemValue) => {
+        // Assign the value to the key, unless the key already has the value, then delete the key/value pair
+        if (hook.includes(itemKey) && hook.getItem(itemKey) === itemValue) {
+            hook.deleteItem(itemKey)
+        } else {
+            hook.setItem(itemKey, itemValue)
+        }
+    }
     return hook
 }
 

--- a/components/frontend/src/measurement/TrendSparkline.jsx
+++ b/components/frontend/src/measurement/TrendSparkline.jsx
@@ -1,10 +1,11 @@
-import { ButtonBase, useTheme } from "@mui/material"
+import { useTheme } from "@mui/material"
 import { func } from "prop-types"
 import { useState } from "react"
 import { VictoryGroup, VictoryLine, VictoryTheme } from "victory"
 
 import { datePropType, measurementsPropType, scalePropType } from "../sharedPropTypes"
 import { pluralize } from "../utils"
+import { ButtonBase } from "../widgets/buttons/ButtonBase"
 
 export function TrendSparkline({ measurements, onClick, reportDate, scale }) {
     const [now] = useState(() => (reportDate ? new Date(reportDate) : new Date()))
@@ -56,20 +57,7 @@ export function TrendSparkline({ measurements, onClick, reportDate, scale }) {
         return sparkline
     }
     return (
-        <ButtonBase
-            aria-label="Show trend graph for this metric"
-            focusRipple
-            onClick={onClick}
-            sx={{
-                display: "block",
-                height: "100%",
-                padding: 2,
-                width: "100%",
-                "&:hover, &.Mui-focusVisible": {
-                    backgroundColor: "action.hover",
-                },
-            }}
-        >
+        <ButtonBase ariaLabel="Show trend graph for this metric" onClick={onClick}>
             {sparkline}
         </ButtonBase>
     )

--- a/components/frontend/src/metric/MetricDetails.jsx
+++ b/components/frontend/src/metric/MetricDetails.jsx
@@ -36,6 +36,7 @@ import { MetricConfigurationParameters } from "./MetricConfigurationParameters"
 import { MetricDebtParameters } from "./MetricDebtParameters"
 import { TrendGraph } from "./TrendGraph"
 
+export const METRIC_NAME_TAB_INDEX = 0
 export const TREND_GRAPH_TAB_INDEX = 4
 
 function RequestMeasurementButton({ metric, metricUuid, reload }) {

--- a/components/frontend/src/subject/SubjectTableRow.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.jsx
@@ -13,7 +13,7 @@ import { Overrun } from "../measurement/Overrun"
 import { StatusIcon } from "../measurement/StatusIcon"
 import { TimeLeft } from "../measurement/TimeLeft"
 import { TrendSparkline } from "../measurement/TrendSparkline"
-import { MetricDetails, TREND_GRAPH_TAB_INDEX } from "../metric/MetricDetails"
+import { METRIC_NAME_TAB_INDEX, MetricDetails, TREND_GRAPH_TAB_INDEX } from "../metric/MetricDetails"
 import { measurementOnDate } from "../report/report_utils"
 import {
     dataModelPropType,
@@ -39,6 +39,7 @@ import {
     getMetricTags,
     getMetricUnit,
 } from "../utils"
+import { ButtonBase } from "../widgets/buttons/ButtonBase"
 import { DivWithHtml } from "../widgets/DivWithHtml"
 import { TableRowWithDetails } from "../widgets/TableRowWithDetails"
 import { Tag } from "../widgets/Tag"
@@ -212,21 +213,28 @@ MeasurementCells.propTypes = {
     settings: settingsPropType,
 }
 
-function MetricName({ metric }) {
+function MetricName({ metric, onClick }) {
     const dataModel = useContext(DataModelContext)
     const name = getMetricName(metric, dataModel)
     if (metric.secondary_name) {
         return (
-            <Stack>
-                {name}
-                <Typography sx={{ fontSize: "90%" }}>{metric.secondary_name}</Typography>
-            </Stack>
+            <ButtonBase ariaLabel="Show configuration tab for this metric" onClick={onClick}>
+                <Stack>
+                    {name}
+                    <Typography sx={{ fontSize: "90%" }}>{metric.secondary_name}</Typography>
+                </Stack>
+            </ButtonBase>
         )
     }
-    return name
+    return (
+        <ButtonBase ariaLabel="Show configuration tab for this metric" onClick={onClick}>
+            {name}
+        </ButtonBase>
+    )
 }
 MetricName.propTypes = {
     metric: metricPropType,
+    onClick: func,
 }
 
 const DragHandleButton = function DragHandleButton({ ref, label, ...props }) {
@@ -319,7 +327,13 @@ export function SubjectTableRow({
             expanded={settings.expandedItems.includes(metricUuid)}
             id={metricUuid}
             onExpand={() => settings.expandedItems.toggle(metricUuid)}
-            firstCellContent={<MetricName metric={metric} />}
+            firstCellContent={
+                <MetricName
+                    metric={metric}
+                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_NAME_TAB_INDEX)}
+                />
+            }
+            firstCellProps={{ sx: { padding: "8px" } }}
         >
             {nrDates > 1 && (
                 <MeasurementCells
@@ -334,16 +348,7 @@ export function SubjectTableRow({
                 <TableCell sx={{ padding: 0, width: "150px" }}>
                     <TrendSparkline
                         measurements={metric.recent_measurements}
-                        onClick={() => {
-                            if (
-                                settings.expandedItems.includes(metricUuid) &&
-                                settings.expandedItems.getItem(metricUuid) === TREND_GRAPH_TAB_INDEX
-                            ) {
-                                settings.expandedItems.deleteItem(metricUuid)
-                            } else {
-                                settings.expandedItems.setItem(metricUuid, TREND_GRAPH_TAB_INDEX)
-                            }
-                        }}
+                        onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, TREND_GRAPH_TAB_INDEX)}
                         reportDate={reportDate}
                         scale={scale}
                     />

--- a/components/frontend/src/subject/SubjectTableRow.test.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.test.jsx
@@ -199,6 +199,26 @@ it("shows the metric secondary name", async () => {
     expectText("Secondary name")
 })
 
+it("expands the metric on the configuration tab when the metric name is clicked", async () => {
+    renderSubjectTableRow({ name: "Metric name" })
+    await asyncClickButton(/show configuration tab for this metric/i)
+    expectSearch("?expanded=metric_uuid%3A0")
+})
+
+it("switches to the configuration tab when the metric name is clicked on an expanded row with a different tab", async () => {
+    history.push("?expanded=metric_uuid:1")
+    renderSubjectTableRow()
+    await asyncClickButton(/show configuration tab for this metric/i)
+    expectSearch("?expanded=metric_uuid%3A0")
+})
+
+it("collapses the metric when the metric name is clicked on an expanded row with the configuation tab active", async () => {
+    history.push("?expanded=metric_uuid:0")
+    renderSubjectTableRow()
+    await asyncClickButton(/show configuration tab for this metric/i)
+    expectSearch("")
+})
+
 it("expands the metric on the trend graph tab when the sparkline is clicked", async () => {
     renderSubjectTableRow()
     await asyncClickButton(/show trend graph/i)

--- a/components/frontend/src/widgets/buttons/ButtonBase.jsx
+++ b/components/frontend/src/widgets/buttons/ButtonBase.jsx
@@ -1,0 +1,32 @@
+import { ButtonBase as MUIButtonBase } from "@mui/material"
+import { func, string } from "prop-types"
+
+import { childrenPropType } from "../../sharedPropTypes"
+
+export function ButtonBase({ ariaLabel, children, onClick }) {
+    return (
+        <MUIButtonBase
+            aria-label={ariaLabel}
+            focusRipple
+            onClick={onClick}
+            sx={{
+                display: "block",
+                textAlign: "inherit",
+                fontSize: "inherit",
+                height: "100%",
+                padding: 2,
+                width: "100%",
+                "&:hover, &.Mui-focusVisible": {
+                    backgroundColor: "action.hover",
+                },
+            }}
+        >
+            {children}
+        </MUIButtonBase>
+    )
+}
+ButtonBase.propTypes = {
+    ariaLabel: string,
+    children: childrenPropType,
+    onClick: func,
+}

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -15,6 +15,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Added
 
 - Make the spark line graph clickable to expand the metric on the trend graph tab, and collapse the metric when clicked again while the trend graph tab is active. Closes [#13024](https://github.com/ICTU/quality-time/issues/13024).
+- Make the metric name clickable to expand the metric on the metric configuration tab, and collapse the metric when clicked again while the configuration tab is active. Closes [#13027](https://github.com/ICTU/quality-time/issues/13027).
 
 ## v5.53.0 - 2026-04-24
 


### PR DESCRIPTION
Make the metric name clickable to expand the metric on the metric configuration tab, and collapse the metric when clicked again while the configuration tab is active.

Closes #13027.