### PR TITLE
Support `generated_at` in Grafana k6 summary.json

### DIFF
--- a/components/collector/src/source_collectors/grafana_k6/json_types.py
+++ b/components/collector/src/source_collectors/grafana_k6/json_types.py
@@ -47,9 +47,11 @@ class State(TypedDict):
 class Metadata(TypedDict):
     """Class representing the metadata object in a summary.json file."""
 
-    generatedAt: str
+    # k6 v1.7.x uses snake_case instead of camelCase as specified by the schema, so support both.
+    generatedAt: NotRequired[str]
+    generated_at: NotRequired[str]
     k6Version: NotRequired[str]
-    k6_version: NotRequired[str]  # k6 v1.7.x uses snake_case instead of camelCase as specified by the schema.
+    k6_version: NotRequired[str]
 
 
 class SummaryJSON(TypedDict):

--- a/components/collector/src/source_collectors/grafana_k6/source_up_to_dateness.py
+++ b/components/collector/src/source_collectors/grafana_k6/source_up_to_dateness.py
@@ -21,7 +21,9 @@ class GrafanaK6SourceUpToDateness(JSONFileSourceCollector, TimePassedCollector):
         """Override to parse the date of the report."""
         json = cast(SummaryJSON, await response.json(content_type=None))
         try:
-            return parse_datetime(json["metadata"]["generatedAt"])
+            # k6 v1.7.x uses "generated_at" instead of "generatedAt" as specified by the schema, so support both.
+            metadata = json["metadata"]
+            return parse_datetime(metadata.get("generatedAt") or metadata["generated_at"])
         except KeyError as error:
             message = 'Could not find an object {"metadata": {"generatedAt": value}} in summary.json.'
             raise CollectorError(message) from error

--- a/components/collector/tests/source_collectors/grafana_k6/test_source_up_to_dateness.py
+++ b/components/collector/tests/source_collectors/grafana_k6/test_source_up_to_dateness.py
@@ -29,3 +29,12 @@ class GrafanaK6SourceUpToDatenessTest(SourceCollectorTestCase):
         )
         expected_value = str(days_ago(parse_datetime(generated_at)))
         self.assert_measurement(measurement, value=expected_value)
+
+    async def test_source_up_to_dateness_with_snake_case_key(self):
+        """Test the source up-to-dateness when k6 uses the snake_case "generated_at" key (k6 v1.7.x)."""
+        generated_at = "2026-04-21T10:00:00.000Z"
+        measurement = await self.collect_measurement(
+            get_request_json_return_value={"metadata": {"generated_at": generated_at}}
+        )
+        expected_value = str(days_ago(parse_datetime(generated_at)))
+        self.assert_measurement(measurement, value=expected_value)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 - Show the configured date below the source name in the metrics table for calendar date sources, so the date is visible when the metric is collapsed. Closes [#11143](https://github.com/ICTU/quality-time/issues/11143).
 - When measuring outdated dependencies with pip as source, allow for filtering major, minor, or patch updates. Closes [#12979](https://github.com/ICTU/quality-time/issues/12979).
 - When using Grafana k6 summary.json as source for the 'source version' metric, also accept the snake case `k6_version` key as written by k6 v1.7.x, in addition to the camel case `k6Version` key specified by the schema. Closes [#13243](https://github.com/ICTU/quality-time/issues/13243).
+- When using Grafana k6 summary.json as source for the 'source up-to-dateness' metric, also accept the snake case `generated_at` key as written by k6 v1.7.x, in addition to the camel case `generatedAt` key specified by the schema. Closes [#13276](https://github.com/ICTU/quality-time/issues/13276).
 
 ### Removed
 


### PR DESCRIPTION
When using Grafana k6 summary.json as source for the 'source up-to-dateness' metric, also accept the snake case `generated_at` key as written by k6 v1.7.x, in addition to the camel case `generatedAt` key specified by the schema.

Closes #13276.