### PR TITLE
Fix login failure for LDAP without userPassword

### DIFF
--- a/components/api_server/src/routes/auth.py
+++ b/components/api_server/src/routes/auth.py
@@ -99,21 +99,29 @@ def verify_user(database: Database, username: str, password: str) -> User:
         ldap_server_pool = ServerPool([Server(url, get_info=ALL) for url in ldap.urls])
         logger.debug("Created LDAP server pool for URLs: %s", ldap.urls)
         # Look up the user to authenticate, using the lookup-user credentials:
-        with Connection(
-            ldap_server_pool, user=ldap.lookup_user_dn, password=ldap.lookup_user_pw, return_empty_attributes=True
-        ) as lookup_connection:
+        with Connection(ldap_server_pool, user=ldap.lookup_user_dn, password=ldap.lookup_user_pw) as lookup_connection:
             logger.debug("Created LDAP lookup connection for lookup user %s", ldap.lookup_user_dn)
             if not lookup_connection.bind():  # pragma: no feature-test-cover
                 logger.warning("Could not bind LDAP lookup connection for lookup user %s", ldap.lookup_user_dn)
                 raise exceptions.LDAPBindError  # noqa: TRY301
             logger.debug("Successfully bound LDAP lookup connection for lookup user %s", ldap.lookup_user_dn)
-            lookup_connection.search(ldap.root_dn, ldap.search_filter, attributes=["userPassword", "cn", "mail"])
+            try:
+                lookup_connection.search(ldap.root_dn, ldap.search_filter, attributes=["userPassword", "cn", "mail"])
+                received_user_password_hash = True
+            except exceptions.LDAPAttributeError:  # pragma: no feature-test-cover
+                received_user_password_hash = False
+                logger.debug("Search for LDAP user with userPassword failed, attempting search without userPassword")
+                lookup_connection.search(ldap.root_dn, ldap.search_filter, attributes=["cn", "mail"])
             logger.debug("Searched for LDAP user using configured LDAP search filter")
             ldap_user = lookup_connection.entries[0]
             logger.debug("Found LDAP user with dn %s using configured LDAP search filter", ldap_user.entry_dn)
         # If the LDAP-server returned the user's password-hash, check the password against the hash, otherwise
         # attempt a bind operation using the user's distinguished name (dn) and password:
-        if (password_hash := ldap_user.userPassword.value) and check_password(password_hash, password):
+        if (
+            received_user_password_hash
+            and (password_hash := ldap_user.userPassword.value)
+            and check_password(password_hash, password)
+        ):
             logger.info("LDAP password check succeeded for LDAP user with dn %s", ldap_user.entry_dn)
         else:  # pragma: no feature-test-cover
             logger.debug("LDAP password check failed, attempting LDAP bind with the user's dn %s", ldap_user.entry_dn)

--- a/components/api_server/tests/routes/test_auth.py
+++ b/components/api_server/tests/routes/test_auth.py
@@ -80,19 +80,19 @@ class LoginTests(AuthTestCase):
             "session_expiration_datetime": datetime.min.replace(tzinfo=tzutc()).isoformat(),
         }
 
-    def assert_ldap_connection_search_called(self):
+    def assert_ldap_connection_search_called(self, attributes=("userPassword", "cn", "mail")):
         """Assert that the LDAP connection search method is called with the correct arguments."""
         self.ldap_connection.search.assert_called_with(
             self.LDAP_ROOT_DN,
             f"(|(uid={USERNAME})(cn={USERNAME}))",
-            attributes=["userPassword", "cn", "mail"],
+            attributes=list(attributes),
         )
 
     def assert_ldap_lookup_connection_created(self, connection_mock):
         """Assert that the LDAP lookup connection was created with the lookup user dn and password."""
         self.assertEqual(
             connection_mock.call_args_list[0][1],
-            {"user": self.LOOKUP_USER_DN, "password": "admin", "return_empty_attributes": True},  # nosec
+            {"user": self.LOOKUP_USER_DN, "password": "admin"},  # nosec
         )
 
     def assert_ldap_bind_connection_created(self, connection_mock):
@@ -263,6 +263,20 @@ class LoginTests(AuthTestCase):
         self.assertEqual(login_ok, login(self.database))
         self.assert_cookie_has_session_id()
         self.assert_ldap_lookup_connection_created(connection_mock)
+
+    @patch("bottle.request", Mock(json={"username": USERNAME, "password": PASSWORD}))
+    @patch("routes.auth.datetime", MOCK_DATETIME)
+    def test_ldap_attribute_error(self, connection_mock, connection_enter):
+        """Test that an LDAP bind is done if the LDAP-server throws an attribute error."""
+        connection_mock.return_value = None
+        self.ldap_entry.userPassword.value = None
+        self.ldap_connection.search.side_effect = [exceptions.LDAPAttributeError, None]
+        connection_enter.return_value = self.ldap_connection
+        self.assertEqual(self.login_ok, login(self.database))
+        self.assert_cookie_has_session_id()
+        self.assert_ldap_lookup_connection_created(connection_mock)
+        self.assert_ldap_bind_connection_created(connection_mock)
+        self.assert_ldap_connection_search_called(("cn", "mail"))
 
 
 class LogoutTests(AuthTestCase):


### PR DESCRIPTION
Attempt #2.

If an LDAP server does not return the userPassword attribute when Quality-time tries to authenticate a user, attempt an LDAP bind instead of throwing an exception.

Fixes #13305.