### PR TITLE
Support `k6_version` in Grafana k6 summary.json

### DIFF
--- a/components/collector/src/source_collectors/grafana_k6/json_types.py
+++ b/components/collector/src/source_collectors/grafana_k6/json_types.py
@@ -48,7 +48,8 @@ class Metadata(TypedDict):
     """Class representing the metadata object in a summary.json file."""
 
     generatedAt: str
-    k6Version: str
+    k6Version: NotRequired[str]
+    k6_version: NotRequired[str]  # k6 v1.7.x uses snake_case instead of camelCase as specified by the schema.
 
 
 class SummaryJSON(TypedDict):

--- a/components/collector/src/source_collectors/grafana_k6/source_version.py
+++ b/components/collector/src/source_collectors/grafana_k6/source_version.py
@@ -20,7 +20,9 @@ class GrafanaK6SourceVersion(JSONFileSourceCollector, VersionCollector):
         """Parse the version from the source response."""
         json = cast(SummaryJSON, await response.json(content_type=None))
         try:
-            return Version(json["metadata"]["k6Version"])
+            # k6 v1.7.x uses "k6_version" instead of "k6Version" as specified by the schema, so support both.
+            metadata = json["metadata"]
+            return Version(metadata.get("k6Version") or metadata["k6_version"])
         except KeyError as error:
             message = 'Could not find an object {"metadata": {"k6Version": value}} in summary.json.'
             raise CollectorError(message) from error

--- a/components/collector/tests/source_collectors/grafana_k6/test_source_version.py
+++ b/components/collector/tests/source_collectors/grafana_k6/test_source_version.py
@@ -11,18 +11,24 @@ class GrafanaK6SourceVersionTest(SourceCollectorTestCase):
 
     async def test_missing_metadata_gives_parse_error(self):
         """Test that a parse error is returned if the JSON has no metadata."""
-        measurement = await self.collect_measurement(get_request_json_return_value={})
+        json = {}
+        measurement = await self.collect_measurement(get_request_json_return_value=json)
         self.assert_measurement(measurement, parse_error="Could not find an object")
 
     async def test_missing_generated_at_gives_parse_error(self):
         """Test that a parse error is returned if the JSON has no k6Version in the metadata."""
-        measurement = await self.collect_measurement(get_request_json_return_value={"metadata": {}})
+        json = {"metadata": {}}
+        measurement = await self.collect_measurement(get_request_json_return_value=json)
         self.assert_measurement(measurement, parse_error="Could not find an object")
 
     async def test_source_version(self):
         """Test the source version."""
-        k6_version = "1.1.0"
-        measurement = await self.collect_measurement(
-            get_request_json_return_value={"metadata": {"k6Version": k6_version}}
-        )
+        json = {"metadata": {"k6Version": (k6_version := "1.10")}}
+        measurement = await self.collect_measurement(get_request_json_return_value=json)
+        self.assert_measurement(measurement, value=k6_version)
+
+    async def test_source_version_with_snake_case_key(self):
+        """Test the source version when k6 uses the snake_case "k6_version" key (k6 v1.7.x)."""
+        json = {"metadata": {"k6_version": (k6_version := "1.7.1")}}
+        measurement = await self.collect_measurement(get_request_json_return_value=json)
         self.assert_measurement(measurement, value=k6_version)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - Show the configured date below the source name in the metrics table for calendar date sources, so the date is visible when the metric is collapsed. Closes [#11143](https://github.com/ICTU/quality-time/issues/11143).
 - When measuring outdated dependencies with pip as source, allow for filtering major, minor, or patch updates. Closes [#12979](https://github.com/ICTU/quality-time/issues/12979).
+- When using Grafana k6 summary.json as source for the 'source version' metric, also accept the snake case `k6_version` key as written by k6 v1.7.x, in addition to the camel case `k6Version` key specified by the schema. Closes [#13243](https://github.com/ICTU/quality-time/issues/13243).
 
 ### Removed
 


### PR DESCRIPTION
When using Grafana k6 summary.json as source for the 'source version' metric, also accept the snake_case `k6_version` key as written by k6 v1.7.x, in addition to the camelCase `k6Version` key specified by the schema.

Closes #13243.