### PR TITLE
Use uv lock instead of sync to refresh lock files

### DIFF
--- a/tools/update_dependencies/src/update_pyproject_toml.py
+++ b/tools/update_dependencies/src/update_pyproject_toml.py
@@ -69,7 +69,7 @@ def update_pyproject_toml(pyproject_toml: Path) -> None:
 def update_uv_lock(pyproject_toml: Path) -> None:
     """Update the uv.lock file for the pyproject.toml."""
     LOG.path(pyproject_toml.parent / "uv.lock")
-    run(["uv", "sync", "--directory", str(pyproject_toml.parent), "--upgrade", "--quiet", "--no-progress"])
+    run(["uv", "lock", "--directory", str(pyproject_toml.parent), "--upgrade", "--quiet", "--no-progress"])
 
 
 def update_pyproject_tomls() -> int:


### PR DESCRIPTION
The update_pyproject_toml.py script was using `uv sync --upgrade` to refresh downstream uv.lock files after updating upstream pyproject.toml files. However, `uv sync` did not always pick up changes in local workspace dependencies, so running `uv lock` manually afterwards still produced changes. Switch to `uv lock --upgrade`, which fully re-resolves the lockfile (including local workspace deps and transitive dependencies). Installing into .venv is unnecessary here because every Python-related just recipe depends on `install-py-dependencies`, which runs `uv sync --locked` and syncs the environment on demand.

Closes #13316.