### PR TITLE
More flexible GitHub release fetching

### DIFF
--- a/tools/update_dependencies/src/github.py
+++ b/tools/update_dependencies/src/github.py
@@ -6,6 +6,8 @@ from urllib.parse import urlparse
 
 import requests
 
+from version import is_valid
+
 
 def github_to_raw(url: str) -> str:
     """Convert GitHub URLs to URLs that return raw content."""
@@ -29,22 +31,27 @@ def github_owner_and_repository(url: str) -> tuple[str, str]:
 
 @cache
 def get_latest_release_json(owner: str, repository: str) -> dict:
-    """Get the latest release JSON from the GitHub releases API. Also add the sha of the commit."""
+    """Get the latest release JSON from the GitHub releases API. Also add the sha of the commit.
+
+    Don't use the latest release endpoint, but rather get recent releases and weed out invalid versions.
+    """
     headers = {"Authorization": f"Bearer {github_token}"} if (github_token := os.environ.get("GITHUB_TOKEN")) else {}
-    releases_url = f"https://api.github.com/repos/{owner}/{repository}/releases/latest"
+    releases_url = f"https://api.github.com/repos/{owner}/{repository}/releases"
     releases_response = requests.get(releases_url, headers=headers, timeout=10)
     try:
         releases_response.raise_for_status()
     except requests.exceptions.HTTPError:
         return {}
-    json = releases_response.json()
-    if "tag_name" not in json:
+    for release in releases_response.json():
+        if not release["draft"] and not release["prerelease"] and is_valid(release.get("tag_name", "invalid")):
+            break
+    else:
         return {}
-    commits_url = f"https://api.github.com/repos/{owner}/{repository}/commits/{json['tag_name']}"
+    commits_url = f"https://api.github.com/repos/{owner}/{repository}/commits/{release['tag_name']}"
     commits_response = requests.get(commits_url, headers=headers, timeout=10)
     try:
         commits_response.raise_for_status()
     except requests.exceptions.HTTPError:
         return {}
-    json["commit_sha"] = commits_response.json()["sha"]
-    return json
+    release["commit_sha"] = commits_response.json()["sha"]
+    return release

--- a/tools/update_dependencies/src/log.py
+++ b/tools/update_dependencies/src/log.py
@@ -31,6 +31,10 @@ class Logger:
         """Log an invalid version."""
         self.log.error("Got an invalid version for %s: %s", dependency, invalid_version, stacklevel=2)
 
+    def no_version(self, dependency: str) -> None:
+        """Log no version found."""
+        self.log.error("No valid version found for %s", dependency, stacklevel=2)
+
     def path(self, path: Path) -> None:
         """Log working on path."""
         self.log.info("Updating %s", path.relative_to(Path.cwd()), stacklevel=2)

--- a/tools/update_dependencies/src/update_github_action.py
+++ b/tools/update_dependencies/src/update_github_action.py
@@ -7,7 +7,7 @@ import sys
 from functools import cache
 from pathlib import Path
 
-from packaging.version import InvalidVersion, Version
+from packaging.version import Version
 
 from filesystem import update_files
 from github import get_latest_release_json
@@ -24,11 +24,11 @@ def get_latest_version(action: str, current_version_string: str) -> DependencyVe
     owner, repository, *_path = action.split("/")
     current_version = Version(current_version_string)
     json = get_latest_release_json(owner, repository)
-    latest_tag = json.get("tag_name", "").strip("v")
-    try:
+    if "tag_name" in json:
+        latest_tag = json["tag_name"].strip("v")
         latest_version = Version(latest_tag)
-    except InvalidVersion:
-        LOG.invalid_version(f"{owner}/{repository}", f"'{latest_tag}'")
+    else:
+        LOG.no_version(f"{owner}/{repository}")
         latest_version = Version("0.0.0")
     changes = json.get("body", "")
     return DependencyVersion(str(max(latest_version, current_version)), changes, json.get("commit_sha", ""))

