### PR TITLE
Fix suppressed violations' user data being lost

### DIFF
--- a/components/shared_code/src/shared/model/measurement.py
+++ b/components/shared_code/src/shared/model/measurement.py
@@ -255,7 +255,10 @@ class Measurement(dict):
         """Return matching old/new source pairs."""
         old_sources = {source["source_uuid"]: source for source in previous_measurement.sources()}
         for source_uuid, source in self.metric["sources"].items():
-            if "copied_from" in source and source["copied_from"] in old_sources:
+            # Only apply the copied_from redirect when the copy has no previous measurement of its own yet, i.e. on the
+            # first measurement after the copy. Otherwise the copy's own entity user data would be overwritten with the
+            # original's on every measurement.
+            if source_uuid not in old_sources and "copied_from" in source and source["copied_from"] in old_sources:
                 old_sources[source_uuid] = old_sources[source["copied_from"]]
         return [
             (old_source, new_source)

--- a/components/shared_code/tests/shared/model/test_measurement.py
+++ b/components/shared_code/tests/shared/model/test_measurement.py
@@ -188,11 +188,7 @@ class MeasurementTest(MeasurementTestCase):
         measurement_1 = Measurement(
             self.metric(),
             sources=[
-                {
-                    "source_uuid": SOURCE_ID,
-                    "type": "azure_devops",
-                    "entity_user_data": {"key": {}},
-                },
+                {"source_uuid": SOURCE_ID, "type": "azure_devops", "entity_user_data": {"key": {}}},
             ],
         )
         measurement_2 = Measurement(
@@ -227,6 +223,41 @@ class MeasurementTest(MeasurementTestCase):
 
         measurement_2.copy_entity_user_data(measurement_1)
         self.assertIn("key", measurement_2.sources()[0]["entity_user_data"])
+
+    def test_entity_user_data_with_copied_source_alongside_original(self):
+        """Test that a copied source's own user data is preserved when both the original and the copy coexist."""
+        metric = self.metric(
+            sources={SOURCE_ID: cast(Source, {}), SOURCE_ID2: cast(Source, {"copied_from": SOURCE_ID})},
+        )
+        measurement_1 = Measurement(
+            metric,
+            sources=[
+                {
+                    "source_uuid": SOURCE_ID,
+                    "type": "azure_devops",
+                    "entities": [{"key": "original_key"}],
+                    "entity_user_data": {"original_key": {"status": "false_positive"}},
+                },
+                {
+                    "source_uuid": SOURCE_ID2,
+                    "type": "azure_devops",
+                    "entities": [{"key": "copy_key"}],
+                    "entity_user_data": {"copy_key": {"status": "wont_fix"}},
+                },
+            ],
+        )
+        measurement_2 = Measurement(
+            metric,
+            sources=[
+                {"source_uuid": SOURCE_ID, "type": "azure_devops", "entities": [{"key": "original_key"}]},
+                {"source_uuid": SOURCE_ID2, "type": "azure_devops", "entities": [{"key": "copy_key"}]},
+            ],
+        )
+        measurement_2.copy_entity_user_data(measurement_1)
+        original_source = measurement_2.sources()[0]
+        copy_source = measurement_2.sources()[1]
+        self.assertEqual("false_positive", original_source["entity_user_data"]["original_key"]["status"])
+        self.assertEqual("wont_fix", copy_source["entity_user_data"]["copy_key"]["status"])
 
     def test_copy_first_seen_timestamps(self):
         """Test that the first seen timestamps can be copied."""

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -27,6 +27,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Fixed
 
 - The documentation on importing reports was claiming that a report with credentials can only be re-imported into the same *Quality-time* instance. This is no longer true since v5.52.0. Fixes [#13080](https://github.com/ICTU/quality-time/issues/13080).
+- When a metric had multiple sources where one source was created by copying another, the copied source's entity user data (such as suppressed violation statuses) was overwritten with the original source's user data on every measurement, causing suppressed violations to revert to "unconfirmed". Fixes [#13275](https://github.com/ICTU/quality-time/issues/13275).
 
 ### Deprecated
 


### PR DESCRIPTION
When a metric had multiple sources where one source was created by copying another, the copied source's entity user data (such as suppressed violation statuses) was overwritten with the original source's user data on every measurement, causing suppressed violations to revert to "unconfirmed".

Fixes #13275.