### PR TITLE
Show configuration tab on clicking target value

### DIFF
--- a/components/frontend/src/measurement/TrendSparkline.jsx
+++ b/components/frontend/src/measurement/TrendSparkline.jsx
@@ -1,13 +1,11 @@
 import { useTheme } from "@mui/material"
-import { func } from "prop-types"
 import { useState } from "react"
 import { VictoryGroup, VictoryLine, VictoryTheme } from "victory"
 
 import { datePropType, measurementsPropType, scalePropType } from "../sharedPropTypes"
 import { pluralize } from "../utils"
-import { ButtonBase } from "../widgets/buttons/ButtonBase"
 
-export function TrendSparkline({ measurements, onClick, reportDate, scale }) {
+export function TrendSparkline({ measurements, reportDate, scale }) {
     const [now] = useState(() => (reportDate ? new Date(reportDate) : new Date()))
     const [weekAgo] = useState(() => {
         let date = reportDate ? new Date(reportDate) : new Date()
@@ -31,7 +29,7 @@ export function TrendSparkline({ measurements, onClick, reportDate, scale }) {
     const ariaLabel = `sparkline graph showing ${yValues.size} different measurement ${pluralize("value", yValues.size)} in the week before ${reportDate ? now.toLocaleDateString() : "today"}`
     // The width property below is not used according to https://formidable.com/open-source/victory/docs/common-props#width,
     // but setting it prevents these messages in the console: "Warning: `Infinity` is an invalid value for the `width` css style property.""
-    const sparkline = (
+    return (
         <VictoryGroup
             aria-label={ariaLabel}
             theme={VictoryTheme.material}
@@ -53,18 +51,9 @@ export function TrendSparkline({ measurements, onClick, reportDate, scale }) {
             />
         </VictoryGroup>
     )
-    if (!onClick) {
-        return sparkline
-    }
-    return (
-        <ButtonBase ariaLabel="Show trend graph for this metric" onClick={onClick}>
-            {sparkline}
-        </ButtonBase>
-    )
 }
 TrendSparkline.propTypes = {
     measurements: measurementsPropType,
-    onClick: func,
     reportDate: datePropType,
     scale: scalePropType,
 }

--- a/components/frontend/src/measurement/TrendSparkline.test.jsx
+++ b/components/frontend/src/measurement/TrendSparkline.test.jsx
@@ -1,8 +1,6 @@
 import { render, screen } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
-import { vi } from "vitest"
 
-import { clickButton, expectNoAccessibilityViolations } from "../testUtils"
+import { expectNoAccessibilityViolations } from "../testUtils"
 import { TrendSparkline } from "./TrendSparkline"
 
 it("has no accessibility violations", async () => {
@@ -80,40 +78,4 @@ it("has no accessibility violations when clickable", async () => {
         />,
     )
     await expectNoAccessibilityViolations(container)
-})
-
-it("does not render a button when onClick is not provided", async () => {
-    render(<TrendSparkline measurements={[]} scale="count" />)
-    expect(screen.queryByRole("button")).toBeNull()
-})
-
-it("renders a button when onClick is provided", async () => {
-    const onClick = vi.fn()
-    render(<TrendSparkline measurements={[]} onClick={onClick} scale="count" />)
-    expect(screen.getByRole("button", { name: /show trend graph/i })).toBeInTheDocument()
-})
-
-it("invokes onClick when the button is clicked", async () => {
-    const onClick = vi.fn()
-    render(<TrendSparkline measurements={[]} onClick={onClick} scale="count" />)
-    clickButton(/show trend graph/i)
-    expect(onClick).toHaveBeenCalledTimes(1)
-})
-
-it("invokes onClick when the button is activated with the space key", async () => {
-    const onClick = vi.fn()
-    render(<TrendSparkline measurements={[]} onClick={onClick} scale="count" />)
-    const button = screen.getByRole("button", { name: /show trend graph/i })
-    button.focus()
-    await userEvent.keyboard(" ")
-    expect(onClick).toHaveBeenCalledTimes(1)
-})
-
-it("invokes onClick when the button is activated with the enter key", async () => {
-    const onClick = vi.fn()
-    render(<TrendSparkline measurements={[]} onClick={onClick} scale="count" />)
-    const button = screen.getByRole("button", { name: /show trend graph/i })
-    button.focus()
-    await userEvent.keyboard("{Enter}")
-    expect(onClick).toHaveBeenCalledTimes(1)
 })

--- a/components/frontend/src/subject/SubjectTableRow.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.jsx
@@ -352,12 +352,16 @@ export function SubjectTableRow({
             )}
             {!columnsToHide.includes("trend") && (
                 <TableCell sx={{ padding: "0px", width: "150px" }}>
-                    <TrendSparkline
-                        measurements={metric.recent_measurements}
+                    <ButtonBase
+                        ariaLabel="Show trend graph for this metric"
                         onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, TREND_GRAPH_TAB_INDEX)}
-                        reportDate={reportDate}
-                        scale={scale}
-                    />
+                    >
+                        <TrendSparkline
+                            measurements={metric.recent_measurements}
+                            reportDate={reportDate}
+                            scale={scale}
+                        />
+                    </ButtonBase>
                 </TableCell>
             )}
             {!columnsToHide.includes("status") && (
@@ -384,7 +388,14 @@ export function SubjectTableRow({
             )}
             {!columnsToHide.includes("target") && (
                 <TableCell align="right">
-                    <MeasurementTarget metric={metric} />
+                    <ButtonBase
+                        ariaLabel="Show configuration tab for this metric"
+                        onClick={() =>
+                            settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_CONFIGURATION_TAB_INDEX)
+                        }
+                    >
+                        <MeasurementTarget metric={metric} />
+                    </ButtonBase>
                 </TableCell>
             )}
             {!columnsToHide.includes("unit") && <TableCell>{unit}</TableCell>}

--- a/components/frontend/src/subject/SubjectTableRow.test.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.test.jsx
@@ -211,21 +211,21 @@ it("shows the metric secondary name", async () => {
 
 it("expands the metric on the configuration tab when the metric name is clicked", async () => {
     renderSubjectTableRow({ name: "Metric name" })
-    await asyncClickButton(/show configuration tab for this metric/i)
+    await asyncClickButton(/show configuration tab for this metric/i, 0)
     expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
 })
 
 it("switches to the configuration tab when the metric name is clicked on an expanded row with a different tab", async () => {
     history.push("?expanded=metric_uuid:1")
     renderSubjectTableRow()
-    await asyncClickButton(/show configuration tab for this metric/i)
+    await asyncClickButton(/show configuration tab for this metric/i, 0)
     expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
 })
 
 it("collapses the metric when the metric name is clicked on an expanded row with the configuation tab active", async () => {
     history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
     renderSubjectTableRow()
-    await asyncClickButton(/show configuration tab for this metric/i)
+    await asyncClickButton(/show configuration tab for this metric/i, 0)
     expectSearch("")
 })
 
@@ -286,5 +286,25 @@ it("collapses the metric when the measurement value is clicked on an expanded ro
     history.push(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
     renderSubjectTableRow()
     await asyncClickButton(/show source tab/i)
+    expectSearch("")
+})
+
+it("expands the metric on the configuration tab when the target value is clicked", async () => {
+    renderSubjectTableRow()
+    await asyncClickButton(/show configuration tab for this metric/i, 1)
+    expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
+})
+
+it("switches to the configuration tab when the measurement target is clicked on an expanded row with a different tab", async () => {
+    history.push(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
+    renderSubjectTableRow()
+    await asyncClickButton(/show configuration tab for this metric/i, 1)
+    expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
+})
+
+it("collapses the metric when the measurement target is clicked on an expanded row with the configuration tab active", async () => {
+    history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
+    renderSubjectTableRow()
+    await asyncClickButton(/show configuration tab for this metric/i, 1)
     expectSearch("")
 })

--- a/components/frontend/src/widgets/buttons/ButtonBase.jsx
+++ b/components/frontend/src/widgets/buttons/ButtonBase.jsx
@@ -13,8 +13,7 @@ export function ButtonBase({ ariaLabel, children, onClick }) {
                 display: "block",
                 textAlign: "inherit",
                 fontSize: "inherit",
-                height: "100%",
-                padding: 2,
+                padding: "8px",
                 width: "100%",
                 "&:hover, &.Mui-focusVisible": {
                     backgroundColor: "action.hover",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 - Clicking the metric name expands the metric on the metric configuration tab, and collapses the metric when clicked again while the configuration tab is active. Closes [#13027](https://github.com/ICTU/quality-time/issues/13027).
 - Clicking the metric status expands the metric on the technical debt tab, and collapses the metric when clicked again while the technical debt tab is active. Closes [#13029](https://github.com/ICTU/quality-time/issues/13029).
 - Clicking the measurement value expands the metric on the first source tab, and collapses the metric when clicked again while the first source tab is active. Closes [#13032](https://github.com/ICTU/quality-time/issues/13032).
+- Clicking the target value expands the metric on the metric configuration tab, and collapses the metric when clicked again while the configuration tab is active. Closes [#13034](https://github.com/ICTU/quality-time/issues/13034).
 
 ## v5.53.0 - 2026-04-24
 


### PR DESCRIPTION
Clicking the target value expands the metric on the metric configuration tab, and collapses the metric when clicked again while the configuration tab is active.

Closes #13034.