### PR TITLE
Open source tab on clicking measurement value

### DIFF
--- a/components/frontend/src/metric/MetricDetails.jsx
+++ b/components/frontend/src/metric/MetricDetails.jsx
@@ -36,9 +36,10 @@ import { MetricConfigurationParameters } from "./MetricConfigurationParameters"
 import { MetricDebtParameters } from "./MetricDebtParameters"
 import { TrendGraph } from "./TrendGraph"
 
-export const METRIC_NAME_TAB_INDEX = 0
+export const METRIC_CONFIGURATION_TAB_INDEX = 0
 export const METRIC_DEBT_TAB_INDEX = 2
 export const TREND_GRAPH_TAB_INDEX = 4
+export const SOURCE_TAB_INDEX = 5
 
 function RequestMeasurementButton({ metric, metricUuid, reload }) {
     const dataModel = useContext(DataModelContext)

--- a/components/frontend/src/subject/SubjectTableRow.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.jsx
@@ -14,9 +14,10 @@ import { StatusIcon } from "../measurement/StatusIcon"
 import { TimeLeft } from "../measurement/TimeLeft"
 import { TrendSparkline } from "../measurement/TrendSparkline"
 import {
+    METRIC_CONFIGURATION_TAB_INDEX,
     METRIC_DEBT_TAB_INDEX,
-    METRIC_NAME_TAB_INDEX,
     MetricDetails,
+    SOURCE_TAB_INDEX,
     TREND_GRAPH_TAB_INDEX,
 } from "../metric/MetricDetails"
 import { measurementOnDate } from "../report/report_utils"
@@ -335,7 +336,7 @@ export function SubjectTableRow({
             firstCellContent={
                 <MetricName
                     metric={metric}
-                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_NAME_TAB_INDEX)}
+                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_CONFIGURATION_TAB_INDEX)}
                 />
             }
             firstCellProps={{ sx: { padding: "8px" } }}
