### PR TITLE
Add Subresource Integrity (SRI) to the jsDelivr CDN script in the docs

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -68,7 +68,13 @@ html_favicon = "../../components/frontend/public/favicon.ico"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 html_css_files = ["copy_button.css"]
-html_js_files = ["https://cdn.jsdelivr.net/npm/clipboard@2.0.11/dist/clipboard.min.js", "copy_button.js"]
+html_js_files = [
+    (
+        "https://cdn.jsdelivr.net/npm/clipboard@2.0.11/dist/clipboard.min.js",
+        {"integrity": "sha256-4XodgW4TwIJuDtf+v6vDJ39FVxI0veC/kSCCmnFp7ck=", "crossorigin": "anonymous"},
+    ),
+    "copy_button.js",
+]
 
 # -- Options for linkcheck ---------------------------------------------------
 

--- a/tools/update_dependencies/src/update_jsdelivr.py
+++ b/tools/update_dependencies/src/update_jsdelivr.py
@@ -1,36 +1,76 @@
 """Updater script for jsdelivr CDN URLs (limited to NPM packages in the Sphinx config at the moment)."""
 
+import re
 import sys
 from pathlib import Path
 
 import requests
 from packaging.version import InvalidVersion, Version
 
-from filesystem import update_file
 from log import get_logger
 from version import DependencyVersion
 
 LOG = get_logger("jsdelivr")
-JSDELIVR_URL_RE = r"https://cdn.jsdelivr.net/npm/(?P<dependency>[\w-]+)@(?P<version>[\d\.]+)"
+HEADERS = {"User-Agent": "Dependency update script for Quality-time (https://github.com/ictu/quality-time)"}
+# Match a jsDelivr npm URL together with the Subresource Integrity hash that follows it, so both stay in sync.
+JSDELIVR_RE = re.compile(
+    r"https://cdn\.jsdelivr\.net/npm/(?P<dependency>[\w-]+)@(?P<version>[\d.]+)"
+    r".*?\"integrity\": \"(?P<sha>sha\d+-[A-Za-z0-9+/=]+)\"",
+    re.DOTALL,
+)
 
 
 def get_latest_version(dependency: str, current_version_string: str) -> DependencyVersion:
-    """Fetch the latest version for the dependency."""
-    url = f"https://data.jsdelivr.com/v1/packages/npm/{dependency}"
+    """Fetch the latest version and matching integrity hash for the dependency."""
     current_version = Version(current_version_string)
-    headers = {"User-Agent": "Dependency update script for Quality-time (https://github.com/ictu/quality-time)"}
-    response = requests.get(url, headers=headers, timeout=10)
+    latest_version = _get_latest_version(dependency, current_version)
+    integrity = _get_integrity_hash(dependency, latest_version) if latest_version > current_version else ""
+    return DependencyVersion(version=str(latest_version), sha=integrity)
+
+
+def _get_latest_version(dependency: str, current_version: Version) -> Version:
+    """Fetch the latest released version of the dependency from jsDelivr."""
+    url = f"https://data.jsdelivr.com/v1/packages/npm/{dependency}"
+    response = requests.get(url, headers=HEADERS, timeout=10)
     response.raise_for_status()
-    json = response.json()
-    latest_tag = json.get("tags", {}).get("latest", "")
+    latest_tag = response.json().get("tags", {}).get("latest", "")
     try:
         latest_version = Version(latest_tag)
     except InvalidVersion:
-        LOG.invalid_version(f"{dependency}", f"'{latest_tag}'")
+        LOG.invalid_version(dependency, f"'{latest_tag}'")
         latest_version = Version("0.0.0")
-    return DependencyVersion(version=str(max(latest_version, current_version)))
+    return max(latest_version, current_version)
+
+
+def _get_integrity_hash(dependency: str, version: Version) -> str:
+    """Fetch the Subresource Integrity hash of the dependency's default file from jsDelivr."""
+    url = f"https://data.jsdelivr.com/v1/packages/npm/{dependency}@{version}?structure=flat"
+    response = requests.get(url, headers=HEADERS, timeout=10)
+    response.raise_for_status()
+    json = response.json()
+    file_hash = next(file["hash"] for file in json["files"] if file["name"] == json["default"])
+    return f"sha256-{file_hash}"
+
+
+def update_jsdelivr(content: str) -> str:
+    """Update the version and integrity hash of all jsDelivr URLs in the content."""
+
+    def replace(match: re.Match[str]) -> str:
+        dependency, version = match.group("dependency"), match.group("version")
+        latest_version = get_latest_version(dependency, version)
+        if latest_version.version == version:
+            return match.group(0)
+        LOG.new_version(dependency, latest_version)
+        return match.group(0).replace(version, latest_version.version).replace(match.group("sha"), latest_version.sha)
+
+    return JSDELIVR_RE.sub(replace, content)
 
 
 if __name__ == "__main__":  # pragma: no cover
     sphinx_config_py = Path.cwd() / "docs" / "src" / "conf.py"
-    sys.exit(update_file(sphinx_config_py, JSDELIVR_URL_RE, get_latest_version, LOG))
+    LOG.path(sphinx_config_py)
+    old_content = sphinx_config_py.read_text()
+    new_content = update_jsdelivr(old_content)
+    if new_content != old_content:
+        sphinx_config_py.write_text(new_content)
+    sys.exit(0)

--- a/tools/update_dependencies/tests/fixtures.py
+++ b/tools/update_dependencies/tests/fixtures.py
@@ -1,5 +1,8 @@
 """Test fixtures."""
 
