### PR TITLE
Fix login failure for LDAP without userPassword

### DIFF
--- a/components/api_server/src/routes/auth.py
+++ b/components/api_server/src/routes/auth.py
@@ -99,7 +99,9 @@ def verify_user(database: Database, username: str, password: str) -> User:
         ldap_server_pool = ServerPool([Server(url, get_info=ALL) for url in ldap.urls])
         logger.debug("Created LDAP server pool for URLs: %s", ldap.urls)
         # Look up the user to authenticate, using the lookup-user credentials:
-        with Connection(ldap_server_pool, user=ldap.lookup_user_dn, password=ldap.lookup_user_pw) as lookup_connection:
+        with Connection(
+            ldap_server_pool, user=ldap.lookup_user_dn, password=ldap.lookup_user_pw, return_empty_attributes=True
+        ) as lookup_connection:
             logger.debug("Created LDAP lookup connection for lookup user %s", ldap.lookup_user_dn)
             if not lookup_connection.bind():  # pragma: no feature-test-cover
                 logger.warning("Could not bind LDAP lookup connection for lookup user %s", ldap.lookup_user_dn)

--- a/components/api_server/tests/routes/test_auth.py
+++ b/components/api_server/tests/routes/test_auth.py
@@ -92,7 +92,7 @@ class LoginTests(AuthTestCase):
         """Assert that the LDAP lookup connection was created with the lookup user dn and password."""
         self.assertEqual(
             connection_mock.call_args_list[0][1],
-            {"user": self.LOOKUP_USER_DN, "password": "admin"},  # nosec
+            {"user": self.LOOKUP_USER_DN, "password": "admin", "return_empty_attributes": True},  # nosec
         )
 
     def assert_ldap_bind_connection_created(self, connection_mock):

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -10,6 +10,12 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the tools/release/src/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- If an LDAP server does not return the user password attribute when Quality-time tries to authenticate a user, attempt an LDAP bind instead of throwing an exception. Fixes [#13305](https://github.com/ICTU/quality-time/issues/13305).
+
 ## v5.55.0 - 2026-05-21
 
 ### Added


### PR DESCRIPTION
If an LDAP server does not return the userPassword attribute when Quality-time tries to authenticate a user, attempt an LDAP bind instead of throwing an exception.

Fixes #13305.