--- a/tools/update_dependencies/src/version.py
+++ b/tools/update_dependencies/src/version.py
@@ -2,6 +2,17 @@
 
 from dataclasses import dataclass
 
+from packaging.version import InvalidVersion, Version
+
+
+def is_valid(version: str) -> bool:
+    """Return whether the version is valid."""
+    try:
+        Version(version)
+    except InvalidVersion:
+        return False
+    return True
+
 
 @dataclass(frozen=True)
 class DependencyVersion:

--- a/tools/update_dependencies/tests/test_github.py
+++ b/tools/update_dependencies/tests/test_github.py
@@ -48,10 +48,20 @@ class GitHubReleaseJSONTest(unittest.TestCase):
 
     # Note get_latest_release_json uses caching, so the owner and/or repository need to be different for each test
 
-    @patch("requests.get", Mock(return_value=Mock(json=Mock(side_effect=[{"tag_name": "1.0"}, {"sha": "sha"}]))))
+    @patch(
+        "requests.get",
+        Mock(
+            return_value=Mock(
+                json=Mock(side_effect=[[{"draft": False, "prerelease": False, "tag_name": "1.0"}], {"sha": "sha"}])
+            )
+        ),
+    )
     def test_get_latest_release_json(self):
         """Test getting the latest release JSON."""
-        self.assertEqual({"tag_name": "1.0", "commit_sha": "sha"}, get_latest_release_json("owner", "repository"))
+        self.assertEqual(
+            {"draft": False, "prerelease": False, "tag_name": "1.0", "commit_sha": "sha"},
+            get_latest_release_json("owner", "repository"),
+        )
 
     @patch("requests.get")
     def test_get_latest_release_json_when_repo_has_no_releases(self, mock_get: Mock):
@@ -59,11 +69,39 @@ class GitHubReleaseJSONTest(unittest.TestCase):
         mock_get.return_value = Mock(raise_for_status=Mock(side_effect=requests.exceptions.HTTPError))
         self.assertEqual({}, get_latest_release_json("owner", "repository without releases"))
 
+    @patch(
+        "requests.get",
+        Mock(return_value=Mock(json=Mock(return_value=[{"draft": True, "prerelease": False, "tag_name": "1.0"}]))),
+    )
+    def test_skip_draft_releases(self):
+        """Test that draft releases are not included."""
+        self.assertEqual({}, get_latest_release_json("owner", "repository with only a draft release"))
+
+    @patch(
+        "requests.get",
+        Mock(return_value=Mock(json=Mock(return_value=[{"draft": False, "prerelease": True, "tag_name": "1.0"}]))),
+    )
+    def test_skip_prerelease_releases(self):
+        """Test that prerelease releases are not included."""
+        self.assertEqual({}, get_latest_release_json("owner", "repository with only a prerelease release"))
+
+    @patch(
+        "requests.get",
+        Mock(
+            return_value=Mock(
+                json=Mock(return_value=[{"draft": False, "prerelease": False, "tag_name": "invalid-1.0"}])
+            )
+        ),
+    )
+    def test_invalid_versions(self):
+        """Test that invalid versions are not included."""
+        self.assertEqual({}, get_latest_release_json("owner", "repository with a invalid version"))
+
     @patch("requests.get")
     def test_http_error_on_commits_endpoint(self, mock_get: Mock):
         """Test getting the latest release JSON when an HTTP error occurs on the commits endpoint."""
         mock_get.side_effect = [
-            Mock(json=Mock(return_value={"tag_name": "1.0"})),
+            Mock(json=Mock(return_value=[{"draft": False, "prerelease": False, "tag_name": "1.0"}])),
             Mock(raise_for_status=Mock(side_effect=requests.exceptions.HTTPError)),
         ]
         self.assertEqual({}, get_latest_release_json("owner", "repository 2"))

