### PR TITLE
Refactor credential transformations to share iteration

### DIFF
--- a/components/api_server/src/model/iterators.py
+++ b/components/api_server/src/model/iterators.py
@@ -2,8 +2,12 @@
 
 from typing import TYPE_CHECKING
 
+from .queries import is_password_parameter
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from shared.model.source import Source
 
 
 def subjects(*reports) -> Iterator:
@@ -22,3 +26,26 @@ def sources(*reports) -> Iterator:
     """Return all sources in the reports."""
     for metric in metrics(*reports):
         yield from metric.get("sources", {}).values()
+
+
+def issue_trackers(*reports) -> Iterator:
+    """Return all issue trackers in the reports."""
+    for report in reports:
+        if issue_tracker := report.get("issue_tracker"):
+            yield issue_tracker
+
+
+def credential_holders(*reports, data_model: dict | None = None) -> Iterator[tuple[dict, list[str]]]:
+    """Yield (parameters, keys) for each item in the reports holding credentials. Keys with empty values are skipped."""
+    for source in sources(*reports):
+        yield source["parameters"], _password_parameter_keys(source, data_model)
+    for issue_tracker in issue_trackers(*reports):
+        parameters = issue_tracker.get("parameters") or {}
+        if parameters:
+            yield parameters, [key for key in ("password", "private_token") if parameters.get(key)]
+
+
+def _password_parameter_keys(source: Source, data_model: dict | None = None) -> list[str]:
+    """Return the password parameter keys of the source with a truthy value."""
+    parameters = source.get("parameters", {}).items()
+    return [key for key, value in parameters if value and is_password_parameter(source["type"], key, data_model)]

--- a/components/api_server/src/model/transformations.py
+++ b/components/api_server/src/model/transformations.py
@@ -8,8 +8,7 @@ from shared_data_model import DATA_MODEL
 
 from utils.functions import asymmetric_decrypt, asymmetric_encrypt, unique, uuid, DecryptionError
 
-from .iterators import sources as iter_sources
-from .queries import is_password_parameter
+from .iterators import credential_holders
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -28,66 +27,27 @@ CREDENTIALS_REPLACEMENT_TEXT = "this string replaces credentials"
 
 def hide_credentials(data_model, *reports) -> None:
     """Hide the credentials in the reports. The data model must be passed so hiding also works when time traveling."""
-    for source in iter_sources(*reports):
-        for parameter_key in __password_parameter_keys(source, data_model):
-            source["parameters"][parameter_key] = CREDENTIALS_REPLACEMENT_TEXT
-    for report in reports:
-        issue_tracker_parameters = report.get("issue_tracker", {}).get("parameters", {})
-        for secret_attribute in ("password", "private_token"):
-            if issue_tracker_parameters.get(secret_attribute):
-                issue_tracker_parameters[secret_attribute] = CREDENTIALS_REPLACEMENT_TEXT
+    for parameters, keys in credential_holders(*reports, data_model=data_model):
+        for key in keys:
+            parameters[key] = CREDENTIALS_REPLACEMENT_TEXT
 
 
-def encrypt_credentials(public_key: str, *reports: dict):
+def encrypt_credentials(public_key: str, *reports: dict) -> None:
     """Encrypt all credentials in the reports."""
-    encrypt_source_credentials(public_key, *reports)
-    encrypt_issue_tracker_credentials(public_key, *reports)
-
-
-def encrypt_source_credentials(public_key: str, *reports: dict):
-    """Encrypt all source credentials in the reports."""
-    for source in iter_sources(*reports):
-        for parameter_key in __password_parameter_keys(source):
-            password = source["parameters"][parameter_key]
-            if isinstance(password, dict | list):
-                password = json.dumps(password)
-            source["parameters"][parameter_key] = asymmetric_encrypt(public_key, password)
-
-
-def encrypt_issue_tracker_credentials(public_key: str, *reports: dict):
-    """Encrypt all issue tracker credentials in the reports."""
-    for report in reports:
-        for secret_attribute in ("password", "private_token"):
-            if secret_attribute in report.get("issue_tracker", {}).get("parameters", {}):
-                password = report["issue_tracker"]["parameters"][secret_attribute]
-                report["issue_tracker"]["parameters"][secret_attribute] = asymmetric_encrypt(public_key, password)
+    for parameters, keys in credential_holders(*reports):
+        for key in keys:
+            value = parameters[key]
+            if isinstance(value, dict | list):
+                value = json.dumps(value)
+            parameters[key] = asymmetric_encrypt(public_key, value)
 
 
 def decrypt_credentials(private_key: str, *reports: dict) -> bool:
     """Decrypt all credentials in the reports. Returns whether all decryptions were successful."""
