### PR TITLE
Deprecate Pyupio Safety as metric source

### DIFF
--- a/components/shared_code/src/shared_data_model/sources/pyupio_safety.py
+++ b/components/shared_code/src/shared_data_model/sources/pyupio_safety.py
@@ -10,6 +10,8 @@ PYUPIO_SAFETY = Source(
     name="Pyupio Safety",
     description="Safety checks Python dependencies for known security vulnerabilities.",
     url=HttpUrl("https://github.com/pyupio/safety"),
+    deprecated=True,
+    deprecation_url=HttpUrl("https://github.com/ICTU/quality-time/issues/13077"),
     parameters=access_parameters(["security_warnings"], source_type="Safety report", source_type_format="JSON"),
     entities={
         "security_warnings": Entity(

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -10,6 +10,12 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the tools/release/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Deprecated
+
+- Support for Pyupio Safety as source for metrics is deprecated and marked for removal in the future, because *Quality-time* only supports v1 of the Safety JSON output and upgrading to v3 is blocked. Closes [#13077](https://github.com/ICTU/quality-time/issues/13077).
+
 ## v5.54.0 - 2026-05-01
 
 ### Added

--- a/docs/styles/config/vocabularies/Base/accept.txt
+++ b/docs/styles/config/vocabularies/Base/accept.txt
@@ -21,6 +21,7 @@ OJAudit
 OpenShift
 PDFs
 Pydantic
+Pyupio
 Robocop
 Snyk
 Termeczky


### PR DESCRIPTION
Support for Pyupio Safety as source for metrics is deprecated and marked for removal in the future, because Quality-time only supports v1 of the Safety JSON output and upgrading to v3 is blocked.

Closes #13077.