--- a/tools/update_dependencies/tests/test_pypi.py
+++ b/tools/update_dependencies/tests/test_pypi.py
@@ -28,7 +28,7 @@ class GetChangesTest(unittest.TestCase):
         logging.disable(logging.NOTSET)
 
     def create_mock_response(
-        self, mock_get: Mock, *json: dict, text: str = "", status_code: int = HTTPStatus.OK
+        self, mock_get: Mock, *json: dict | list, text: str = "", status_code: int = HTTPStatus.OK
     ) -> None:
         """Create a mock response for the mock requests.get method with the JSON result."""
         response = Mock()
@@ -69,7 +69,7 @@ class GetChangesTest(unittest.TestCase):
             self.create_mock_response(
                 mock_get,
                 {"info": {"project_urls": {"docs": docs, key: repo}}},
-                {"body": changelog, "tag_name": "1.1"},
+                [{"draft": False, "prerelease": False, "body": changelog, "tag_name": "1.1"}],
                 {"sha": "sha"},
             )
             self.assertEqual(changelog, get_changes(f"package-4-{key}", "1.1", LOG))
@@ -87,7 +87,7 @@ class GetChangesTest(unittest.TestCase):
         self.create_mock_response(
             mock_get,
             {"info": {"description": f"Package description\n{github_url}\n"}},
-            {"tag_name": "1.1", "body": changelog},
+            [{"draft": False, "prerelease": False, "tag_name": "1.1", "body": changelog}],
             {"sha": "sha"},
         )
         self.assertEqual(changelog, get_changes("package-6", "1.1", LOG))
@@ -98,7 +98,7 @@ class GetChangesTest(unittest.TestCase):
         self.create_mock_response(
             mock_get,
             {"info": {"description": f"Package description\n{github_url}\n"}},
-            {"tag_name": "1.1"},
+            [{"draft": False, "prerelease": False, "tag_name": "1.1"}],
             {"sha": "sha"},
         )
         self.assertEqual("", get_changes("package-7", "1.1", LOG))

--- a/tools/update_dependencies/tests/test_update_github_action.py
+++ b/tools/update_dependencies/tests/test_update_github_action.py
@@ -14,7 +14,14 @@ class UpdateGitHubActionTest(unittest.TestCase):
     @patch("requests.get")
     def test_unchanged(self, mock_get: Mock):
         """Test an unchanged version."""
-        mock_get.return_value = Mock(json=Mock(side_effect=[{"tag_name": "1.0", "body": "changelog"}, {"sha": "sha"}]))
+        mock_get.return_value = Mock(
+            json=Mock(
+                side_effect=[
+                    [{"draft": False, "prerelease": False, "tag_name": "1.0", "body": "changelog"}],
+                    {"sha": "sha"},
+                ]
+            )
+        )
         latest_version = get_latest_version("docker/docker", "1.0")
         self.assertEqual("1.0", latest_version.version)
         self.assertEqual("changelog", latest_version.changes)
@@ -22,7 +29,14 @@ class UpdateGitHubActionTest(unittest.TestCase):
     @patch("requests.get")
     def test_newer(self, mock_get: Mock):
         """Test an newer version."""
-        mock_get.return_value = Mock(json=Mock(side_effect=[{"tag_name": "1.1", "body": "changelog"}, {"sha": "sha"}]))
+        mock_get.return_value = Mock(
+            json=Mock(
+                side_effect=[
+                    [{"draft": False, "prerelease": False, "tag_name": "1.1", "body": "changelog"}],
+                    {"sha": "sha"},
+                ]
+            )
+        )
         latest_version = get_latest_version("docker/hub", "1.0")
         self.assertEqual("1.1", latest_version.version)
         self.assertEqual("changelog", latest_version.changes)
@@ -30,13 +44,15 @@ class UpdateGitHubActionTest(unittest.TestCase):
     @patch("requests.get")
     def test_older(self, mock_get: Mock):
         """Test an older version."""
-        mock_get.return_value = Mock(json=Mock(side_effect=[{"tag_name": "0.9"}, {"sha": "sha"}]))
+        mock_get.return_value = Mock(
+            json=Mock(side_effect=[[{"draft": False, "prerelease": False, "tag_name": "0.9"}], {"sha": "sha"}])
+        )
         self.assertEqual("1.0", get_latest_version("github/action", "1.0").version)
 
     @patch("logging.Logger.error")
     @patch("requests.get")
