### PR TITLE
Only collapse metric on expand/collapse button

### DIFF
--- a/components/frontend/src/hooks/url_search_query.js
+++ b/components/frontend/src/hooks/url_search_query.js
@@ -100,14 +100,6 @@ function useMappingURLSearchQuery(key, parseValue, missingItemValue) {
         const newValue = [...hook._allItemsExcept(itemKey), `${itemKey}:${itemValue}`]
         setURLSearchQuery(key, newValue, hook.defaultValue, hook.set)
     }
-    hook.setOrDeleteItem = (itemKey, itemValue) => {
-        // Assign the value to the key, unless the key already has the value, then delete the key/value pair
-        if (hook.includes(itemKey) && hook.getItem(itemKey) === itemValue) {
-            hook.deleteItem(itemKey)
-        } else {
-            hook.setItem(itemKey, itemValue)
-        }
-    }
     return hook
 }
 

--- a/components/frontend/src/subject/SubjectTableRow.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.jsx
@@ -288,9 +288,12 @@ export function SubjectTableRow({
     const rowRef = useRef(null)
     const dragHandleRef = useRef(null)
 
+    const isExpanded = settings.expandedItems.includes(metricUuid)
     const anyRowExpanded = settings.expandedItems.value.length > 0
     const rowsAreSorted = settings.sortColumn.value !== ""
-    const clickableStyle = { "&:hover, &.Mui-focusVisible": { backgroundColor: "action.hover" } }
+    const columnSx = isExpanded ? null : { "&:hover, &.Mui-focusVisible": { backgroundColor: "action.hover" } }
+    const onColumnClick = (tabIndex) =>
+        isExpanded ? undefined : () => settings.expandedItems.setItem(metricUuid, tabIndex)
 
     return (
         <TableRowWithDetails
@@ -324,13 +327,13 @@ export function SubjectTableRow({
                     subjectUuid={subjectUuid}
                 />
             }
-            expanded={settings.expandedItems.includes(metricUuid)}
+            expanded={isExpanded}
             id={metricUuid}
             onExpand={() => settings.expandedItems.toggle(metricUuid)}
             firstCellContent={<MetricName metric={metric} />}
             firstCellProps={{
-                sx: clickableStyle,
-                onClick: () => settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_CONFIGURATION_TAB_INDEX),
+                sx: columnSx,
+                onClick: onColumnClick(METRIC_CONFIGURATION_TAB_INDEX),
             }}
         >
             {nrDates > 1 && (
@@ -343,62 +346,39 @@ export function SubjectTableRow({
                 />
             )}
             {!columnsToHide.includes("trend") && (
-                <TableCell
-                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, TREND_GRAPH_TAB_INDEX)}
-                    sx={{ width: "150px", ...clickableStyle }}
-                >
+                <TableCell onClick={onColumnClick(TREND_GRAPH_TAB_INDEX)} sx={{ width: "150px", ...columnSx }}>
                     <TrendSparkline measurements={metric.recent_measurements} reportDate={reportDate} scale={scale} />
                 </TableCell>
             )}
             {!columnsToHide.includes("status") && (
-                <TableCell
-                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_DEBT_TAB_INDEX)}
-                    sx={clickableStyle}
-                >
+                <TableCell onClick={onColumnClick(METRIC_CONFIGURATION_TAB_INDEX)} sx={columnSx}>
                     <Typography sx={{ paddingLeft: "6px", fontSize: "24px" }}>
                         <StatusIcon status={metric.status} statusStart={metric.status_start} />
                     </Typography>
                 </TableCell>
             )}
             {!columnsToHide.includes("measurement") && (
-                <TableCell
-                    align="right"
-                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, SOURCE_TAB_INDEX)}
-                    sx={clickableStyle}
-                >
+                <TableCell align="right" onClick={onColumnClick(SOURCE_TAB_INDEX)} sx={columnSx}>
                     <MeasurementValue metric={metric} reportDate={reportDate} />
                 </TableCell>
             )}
             {!columnsToHide.includes("target") && (
-                <TableCell
-                    align="right"
-                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_CONFIGURATION_TAB_INDEX)}
-                    sx={clickableStyle}
-                >
+                <TableCell align="right" onClick={onColumnClick(METRIC_CONFIGURATION_TAB_INDEX)} sx={columnSx}>
                     <MeasurementTarget metric={metric} />
                 </TableCell>
             )}
             {!columnsToHide.includes("unit") && (
-                <TableCell
-                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_CONFIGURATION_TAB_INDEX)}
-                    sx={clickableStyle}
-                >
+                <TableCell onClick={onColumnClick(METRIC_CONFIGURATION_TAB_INDEX)} sx={columnSx}>
                     {unit}
                 </TableCell>
             )}
             {!columnsToHide.includes("source") && (
-                <TableCell
-                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, SOURCES_TAB_INDEX)}
-                    sx={clickableStyle}
-                >
+                <TableCell onClick={onColumnClick(SOURCES_TAB_INDEX)} sx={columnSx}>
                     <MeasurementSources metric={metric} />
                 </TableCell>
             )}
             {!columnsToHide.includes("time_left") && (
-                <TableCell
-                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_DEBT_TAB_INDEX)}
-                    sx={clickableStyle}
-                >
+                <TableCell onClick={onColumnClick(METRIC_DEBT_TAB_INDEX)} sx={columnSx}>
                     <TimeLeft metric={metric} report={report} />
                 </TableCell>
             )}
