### PR TITLE
Clicking the source column expands the metric

### DIFF
--- a/components/frontend/src/metric/MetricDetails.jsx
+++ b/components/frontend/src/metric/MetricDetails.jsx
@@ -37,6 +37,7 @@ import { MetricDebtParameters } from "./MetricDebtParameters"
 import { TrendGraph } from "./TrendGraph"
 
 export const METRIC_CONFIGURATION_TAB_INDEX = 0
+export const SOURCES_TAB_INDEX = 1
 export const METRIC_DEBT_TAB_INDEX = 2
 export const TREND_GRAPH_TAB_INDEX = 4
 export const SOURCE_TAB_INDEX = 5

--- a/components/frontend/src/subject/SubjectTableRow.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.jsx
@@ -18,6 +18,7 @@ import {
     METRIC_DEBT_TAB_INDEX,
     MetricDetails,
     SOURCE_TAB_INDEX,
+    SOURCES_TAB_INDEX,
     TREND_GRAPH_TAB_INDEX,
 } from "../metric/MetricDetails"
 import { measurementOnDate } from "../report/report_utils"
@@ -386,7 +387,10 @@ export function SubjectTableRow({
                 </TableCell>
             )}
             {!columnsToHide.includes("source") && (
-                <TableCell>
+                <TableCell
+                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, SOURCES_TAB_INDEX)}
+                    sx={clickableStyle}
+                >
                     <MeasurementSources metric={metric} />
                 </TableCell>
             )}

--- a/components/frontend/src/subject/SubjectTableRow.test.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.test.jsx
@@ -12,6 +12,7 @@ import {
     METRIC_CONFIGURATION_TAB_INDEX,
     METRIC_DEBT_TAB_INDEX,
     SOURCE_TAB_INDEX,
+    SOURCES_TAB_INDEX,
     TREND_GRAPH_TAB_INDEX,
 } from "../metric/MetricDetails"
 import {
@@ -80,10 +81,12 @@ function SubjectTableRowWrapper({
                         direction: direction,
                         evaluate_targets: evaluateTargets,
                         issue_ids: issueIds,
+                        latest_measurement: { sources: [{ source_uuid: "source_uuid" }] },
                         name: name,
                         recent_measurements: [],
                         scale: scale,
                         secondary_name: secondaryName,
+                        sources: { source_uuid: { type: "source_type", parameters: {} } },
                         status_start: "2024-01-03T00:00",
                         type: "metric_type",
                         unit: "things",
@@ -408,5 +411,25 @@ it("collapses the metric when the issues are clicked on an expanded row with the
     history.push(`?expanded=metric_uuid:${METRIC_DEBT_TAB_INDEX}`)
     renderSubjectTableRow({ issueIds: ["ABC-1"] })
     await asyncClickText(/ABC-1/)
+    expectSearch("")
+})
+
+it("expands the metric on the sources tab when the source is clicked", async () => {
+    renderSubjectTableRow()
+    await asyncClickText(/Source type name/)
+    expectSearch(`?expanded=metric_uuid%3A${SOURCES_TAB_INDEX}`)
+})
+
+it("switches to the sources tab when the source is clicked on an expanded row with a different tab", async () => {
+    history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
+    renderSubjectTableRow()
+    await asyncClickText(/Source type name/)
+    expectSearch(`?expanded=metric_uuid%3A${SOURCES_TAB_INDEX}`)
+})
+
+it("collapses the metric when the source is clicked on an expanded row with the sources tab active", async () => {
+    history.push(`?expanded=metric_uuid:${SOURCES_TAB_INDEX}`)
+    renderSubjectTableRow()
+    await asyncClickText(/Source type name/, 0)
     expectSearch("")
 })

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -23,6 +23,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 - Clicking the time left expands the metric on the technical debt tab, and collapses the metric when clicked again while the technical debt tab is active. Closes [#13038](https://github.com/ICTU/quality-time/issues/13038).
 - Clicking the metric comment expands the metric on the technical debt tab, and collapses the metric when clicked again while the technical debt tab is active. Closes [#13040](https://github.com/ICTU/quality-time/issues/13040).
 - Clicking the issues expands the metric on the technical debt tab, and collapses the metric when clicked again while the technical debt tab is active. Closes [#13042](https://github.com/ICTU/quality-time/issues/13042).
+- Clicking the source column expands the metric on the sources tab, and collapses the metric when clicked again while the sources tab is active. Closes [#13044](https://github.com/ICTU/quality-time/issues/13044).
 
 ## v5.53.0 - 2026-04-24
 


### PR DESCRIPTION
Clicking the source column expands the metric on the sources tab, and collapses the metric when clicked again while the sources tab is active.

Closes #13044.