### PR TITLE
Clicking the issues expands the metric

### DIFF
--- a/components/frontend/src/issue/IssueStatus.jsx
+++ b/components/frontend/src/issue/IssueStatus.jsx
@@ -141,7 +141,12 @@ prefixName.propType = {
 function IssueCard({ issueStatus, settings, error }) {
     // The issue status can be unknown when the issue was added recently and the status hasn't been collected yet
     const color = error ? "error" : (issueStatus.status_category ?? "unknown")
-    const onClick = issueStatus.landing_url ? () => globalThis.open(issueStatus.landing_url) : null
+    const onClick = issueStatus.landing_url
+        ? (event) => {
+              event.stopPropagation()
+              globalThis.open(issueStatus.landing_url)
+          }
+        : null
     return (
         <Card onClick={onClick} elevation={1} sx={{ display: "inline-flex", margin: "1px" }}>
             <CardActionArea disableRipple={!issueStatus.landing_url}>

--- a/components/frontend/src/subject/SubjectTableRow.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.jsx
@@ -418,7 +418,10 @@ export function SubjectTableRow({
                 </TableCell>
             )}
             {!columnsToHide.includes("issues") && (
-                <TableCell>
+                <TableCell
+                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_DEBT_TAB_INDEX)}
+                    sx={clickableStyle}
+                >
                     <IssueStatus metric={metric} issueTrackerMissing={!report.issue_tracker} settings={settings} />
                 </TableCell>
             )}

--- a/components/frontend/src/subject/SubjectTableRow.test.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.test.jsx
@@ -30,7 +30,16 @@ import { SubjectTableRow } from "./SubjectTableRow"
 
 beforeEach(() => history.push(""))
 
-function SubjectTableRowWrapper({ ascending, comment, direction, evaluateTargets, name, scale, secondaryName }) {
+function SubjectTableRowWrapper({
+    ascending,
+    comment,
+    direction,
+    evaluateTargets,
+    issueIds,
+    name,
+    scale,
+    secondaryName,
+}) {
     const settings = useSettings()
     const dates = [new Date("2024-01-03"), new Date("2024-01-02"), new Date("2024-01-01")]
     if (ascending) {
@@ -70,6 +79,7 @@ function SubjectTableRowWrapper({ ascending, comment, direction, evaluateTargets
                         comment: comment,
                         direction: direction,
                         evaluate_targets: evaluateTargets,
+                        issue_ids: issueIds,
                         name: name,
                         recent_measurements: [],
                         scale: scale,
@@ -96,6 +106,7 @@ function renderSubjectTableRow({
     ascending = false,
     scale = "count",
     evaluateTargets = undefined,
+    issueIds = undefined,
     permissions = "",
     name = "",
     secondaryName = "",
@@ -110,6 +121,7 @@ function renderSubjectTableRow({
                             comment={comment}
                             direction={direction}
                             evaluateTargets={evaluateTargets}
+                            issueIds={issueIds}
                             name={name}
                             scale={scale}
                             secondaryName={secondaryName}
@@ -376,5 +388,25 @@ it("collapses the metric when the comment is clicked on an expanded row with the
     history.push(`?expanded=metric_uuid:${METRIC_DEBT_TAB_INDEX}`)
     renderSubjectTableRow({ comment: "Metric comment" })
     await asyncClickText("Metric comment")
+    expectSearch("")
+})
+
+it("expands the metric on the technical debt tab when the issues are clicked", async () => {
+    renderSubjectTableRow({ issueIds: ["ABC-1"] })
+    await asyncClickText(/ABC-1/)
+    expectSearch(`?expanded=metric_uuid%3A${METRIC_DEBT_TAB_INDEX}`)
+})
+
+it("switches to the technical debt tab when the issues are clicked on an expanded row with a different tab", async () => {
+    history.push(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
+    renderSubjectTableRow({ issueIds: ["ABC-1"] })
+    await asyncClickText(/ABC-1/)
+    expectSearch(`?expanded=metric_uuid%3A${METRIC_DEBT_TAB_INDEX}`)
+})
+
+it("collapses the metric when the issues are clicked on an expanded row with the technical debt tab active", async () => {
+    history.push(`?expanded=metric_uuid:${METRIC_DEBT_TAB_INDEX}`)
+    renderSubjectTableRow({ issueIds: ["ABC-1"] })
+    await asyncClickText(/ABC-1/)
     expectSearch("")
 })

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -22,6 +22,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 - Clicking the unit expands the metric on the metric configuration tab, and collapses the metric when clicked again while the configuration tab is active. Closes [#13036](https://github.com/ICTU/quality-time/issues/13036).
 - Clicking the time left expands the metric on the technical debt tab, and collapses the metric when clicked again while the technical debt tab is active. Closes [#13038](https://github.com/ICTU/quality-time/issues/13038).
 - Clicking the metric comment expands the metric on the technical debt tab, and collapses the metric when clicked again while the technical debt tab is active. Closes [#13040](https://github.com/ICTU/quality-time/issues/13040).
+- Clicking the issues expands the metric on the technical debt tab, and collapses the metric when clicked again while the technical debt tab is active. Closes [#13042](https://github.com/ICTU/quality-time/issues/13042).
 
 ## v5.53.0 - 2026-04-24
 


### PR DESCRIPTION
Clicking the issues expands the metric on the technical debt tab, and collapses the metric when clicked again while the technical debt tab is active.

Closes #13042.