-    def test_invalid_version(self, mock_get: Mock, mock_error: Mock):
+    def test_no_version(self, mock_get: Mock, mock_error: Mock):
         """Test that the package.json is not written if there are no outdated packages."""
-        mock_get.return_value = Mock(json=Mock(return_value={}))
+        mock_get.return_value = Mock(json=Mock(return_value=[]))
         self.assertEqual("1.0", get_latest_version("docker/action", "1.0").version)
-        mock_error.assert_called_once_with("Got an invalid version for %s: %s", "docker/action", "''", stacklevel=2)
+        mock_error.assert_called_once_with("No valid version found for %s", "docker/action", stacklevel=2)

--- a/tools/update_dependencies/tests/test_update_package_json.py
+++ b/tools/update_dependencies/tests/test_update_package_json.py
@@ -44,7 +44,11 @@ class UpdatePackageJsonTest(unittest.TestCase):
         Mock(
             side_effect=[
                 Mock(json=Mock(return_value={"repository": {"url": "https://github.com/package/1.1"}})),
-                Mock(json=Mock(return_value={"body": "Changelog", "tag_name": "v1.1"})),
+                Mock(
+                    json=Mock(
+                        return_value=[{"draft": False, "prerelease": False, "body": "Changelog", "tag_name": "v1.1"}]
+                    )
+                ),
                 Mock(json=Mock(return_value={"sha": "sha"})),
             ]
         ),

--- a/tools/update_dependencies/tests/test_update_pyproject_toml.py
+++ b/tools/update_dependencies/tests/test_update_pyproject_toml.py
@@ -73,7 +73,10 @@ class UpdatePyprojectTomlsTest(unittest.TestCase):
         Mock(
             side_effect=[
                 Mock(json=Mock(return_value=pypi_metadata())),
-                Mock(headers={"Content-Type": "text/html"}),
+                Mock(
+                    headers={"Content-Type": "text/html"},
+                    json=Mock(return_value=[{"draft": False, "prerelease": False, "tag_name": "v1.1"}]),
+                ),
             ]
         ),
     )
@@ -98,7 +101,11 @@ class UpdatePyprojectTomlsTest(unittest.TestCase):
         Mock(
             side_effect=[
                 Mock(json=Mock(return_value=pypi_metadata(changelog_url=""))),
-                Mock(json=Mock(return_value={"body": changelog, "tag_name": "v1.1"})),
+                Mock(
+                    json=Mock(
+                        return_value=[{"draft": False, "prerelease": False, "body": changelog, "tag_name": "v1.1"}]
+                    )
+                ),
                 Mock(json=Mock(return_value={"sha": "sha"})),
             ]
         ),

--- a/tools/update_dependencies/tests/test_version.py
+++ b/tools/update_dependencies/tests/test_version.py
@@ -1,0 +1,17 @@
+"""Unit tests for the version module."""
+
+import unittest
+
+from version import is_valid
+
+
+class IsValidTest(unittest.TestCase):
+    """Unit tests for the is_valid version checker."""
+
+    def test_is_valid(self):
+        """Test that a valid version is reported as valid."""
+        self.assertTrue(is_valid("1.0"))
+
+    def test_is_invalid(self):
+        """Test that a invalid version is reported as invalid."""
+        self.assertFalse(is_valid("nope-1.0"))


### PR DESCRIPTION
Some projects publish multiple releases to GitHub. For example, CodeQL publishes a bundle as well as releases for the CodeQL action itself, at the same repository. The bundle has a prefix causing its version number to be invalid. The bundle always gets the latest tag, causing the update script to miss updates of the CodeQL action.

Instead of fetching only the latest GitHub release, the update script now gets recent releases and skips releases that are draft, prerelease or have an invalid version number.

Closes #13164.