### PR TITLE
Fix SonarCloud security findings

### DIFF
--- a/components/frontend/Dockerfile
+++ b/components/frontend/Dockerfile
@@ -7,7 +7,7 @@ COPY index.html /home/frontend
 COPY *.ts /home/frontend
 COPY src /home/frontend/src
 COPY .env /home/frontend
-RUN npm install --ignore-scripts && \
+RUN npm ci --ignore-scripts && \
     npm run --ignore-scripts build
 
 FROM nginxinc/nginx-unprivileged:1.30-alpine3.23-slim

--- a/components/renderer/Dockerfile
+++ b/components/renderer/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache chromium
 
 WORKDIR /home/renderer
 COPY package*.json /home/renderer/
-RUN npm install --ignore-scripts
+RUN npm ci --ignore-scripts
 
 COPY src/*js /home/renderer/
 

--- a/justfile
+++ b/justfile
@@ -103,7 +103,7 @@ install-py-dependencies:
 [private]
 install-js-dependencies:
     ?[ {{ package_json_exists }} = true ]
-    npm install --ignore-scripts --silent
+    npm ci --ignore-scripts --silent
 
 # === Build artifacts ===
 


### PR DESCRIPTION
- Run `uv sync` with `--no-build` to prevent building source distributions, which may lead to the execution of setup scripts.

Fixes #13067.