### PR TITLE
Fix documentation on importing reports

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -165,7 +165,8 @@ The {index}`public key <public key>` argument is optional.
 If no public key is provided, the public key of the exporting *Quality-time* instance is used for encrypting the source credentials.
 If the report needs to be imported in a different *Quality-time* instance, the public key of that instance should be provided.
 It can be obtained at `https://quality-time.destination.org/api/v3/public_key`.
-The exported JSON report can only be imported into the *Quality-time* whose public key has been used for the encryption of credentials during the export.
+The exported JSON report *including its credentials* can only be imported into the *Quality-time* whose public key has been used for the encryption of credentials during the export.
+If the report is imported into another *Quality-time* instance, the credentials will not be imported.
 
 The public key endpoint returns a JSON like this:
 
@@ -205,7 +206,7 @@ The importing endpoint is available via `https://quality-time.destination.org/ap
 The import endpoint accepts JSON content only.
 See the [example reports](https://github.com/ICTU/quality-time/tree/master/components/api_server/src/example-reports) for the format.
 
-For example, using curl, assuming you have logged in as shown above, and that the report filename is `report.json`:
+For example, using curl, assuming **you have logged in as shown above** and that the report filename is `report.json`:
 
 ```console
 curl --cookie cookie.txt --request POST --header "Content-Type: application/json" --data @report.json https://quality-time.destination.org/api/v3/report/import
@@ -220,7 +221,7 @@ On success, you'll see a reply like this:
 On import, all UUIDs contained in the report (UUIDs of the report, subjects, metrics and sources) will be replaced to prevent conflicts if the report already exists.
 
 If the report contains encrypted credentials, the importing *Quality-time* instance will decrypt the credentials using its public key.
-Note that if the credentials were encrypted using the public key of a different *Quality-time* instance, an error will occur, and the import will fail.
+Note that if the credentials were encrypted using the public key of a different *Quality-time* instance, the report will be imported, but without the credentials.
 
 To allow for seeding a *Quality-time* instance with default reports, imported reports may contain unencrypted credentials.
 These unencrypted credentials will be imported unchanged.

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ## [Unreleased]
 
+### Fixed
+
+- The documentation on importing reports was claiming that a report with credentials can only be re-imported into the same *Quality-time* instance. This is no longer true since v5.52.0. Fixes [#13080](https://github.com/ICTU/quality-time/issues/13080).
+
 ### Deprecated
 
 - Support for Pyupio Safety as source for metrics is deprecated and marked for removal in the future, because *Quality-time* only supports v1 of the Safety JSON output and upgrading to v3 is blocked. Closes [#13077](https://github.com/ICTU/quality-time/issues/13077).

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -487,9 +487,11 @@ See the [API-documentation](api.md#export-to-pdf) for exporting reports via the 
 
 *Quality-time* provides functionality for importing and exporting reports in JSON format. This functionality can be used to import template reports, to back up reports, or for transferring reports from one *Quality-time* instance to another one.
 
-To export a report, use the "Export report" button in the report header. The exported JSON file contains the report configuration but does not include measurements. Source credentials in the exported report are encrypted using the public key of the exporting *Quality-time* instance. This means that an exported report with credentials can only be re-imported into the same instance. To transfer a report with credentials to a different *Quality-time* instance, use the [API](api.md#export-and-import-reports-as-json) to encrypt the credentials with the public key of the destination instance.
+To export a report, use the "Export report" button in the report header. The exported JSON file contains the report configuration but does not include measurements. Source credentials in the exported report are encrypted using the public key of the exporting *Quality-time* instance. This means that an exported report *including its credentials* can only be re-imported into the same instance. To transfer a report including its credentials to a different *Quality-time* instance, use the [API](api.md#export-and-import-reports-as-json) to encrypt the credentials with the public key of the destination instance. It is possible to import a report in a Quality-time instance whose public key was not used to encrypt the credentials, but in that case the credentials will not be imported.
 
-To import a report, use the "Import report" button on the reports overview page to select a report in JSON format and import it. Both buttons are only available to logged-in users.
+To import a report, use the "Import report" button on the reports overview page to select a report in JSON format and import it.
+
+The export and the import buttons are only available to logged-in users.
 
 Both the import and the export functionality are also available via the [API](api.md#export-and-import-reports-as-json).
 


### PR DESCRIPTION
The documentation on importing reports was claiming that a report with credentials can only be re-imported into the same Quality-time instance. This is no longer true since v5.52.0.

Fixes #13080.