### PR TITLE
Clicking comments expands the metric

### DIFF
--- a/components/frontend/src/subject/SubjectTableRow.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.jsx
@@ -410,7 +410,10 @@ export function SubjectTableRow({
                 </TableCell>
             )}
             {!columnsToHide.includes("comment") && (
-                <TableCell>
+                <TableCell
+                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_DEBT_TAB_INDEX)}
+                    sx={clickableStyle}
+                >
                     <DivWithHtml>{metric.comment}</DivWithHtml>
                 </TableCell>
             )}

--- a/components/frontend/src/subject/SubjectTableRow.test.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.test.jsx
@@ -358,3 +358,23 @@ it("collapses the metric when the time left is clicked on an expanded row with t
     await asyncClickText(/days/)
     expectSearch("")
 })
+
+it("expands the metric on the technical debt tab when the comment is clicked", async () => {
+    renderSubjectTableRow({ comment: "Metric comment" })
+    await asyncClickText("Metric comment")
+    expectSearch(`?expanded=metric_uuid%3A${METRIC_DEBT_TAB_INDEX}`)
+})
+
+it("switches to the technical debt tab when the comment is clicked on an expanded row with a different tab", async () => {
+    history.push(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
+    renderSubjectTableRow({ comment: "Metric comment" })
+    await asyncClickText("Metric comment")
+    expectSearch(`?expanded=metric_uuid%3A${METRIC_DEBT_TAB_INDEX}`)
+})
+
+it("collapses the metric when the comment is clicked on an expanded row with the technical debt tab active", async () => {
+    history.push(`?expanded=metric_uuid:${METRIC_DEBT_TAB_INDEX}`)
+    renderSubjectTableRow({ comment: "Metric comment" })
+    await asyncClickText("Metric comment")
+    expectSearch("")
+})

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -21,6 +21,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 - Clicking the target value expands the metric on the metric configuration tab, and collapses the metric when clicked again while the configuration tab is active. Closes [#13034](https://github.com/ICTU/quality-time/issues/13034).
 - Clicking the unit expands the metric on the metric configuration tab, and collapses the metric when clicked again while the configuration tab is active. Closes [#13036](https://github.com/ICTU/quality-time/issues/13036).
 - Clicking the time left expands the metric on the technical debt tab, and collapses the metric when clicked again while the technical debt tab is active. Closes [#13038](https://github.com/ICTU/quality-time/issues/13038).
+- Clicking the metric comment expands the metric on the technical debt tab, and collapses the metric when clicked again while the technical debt tab is active. Closes [#13040](https://github.com/ICTU/quality-time/issues/13040).
 
 ## v5.53.0 - 2026-04-24
 


### PR DESCRIPTION
Clicking the metric comment expands the metric on the technical debt tab, and collapses the metric when clicked again while the technical debt tab is active.

Closes #13040.