### PR TITLE
Clicking the unit expands the metric

### DIFF
--- a/components/frontend/src/subject/SubjectTableRow.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.jsx
@@ -398,7 +398,18 @@ export function SubjectTableRow({
                     </ButtonBase>
                 </TableCell>
             )}
-            {!columnsToHide.includes("unit") && <TableCell>{unit}</TableCell>}
+            {!columnsToHide.includes("unit") && (
+                <TableCell>
+                    <ButtonBase
+                        ariaLabel="Show configuration tab for this metric"
+                        onClick={() =>
+                            settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_CONFIGURATION_TAB_INDEX)
+                        }
+                    >
+                        {unit}
+                    </ButtonBase>
+                </TableCell>
+            )}
             {!columnsToHide.includes("source") && (
                 <TableCell>
                     <MeasurementSources metric={metric} />

--- a/components/frontend/src/subject/SubjectTableRow.test.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.test.jsx
@@ -308,3 +308,23 @@ it("collapses the metric when the measurement target is clicked on an expanded r
     await asyncClickButton(/show configuration tab for this metric/i, 1)
     expectSearch("")
 })
+
+it("expands the metric on the configuration tab when the unit is clicked", async () => {
+    renderSubjectTableRow()
+    await asyncClickButton(/show configuration tab for this metric/i, 2)
+    expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
+})
+
+it("switches to the configuration tab when the unit is clicked on an expanded row with a different tab", async () => {
+    history.push(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
+    renderSubjectTableRow()
+    await asyncClickButton(/show configuration tab for this metric/i, 2)
+    expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
+})
+
+it("collapses the metric when the unit is clicked on an expanded row with the configuration tab active", async () => {
+    history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
+    renderSubjectTableRow()
+    await asyncClickButton(/show configuration tab for this metric/i, 2)
+    expectSearch("")
+})

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,6 +19,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 - Clicking the metric status expands the metric on the technical debt tab, and collapses the metric when clicked again while the technical debt tab is active. Closes [#13029](https://github.com/ICTU/quality-time/issues/13029).
 - Clicking the measurement value expands the metric on the first source tab, and collapses the metric when clicked again while the first source tab is active. Closes [#13032](https://github.com/ICTU/quality-time/issues/13032).
 - Clicking the target value expands the metric on the metric configuration tab, and collapses the metric when clicked again while the configuration tab is active. Closes [#13034](https://github.com/ICTU/quality-time/issues/13034).
+- Clicking the unit expands the metric on the metric configuration tab, and collapses the metric when clicked again while the configuration tab is active. Closes [#13036](https://github.com/ICTU/quality-time/issues/13036).
 
 ## v5.53.0 - 2026-04-24
 


### PR DESCRIPTION
Clicking the unit expands the metric on the metric configuration tab, and collapses the metric when clicked again while the configuration tab is active.

Closes #13036.