-    source_decryption_successful = decrypt_source_credentials(private_key, *reports)
-    issue_tracker_decryption_successful = decrypt_issue_tracker_credentials(private_key, *reports)
-    return source_decryption_successful and issue_tracker_decryption_successful
-
-
-def decrypt_source_credentials(private_key: str, *reports: dict) -> bool:
-    """Decrypt all source credentials in the reports. Returns whether all decryptions were successful."""
     decryption_successful = True
-    for source in iter_sources(*reports):
-        parameters = source["parameters"]
-        for parameter_key in __password_parameter_keys(source):
-            decryption_successful &= decrypt_parameter(private_key, parameters, parameter_key)
-    return decryption_successful
-
-
-def decrypt_issue_tracker_credentials(private_key: str, *reports: dict) -> bool:
-    """Decrypt all issue tracker credentials in the reports. Returns whether all decryptions were successful."""
-    decryption_successful = True
-    for report in reports:
-        for secret_attribute in ("password", "private_token"):
-            if secret_attribute in report.get("issue_tracker", {}).get("parameters", {}):
-                parameters = report["issue_tracker"]["parameters"]
-                decryption_successful &= decrypt_parameter(private_key, parameters, secret_attribute)
+    for parameters, keys in credential_holders(*reports):
+        for key in keys:
+            decryption_successful &= decrypt_parameter(private_key, parameters, key)
     return decryption_successful
 
 
@@ -211,9 +171,3 @@ def _sources_to_change(
     else:
         sources_to_change = {}
     yield from sources_to_change.items()
-
-
-def __password_parameter_keys(source: Source, data_model: dict | None = None) -> list[str]:
-    """Return the password parameter keys of the source."""
-    parameters = source.get("parameters", {}).items()
-    return [key for key, value in parameters if value and is_password_parameter(source["type"], key, data_model)]

--- a/components/api_server/tests/model/test_transformations.py
+++ b/components/api_server/tests/model/test_transformations.py
@@ -51,6 +51,18 @@ class HideCredentialsTest(DataModelTestCase):
         hide_credentials(self.DATA_MODEL, self.report)
         self.assertEqual("", self.issue_tracker_parameters["private_token"])
 
+    def test_hide_credentials_when_report_has_no_issue_tracker(self):
+        """Test that hiding credentials works on a report that has no issue tracker."""
+        del self.report["issue_tracker"]
+        hide_credentials(self.DATA_MODEL, self.report)
+        self.assertEqual(CREDENTIALS_REPLACEMENT_TEXT, self.source_parameters["password"])
+
+    def test_hide_credentials_when_issue_tracker_has_no_parameters(self):
+        """Test that hiding credentials works on a report whose issue tracker has no parameters yet."""
+        self.report["issue_tracker"] = {"type": "jira"}
+        hide_credentials(self.DATA_MODEL, self.report)
+        self.assertEqual(CREDENTIALS_REPLACEMENT_TEXT, self.source_parameters["password"])
+
 
 class ChangeSourceParameterTest(DataModelTestCase):
     """Unit tests for the change source parameter transformation."""


### PR DESCRIPTION
Extract a `credential_holders` iterator yielding `(parameters, keys)` for sources and issue trackers, and rewrite `hide_credentials`, `encrypt_credentials`, and `decrypt_credentials` to use the iterator. Also add an `issue_trackers` iterator alongside `subjects` / `metrics` / `sources`.

Preparatory refactor for #12901.

Closes #13115.