@@ -373,7 +374,12 @@ export function SubjectTableRow({
             )}
             {!columnsToHide.includes("measurement") && (
                 <TableCell align="right">
-                    <MeasurementValue metric={metric} reportDate={reportDate} />
+                    <ButtonBase
+                        ariaLabel="Show source tab for this metric"
+                        onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, SOURCE_TAB_INDEX)}
+                    >
+                        <MeasurementValue metric={metric} reportDate={reportDate} />
+                    </ButtonBase>
                 </TableCell>
             )}
             {!columnsToHide.includes("target") && (

--- a/components/frontend/src/subject/SubjectTableRow.test.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.test.jsx
@@ -9,6 +9,12 @@ import { useSettings } from "../app_ui_settings"
 import { DataModelContext } from "../context/DataModel"
 import { EDIT_REPORT_PERMISSION, PermissionsContext } from "../context/Permissions"
 import {
+    METRIC_CONFIGURATION_TAB_INDEX,
+    METRIC_DEBT_TAB_INDEX,
+    SOURCE_TAB_INDEX,
+    TREND_GRAPH_TAB_INDEX,
+} from "../metric/MetricDetails"
+import {
     asyncClickButton,
     expectLabelText,
     expectNoAccessibilityViolations,
@@ -175,7 +181,7 @@ it("shows the drag handle when row is not expanded and user is authenticated", (
 })
 
 it("shows no drag handle when row is expanded", async () => {
-    history.push("?expanded=metric_uuid:0")
+    history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
     await act(async () => {
         renderSubjectTableRow()
     })
@@ -206,18 +212,18 @@ it("shows the metric secondary name", async () => {
 it("expands the metric on the configuration tab when the metric name is clicked", async () => {
     renderSubjectTableRow({ name: "Metric name" })
     await asyncClickButton(/show configuration tab for this metric/i)
-    expectSearch("?expanded=metric_uuid%3A0")
+    expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
 })
 
 it("switches to the configuration tab when the metric name is clicked on an expanded row with a different tab", async () => {
     history.push("?expanded=metric_uuid:1")
     renderSubjectTableRow()
     await asyncClickButton(/show configuration tab for this metric/i)
-    expectSearch("?expanded=metric_uuid%3A0")
+    expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
 })
 
 it("collapses the metric when the metric name is clicked on an expanded row with the configuation tab active", async () => {
-    history.push("?expanded=metric_uuid:0")
+    history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
     renderSubjectTableRow()
     await asyncClickButton(/show configuration tab for this metric/i)
     expectSearch("")
@@ -226,18 +232,18 @@ it("collapses the metric when the metric name is clicked on an expanded row with
 it("expands the metric on the technical debt tab when the status is clicked", async () => {
     renderSubjectTableRow()
     await asyncClickButton(/show technical debt tab for this metric/i)
-    expectSearch("?expanded=metric_uuid%3A2")
+    expectSearch(`?expanded=metric_uuid%3A${METRIC_DEBT_TAB_INDEX}`)
 })
 
 it("switches to the technical debt tab when the status is clicked on an expanded row with a different tab", async () => {
-    history.push("?expanded=metric_uuid:0")
+    history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
     renderSubjectTableRow()
     await asyncClickButton(/show technical debt tab for this metric/i)
-    expectSearch("?expanded=metric_uuid%3A2")
+    expectSearch(`?expanded=metric_uuid%3A${METRIC_DEBT_TAB_INDEX}`)
 })
 
 it("collapses the metric when the status is clicked on an expanded row with the technical debt tab active", async () => {
-    history.push("?expanded=metric_uuid:2")
+    history.push(`?expanded=metric_uuid:${METRIC_DEBT_TAB_INDEX}`)
     renderSubjectTableRow()
     await asyncClickButton(/show technical debt tab for this metric/i)
     expectSearch("")
@@ -246,19 +252,39 @@ it("collapses the metric when the status is clicked on an expanded row with the 
 it("expands the metric on the trend graph tab when the sparkline is clicked", async () => {
     renderSubjectTableRow()
     await asyncClickButton(/show trend graph/i)
-    expectSearch("?expanded=metric_uuid%3A4")
+    expectSearch(`?expanded=metric_uuid%3A${TREND_GRAPH_TAB_INDEX}`)
 })
 
 it("switches to the trend graph tab when the sparkline is clicked on an expanded row with a different tab", async () => {
-    history.push("?expanded=metric_uuid:0")
+    history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
     renderSubjectTableRow()
     await asyncClickButton(/show trend graph/i)
-    expectSearch("?expanded=metric_uuid%3A4")
+    expectSearch(`?expanded=metric_uuid%3A${TREND_GRAPH_TAB_INDEX}`)
 })
 
 it("collapses the metric when the sparkline is clicked on an expanded row with the trend graph tab active", async () => {
-    history.push("?expanded=metric_uuid:4")
+    history.push(`?expanded=metric_uuid:${TREND_GRAPH_TAB_INDEX}`)
     renderSubjectTableRow()
     await asyncClickButton(/show trend graph/i)
+    expectSearch("")
+})
+
+it("expands the metric on the first source tab when the measurement value is clicked", async () => {
+    renderSubjectTableRow()
+    await asyncClickButton(/show source tab/i)
+    expectSearch(`?expanded=metric_uuid%3A${SOURCE_TAB_INDEX}`)
+})
+
+it("switches to the source tab when the measurement value is clicked on an expanded row with a different tab", async () => {
+    history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
+    renderSubjectTableRow()
+    await asyncClickButton(/show source tab/i)
+    expectSearch(`?expanded=metric_uuid%3A${SOURCE_TAB_INDEX}`)
+})
+
+it("collapses the metric when the measurement value is clicked on an expanded row with the source tab active", async () => {
+    history.push(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
+    renderSubjectTableRow()
+    await asyncClickButton(/show source tab/i)
     expectSearch("")
 })

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,9 +14,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ### Added
 
-- Make the spark line graph clickable to expand the metric on the trend graph tab, and collapse the metric when clicked again while the trend graph tab is active. Closes [#13024](https://github.com/ICTU/quality-time/issues/13024).
-- Make the metric name clickable to expand the metric on the metric configuration tab, and collapse the metric when clicked again while the configuration tab is active. Closes [#13027](https://github.com/ICTU/quality-time/issues/13027).
-- Make the metric status clickable to expand the metric on the technical debt tab, and collapse the metric when clicked again while the technical debt tab is active. Closes [#13029](https://github.com/ICTU/quality-time/issues/13029).
+- Clicking the spark line graph expands the metric on the trend graph tab, and collapses the metric when clicked again while the trend graph tab is active. Closes [#13024](https://github.com/ICTU/quality-time/issues/13024).
+- Clicking the metric name expands the metric on the metric configuration tab, and collapses the metric when clicked again while the configuration tab is active. Closes [#13027](https://github.com/ICTU/quality-time/issues/13027).
+- Clicking the metric status expands the metric on the technical debt tab, and collapses the metric when clicked again while the technical debt tab is active. Closes [#13029](https://github.com/ICTU/quality-time/issues/13029).
+- Clicking the measurement value expands the metric on the first source tab, and collapses the metric when clicked again while the first source tab is active. Closes [#13032](https://github.com/ICTU/quality-time/issues/13032).
 
 ## v5.53.0 - 2026-04-24
 


### PR DESCRIPTION
Make the measurement value clickable to expand the metric on the first source tab, and collapse the metric when clicked again while the first source tab is active.

Closes #13032.