-DIGEST = DIGEST1 = f"sha256:{'a' * 64}"
-DIGEST2 = f"sha256:{'b' * 64}"
-DIGEST3 = f"sha256:{'c' * 64}"
+HASH1 = "a" * 64
+HASH2 = "b" * 64
+HASH3 = "c" * 64
+DIGEST = DIGEST1 = f"sha256:{HASH1}"
+DIGEST2 = f"sha256:{HASH2}"
+DIGEST3 = f"sha256:{HASH3}"

--- a/tools/update_dependencies/tests/test_update_jsdelivr.py
+++ b/tools/update_dependencies/tests/test_update_jsdelivr.py
@@ -3,33 +3,76 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from update_jsdelivr import get_latest_version
+from update_jsdelivr import get_latest_version, update_jsdelivr
 
+from .fixtures import HASH1, HASH2
 from .helpers import mock_response
+
+# A flat package listing as returned by the jsDelivr API with the ?structure=flat query parameter.
+FLAT_FILES = {"default": "/dist/clipboard.min.js", "files": [{"name": "/dist/clipboard.min.js", "hash": HASH2}]}
+
+# The relevant part of the Sphinx config, formatted as Ruff would format it.
+CONF = (
+    "html_js_files = [\n"
+    "    (\n"
+    '        "https://cdn.jsdelivr.net/npm/clipboard@2.0.11/dist/clipboard.min.js",\n'
+    f'        {{"integrity": "sha256-{HASH1}", "crossorigin": "anonymous"}},\n'
+    "    ),\n"
+    '    "copy_button.js",\n'
+    "]\n"
+)
 
 
 @patch("requests.get")
-class UpdateJsdelivrTest(unittest.TestCase):
+class GetLatestVersionTest(unittest.TestCase):
     """Unit tests for the get latest jsdelivr version function."""
 
     def test_unchanged(self, mock_get: Mock):
-        """Test an unchanged version."""
+        """Test that an unchanged version does not fetch an integrity hash."""
         mock_get.return_value = mock_response({"tags": {"latest": "1.0"}})
-        self.assertEqual("1.0", get_latest_version("clipboard", "1.0").version)
+        latest_version = get_latest_version("clipboard", "1.0")
+        self.assertEqual("1.0", latest_version.version)
+        self.assertEqual("", latest_version.sha)
 
     def test_newer(self, mock_get: Mock):
-        """Test an newer version."""
-        mock_get.return_value = mock_response({"tags": {"latest": "1.1"}})
-        self.assertEqual("1.1", get_latest_version("clipboard", "1.0").version)
+        """Test that a newer version also fetches the matching integrity hash."""
+        mock_get.side_effect = [mock_response({"tags": {"latest": "1.1"}}), mock_response(FLAT_FILES)]
+        latest_version = get_latest_version("clipboard", "1.0")
+        self.assertEqual("1.1", latest_version.version)
+        self.assertEqual(f"sha256-{HASH2}", latest_version.sha)
 
     def test_older(self, mock_get: Mock):
-        """Test an older version."""
+        """Test that an older latest version keeps the current version and does not fetch a hash."""
         mock_get.return_value = mock_response({"tags": {"latest": "0.9"}})
-        self.assertEqual("1.0", get_latest_version("clipboard", "1.0").version)
+        latest_version = get_latest_version("clipboard", "1.0")
+        self.assertEqual("1.0", latest_version.version)
+        self.assertEqual("", latest_version.sha)
 
     @patch("logging.Logger.error")
     def test_invalid_version(self, mock_error: Mock, mock_get: Mock):
-        """Test that the file is not written if there are no outdated packages."""
+        """Test that an invalid latest version is logged and ignored."""
         mock_get.return_value = mock_response({})
         self.assertEqual("1.0", get_latest_version("clipboard", "1.0").version)
         mock_error.assert_called_once_with("Got an invalid version for %s: %s", "clipboard", "''", stacklevel=2)
+
+
+@patch("logging.Logger.warning")
+@patch("requests.get")
+class UpdateJsdelivrTest(unittest.TestCase):
+    """Unit tests for rewriting the version and integrity hash in the Sphinx config."""
+
+    def test_new_version_and_hash(self, mock_get: Mock, mock_warning: Mock):
+        """Test that both the version and the integrity hash are updated on a bump."""
+        mock_get.side_effect = [mock_response({"tags": {"latest": "2.0.12"}}), mock_response(FLAT_FILES)]
+        new_content = update_jsdelivr(CONF)
+        self.assertIn("clipboard@2.0.12/dist/clipboard.min.js", new_content)
+        self.assertIn(f'"integrity": "sha256-{HASH2}"', new_content)
+        self.assertNotIn("2.0.11", new_content)
+        self.assertNotIn(HASH1, new_content)
+        mock_warning.assert_called_once()
+
+    def test_unchanged(self, mock_get: Mock, mock_warning: Mock):
+        """Test that the content is unchanged if there is no new version."""
+        mock_get.return_value = mock_response({"tags": {"latest": "2.0.11"}})
+        self.assertEqual(CONF, update_jsdelivr(CONF))
+        mock_warning.assert_not_called()


### PR DESCRIPTION
Load the jsDelivr clipboard script in the docs with an integrity hash and crossorigin attribute, so the browser refuses to execute it if the CDN or upstream package is tampered with. Keep the version and integrity hash in sync on bumps via the jsDelivr updater.

Closes #13331.