### PR TITLE
Show technical debt tab on metric status click

### DIFF
--- a/components/frontend/src/metric/MetricDetails.jsx
+++ b/components/frontend/src/metric/MetricDetails.jsx
@@ -37,6 +37,7 @@ import { MetricDebtParameters } from "./MetricDebtParameters"
 import { TrendGraph } from "./TrendGraph"
 
 export const METRIC_NAME_TAB_INDEX = 0
+export const METRIC_DEBT_TAB_INDEX = 2
 export const TREND_GRAPH_TAB_INDEX = 4
 
 function RequestMeasurementButton({ metric, metricUuid, reload }) {

--- a/components/frontend/src/subject/SubjectTableRow.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.jsx
@@ -13,7 +13,12 @@ import { Overrun } from "../measurement/Overrun"
 import { StatusIcon } from "../measurement/StatusIcon"
 import { TimeLeft } from "../measurement/TimeLeft"
 import { TrendSparkline } from "../measurement/TrendSparkline"
-import { METRIC_NAME_TAB_INDEX, MetricDetails, TREND_GRAPH_TAB_INDEX } from "../metric/MetricDetails"
+import {
+    METRIC_DEBT_TAB_INDEX,
+    METRIC_NAME_TAB_INDEX,
+    MetricDetails,
+    TREND_GRAPH_TAB_INDEX,
+} from "../metric/MetricDetails"
 import { measurementOnDate } from "../report/report_utils"
 import {
     dataModelPropType,
@@ -345,7 +350,7 @@ export function SubjectTableRow({
                 />
             )}
             {!columnsToHide.includes("trend") && (
-                <TableCell sx={{ padding: 0, width: "150px" }}>
+                <TableCell sx={{ padding: "0px", width: "150px" }}>
                     <TrendSparkline
                         measurements={metric.recent_measurements}
                         onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, TREND_GRAPH_TAB_INDEX)}
@@ -355,10 +360,15 @@ export function SubjectTableRow({
                 </TableCell>
             )}
             {!columnsToHide.includes("status") && (
-                <TableCell>
-                    <Typography sx={{ paddingLeft: "6px", fontSize: "24px" }}>
-                        <StatusIcon status={metric.status} statusStart={metric.status_start} />
-                    </Typography>
+                <TableCell sx={{ padding: "8px" }}>
+                    <ButtonBase
+                        ariaLabel="Show technical debt tab for this metric"
+                        onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_DEBT_TAB_INDEX)}
+                    >
+                        <Typography sx={{ paddingLeft: "6px", fontSize: "24px" }}>
+                            <StatusIcon status={metric.status} statusStart={metric.status_start} />
+                        </Typography>
+                    </ButtonBase>
                 </TableCell>
             )}
             {!columnsToHide.includes("measurement") && (

--- a/components/frontend/src/subject/SubjectTableRow.test.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.test.jsx
@@ -1,4 +1,6 @@
 import { Table, TableBody } from "@mui/material"
+import { LocalizationProvider } from "@mui/x-date-pickers"
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs"
 import { act, render } from "@testing-library/react"
 import history from "history/browser"
 
@@ -90,21 +92,23 @@ function renderSubjectTableRow({
     secondaryName = "",
 } = {}) {
     return render(
-        <PermissionsContext value={[permissions]}>
-            <DataModelContext value={dataModel}>
-                <SnackbarAlerts messages={[]} showMessage={() => {}}>
-                    <SubjectTableRowWrapper
-                        ascending={ascending}
-                        comment={comment}
-                        direction={direction}
-                        evaluateTargets={evaluateTargets}
-                        name={name}
-                        scale={scale}
-                        secondaryName={secondaryName}
-                    />
-                </SnackbarAlerts>
-            </DataModelContext>
-        </PermissionsContext>,
+        <LocalizationProvider dateAdapter={AdapterDayjs}>
+            <PermissionsContext value={[permissions]}>
+                <DataModelContext value={dataModel}>
+                    <SnackbarAlerts messages={[]} showMessage={() => {}}>
+                        <SubjectTableRowWrapper
+                            ascending={ascending}
+                            comment={comment}
+                            direction={direction}
+                            evaluateTargets={evaluateTargets}
+                            name={name}
+                            scale={scale}
+                            secondaryName={secondaryName}
+                        />
+                    </SnackbarAlerts>
+                </DataModelContext>
+            </PermissionsContext>
+        </LocalizationProvider>,
     )
 }
 
@@ -216,6 +220,26 @@ it("collapses the metric when the metric name is clicked on an expanded row with
     history.push("?expanded=metric_uuid:0")
     renderSubjectTableRow()
     await asyncClickButton(/show configuration tab for this metric/i)
+    expectSearch("")
+})
+
+it("expands the metric on the technical debt tab when the status is clicked", async () => {
+    renderSubjectTableRow()
+    await asyncClickButton(/show technical debt tab for this metric/i)
+    expectSearch("?expanded=metric_uuid%3A2")
+})
+
+it("switches to the technical debt tab when the status is clicked on an expanded row with a different tab", async () => {
+    history.push("?expanded=metric_uuid:0")
+    renderSubjectTableRow()
+    await asyncClickButton(/show technical debt tab for this metric/i)
+    expectSearch("?expanded=metric_uuid%3A2")
+})
+
+it("collapses the metric when the status is clicked on an expanded row with the technical debt tab active", async () => {
+    history.push("?expanded=metric_uuid:2")
+    renderSubjectTableRow()
+    await asyncClickButton(/show technical debt tab for this metric/i)
     expectSearch("")
 })
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - Make the spark line graph clickable to expand the metric on the trend graph tab, and collapse the metric when clicked again while the trend graph tab is active. Closes [#13024](https://github.com/ICTU/quality-time/issues/13024).
 - Make the metric name clickable to expand the metric on the metric configuration tab, and collapse the metric when clicked again while the configuration tab is active. Closes [#13027](https://github.com/ICTU/quality-time/issues/13027).
+- Make the metric status clickable to expand the metric on the technical debt tab, and collapse the metric when clicked again while the technical debt tab is active. Closes [#13029](https://github.com/ICTU/quality-time/issues/13029).
 
 ## v5.53.0 - 2026-04-24
 


### PR DESCRIPTION
Make the metric status clickable to expand the metric on the technical debt tab, and collapse the metric when clicked again while the technical debt tab is active.

Closes #13029.