@@ -414,26 +394,17 @@ export function SubjectTableRow({
                 </TableCell>
             )}
             {!columnsToHide.includes("comment") && (
-                <TableCell
-                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_DEBT_TAB_INDEX)}
-                    sx={clickableStyle}
-                >
+                <TableCell onClick={onColumnClick(METRIC_DEBT_TAB_INDEX)} sx={columnSx}>
                     <DivWithHtml>{metric.comment}</DivWithHtml>
                 </TableCell>
             )}
             {!columnsToHide.includes("issues") && (
-                <TableCell
-                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_DEBT_TAB_INDEX)}
-                    sx={clickableStyle}
-                >
+                <TableCell onClick={onColumnClick(METRIC_DEBT_TAB_INDEX)} sx={columnSx}>
                     <IssueStatus metric={metric} issueTrackerMissing={!report.issue_tracker} settings={settings} />
                 </TableCell>
             )}
             {!columnsToHide.includes("tags") && (
-                <TableCell
-                    onClick={() => settings.expandedItems.setOrDeleteItem(metricUuid, METRIC_CONFIGURATION_TAB_INDEX)}
-                    sx={clickableStyle}
-                >
+                <TableCell onClick={onColumnClick(METRIC_CONFIGURATION_TAB_INDEX)} sx={columnSx}>
                     {getMetricTags(metric).map((tag) => (
                         <Tag key={tag} tag={tag} />
                     ))}

--- a/components/frontend/src/subject/SubjectTableRow.test.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.test.jsx
@@ -237,18 +237,11 @@ it("expands the metric on the configuration tab when the metric name is clicked"
     expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
 })
 
-it("switches to the configuration tab when the metric name is clicked on an expanded row with a different tab", async () => {
-    history.push("?expanded=metric_uuid:1")
+it("does not change the search when the metric name is clicked on an expanded row", async () => {
+    history.push(`?expanded=metric_uuid:${SOURCES_TAB_INDEX}`)
     renderSubjectTableRow({ name: "Metric name" })
     await asyncClickText(/Metric name/, 0)
-    expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
-})
-
-it("collapses the metric when the metric name is clicked on an expanded row with the configuation tab active", async () => {
-    history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
-    renderSubjectTableRow({ name: "Metric name" })
-    await asyncClickText(/Metric name/, 0)
-    expectSearch("")
+    expectSearch(`?expanded=metric_uuid:${SOURCES_TAB_INDEX}`)
 })
 
 it("collapses the metric when the expand button is clicked on an expanded row with a different tab", async () => {
@@ -258,24 +251,17 @@ it("collapses the metric when the expand button is clicked on an expanded row wi
     expectSearch("")
 })
 
-it("expands the metric on the technical debt tab when the status is clicked", async () => {
+it("expands the metric on the configuration tab when the status is clicked", async () => {
     renderSubjectTableRow()
     await asyncClickByTestId("QuestionMarkIcon")
-    expectSearch(`?expanded=metric_uuid%3A${METRIC_DEBT_TAB_INDEX}`)
+    expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
 })
 
-it("switches to the technical debt tab when the status is clicked on an expanded row with a different tab", async () => {
-    history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
+it("does not change the search when the status is clicked on an expanded row", async () => {
+    history.push(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
     renderSubjectTableRow()
     await asyncClickByTestId("QuestionMarkIcon")
-    expectSearch(`?expanded=metric_uuid%3A${METRIC_DEBT_TAB_INDEX}`)
-})
-
-it("collapses the metric when the status is clicked on an expanded row with the technical debt tab active", async () => {
-    history.push(`?expanded=metric_uuid:${METRIC_DEBT_TAB_INDEX}`)
-    renderSubjectTableRow()
-    await asyncClickByTestId("QuestionMarkIcon")
-    expectSearch("")
+    expectSearch(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
 })
 
 it("expands the metric on the trend graph tab when the sparkline is clicked", async () => {
@@ -284,18 +270,11 @@ it("expands the metric on the trend graph tab when the sparkline is clicked", as
     expectSearch(`?expanded=metric_uuid%3A${TREND_GRAPH_TAB_INDEX}`)
 })
 
-it("switches to the trend graph tab when the sparkline is clicked on an expanded row with a different tab", async () => {
+it("does not change the search when the sparkline is clicked on an expanded row", async () => {
     history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
     renderSubjectTableRow()
     await asyncClickRole("cell", /sparkline graph showing 0 different measurement values in the week before today/)
-    expectSearch(`?expanded=metric_uuid%3A${TREND_GRAPH_TAB_INDEX}`)
-})
-
-it("collapses the metric when the sparkline is clicked on an expanded row with the trend graph tab active", async () => {
-    history.push(`?expanded=metric_uuid:${TREND_GRAPH_TAB_INDEX}`)
-    renderSubjectTableRow()
-    await asyncClickRole("cell", /sparkline graph showing 0 different measurement values in the week before today/)
-    expectSearch("")
+    expectSearch(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
 })
 
 it("expands the metric on the first source tab when the measurement value is clicked", async () => {
@@ -304,18 +283,11 @@ it("expands the metric on the first source tab when the measurement value is cli
     expectSearch(`?expanded=metric_uuid%3A${SOURCE_TAB_INDEX}`)
 })
 
-it("switches to the source tab when the measurement value is clicked on an expanded row with a different tab", async () => {
+it("does not change the search when the measurement value is clicked on an expanded row", async () => {
     history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
     renderSubjectTableRow()
     await asyncClickRole("cell", "?")
-    expectSearch(`?expanded=metric_uuid%3A${SOURCE_TAB_INDEX}`)
-})
-
-it("collapses the metric when the measurement value is clicked on an expanded row with the source tab active", async () => {
-    history.push(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
-    renderSubjectTableRow()
-    await asyncClickRole("cell", "?")
-    expectSearch("")
+    expectSearch(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
 })
 
 it("expands the metric on the configuration tab when the target value is clicked", async () => {
@@ -324,18 +296,11 @@ it("expands the metric on the configuration tab when the target value is clicked
     expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
 })
 
-it("switches to the configuration tab when the measurement target is clicked on an expanded row with a different tab", async () => {
+it("does not change the search when the measurement target is clicked on an expanded row", async () => {
     history.push(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
     renderSubjectTableRow()
     await asyncClickRole("cell", "≦ 0")
-    expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
-})
-
-it("collapses the metric when the measurement target is clicked on an expanded row with the configuration tab active", async () => {
-    history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
-    renderSubjectTableRow()
-    await asyncClickRole("cell", "≦ 0")
-    expectSearch("")
+    expectSearch(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
 })
 
 it("expands the metric on the configuration tab when the unit is clicked", async () => {
@@ -344,18 +309,11 @@ it("expands the metric on the configuration tab when the unit is clicked", async
     expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
 })
 
-it("switches to the configuration tab when the unit is clicked on an expanded row with a different tab", async () => {
+it("does not change the search when the unit is clicked on an expanded row", async () => {
     history.push(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
     renderSubjectTableRow()
     await asyncClickText(/things/)
-    expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
-})
-
-it("collapses the metric when the unit is clicked on an expanded row with the configuration tab active", async () => {
-    history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
-    renderSubjectTableRow()
-    await asyncClickText(/things/)
-    expectSearch("")
+    expectSearch(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
 })
 
 it("expands the metric on the technical debt tab when the time left is clicked", async () => {
@@ -364,18 +322,11 @@ it("expands the metric on the technical debt tab when the time left is clicked",
     expectSearch(`?expanded=metric_uuid%3A${METRIC_DEBT_TAB_INDEX}`)
 })
 
-it("switches to the technical debt tab when the time left is clicked on an expanded row with a different tab", async () => {
+it("does not change the search when the time left is clicked on an expanded row", async () => {
     history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
     renderSubjectTableRow()
     await asyncClickText(/days/)
-    expectSearch(`?expanded=metric_uuid%3A${METRIC_DEBT_TAB_INDEX}`)
-})
-
-it("collapses the metric when the time left is clicked on an expanded row with the technical debt tab active", async () => {
-    history.push(`?expanded=metric_uuid:${METRIC_DEBT_TAB_INDEX}`)
-    renderSubjectTableRow()
-    await asyncClickText(/days/)
-    expectSearch("")
+    expectSearch(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
 })
 
 it("expands the metric on the technical debt tab when the comment is clicked", async () => {
@@ -384,18 +335,11 @@ it("expands the metric on the technical debt tab when the comment is clicked", a
     expectSearch(`?expanded=metric_uuid%3A${METRIC_DEBT_TAB_INDEX}`)
 })
 
-it("switches to the technical debt tab when the comment is clicked on an expanded row with a different tab", async () => {
+it("does not change the search when the comment is clicked on an expanded row", async () => {
     history.push(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
     renderSubjectTableRow({ comment: "Metric comment" })
     await asyncClickText("Metric comment")
-    expectSearch(`?expanded=metric_uuid%3A${METRIC_DEBT_TAB_INDEX}`)
-})
-
-it("collapses the metric when the comment is clicked on an expanded row with the technical debt tab active", async () => {
-    history.push(`?expanded=metric_uuid:${METRIC_DEBT_TAB_INDEX}`)
-    renderSubjectTableRow({ comment: "Metric comment" })
-    await asyncClickText("Metric comment")
-    expectSearch("")
+    expectSearch(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
 })
 
 it("expands the metric on the technical debt tab when the issues are clicked", async () => {
@@ -404,18 +348,11 @@ it("expands the metric on the technical debt tab when the issues are clicked", a
     expectSearch(`?expanded=metric_uuid%3A${METRIC_DEBT_TAB_INDEX}`)
 })
 
-it("switches to the technical debt tab when the issues are clicked on an expanded row with a different tab", async () => {
+it("does not change the search when the issues are clicked on an expanded row", async () => {
     history.push(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
     renderSubjectTableRow({ issueIds: ["ABC-1"] })
     await asyncClickText(/ABC-1/)
-    expectSearch(`?expanded=metric_uuid%3A${METRIC_DEBT_TAB_INDEX}`)
-})
-
-it("collapses the metric when the issues are clicked on an expanded row with the technical debt tab active", async () => {
-    history.push(`?expanded=metric_uuid:${METRIC_DEBT_TAB_INDEX}`)
-    renderSubjectTableRow({ issueIds: ["ABC-1"] })
-    await asyncClickText(/ABC-1/)
-    expectSearch("")
+    expectSearch(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
 })
 
 it("expands the metric on the sources tab when the source is clicked", async () => {
@@ -424,18 +361,11 @@ it("expands the metric on the sources tab when the source is clicked", async () 
     expectSearch(`?expanded=metric_uuid%3A${SOURCES_TAB_INDEX}`)
 })
 
-it("switches to the sources tab when the source is clicked on an expanded row with a different tab", async () => {
+it("does not change the search when the source is clicked on an expanded row", async () => {
     history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
     renderSubjectTableRow()
     await asyncClickText(/Source type name/)
-    expectSearch(`?expanded=metric_uuid%3A${SOURCES_TAB_INDEX}`)
-})
-
-it("collapses the metric when the source is clicked on an expanded row with the sources tab active", async () => {
-    history.push(`?expanded=metric_uuid:${SOURCES_TAB_INDEX}`)
-    renderSubjectTableRow()
-    await asyncClickText(/Source type name/, 0)
-    expectSearch("")
+    expectSearch(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
 })
 
 it("expands the metric on the configuration tab when a tag is clicked", async () => {
@@ -444,16 +374,9 @@ it("expands the metric on the configuration tab when a tag is clicked", async ()
     expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
 })
 
-it("switches to the configuration tab when a tag is clicked on an expanded row with a different tab", async () => {
+it("does not change the search when a tag is clicked on an expanded row", async () => {
     history.push(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
     renderSubjectTableRow({ tags: ["tag1"] })
     await asyncClickText(/tag1/)
-    expectSearch(`?expanded=metric_uuid%3A${METRIC_CONFIGURATION_TAB_INDEX}`)
-})
-
-it("collapses the metric when a tag is clicked on an expanded row with the configuration tab active", async () => {
-    history.push(`?expanded=metric_uuid:${METRIC_CONFIGURATION_TAB_INDEX}`)
-    renderSubjectTableRow({ tags: ["tag1"] })
-    await asyncClickText(/tag1/)
-    expectSearch("")
+    expectSearch(`?expanded=metric_uuid:${SOURCE_TAB_INDEX}`)
 })

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,7 +14,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ### Added
 
-- Clicking columns in the metric table expands the metric details, if not yet expanded, and activates the tab most closely corresponding to the column clicked. If the metric is expanded and the corresponding tab is already active, clicking the column collapses the metric. Closes [#4172](https://github.com/ICTU/quality-time/issues/4172).
+- Clicking columns in the metric table expands the metric details, if not yet expanded, and activates the tab most closely corresponding to the column clicked. Once the metric is expanded, clicking columns has no effect. Closes [#4172](https://github.com/ICTU/quality-time/issues/4172).
 
 ## v5.53.0 - 2026-04-24
 


### PR DESCRIPTION
Only collapse metric on expand/collapse button and don't collapse the metric on clicking a column.

Closes #13053.