### PR TITLE
Rename merge request upvotes parameter

### DIFF
--- a/components/collector/src/base_collectors/source_collector.py
+++ b/components/collector/src/base_collectors/source_collector.py
@@ -556,6 +556,6 @@ class MergeRequestCollector(SourceCollector):
         """Return whether the merge request upvotes matches the configured upvotes."""
         # If the required number of upvotes is zero, merge requests are included regardless of how many upvotes they
         # actually have. If the required number of upvotes is more than zero then only merge requests that have fewer
-        # than the minimum number of upvotes are included in the count:
+        # than the required number of upvotes are included in the count:
         required_upvotes = int(cast(str, self._parameter("upvotes")))
         return required_upvotes == 0 or int(entity["upvotes"]) < required_upvotes

--- a/components/shared_code/src/shared_data_model/metrics.py
+++ b/components/shared_code/src/shared_data_model/metrics.py
@@ -288,8 +288,8 @@ itself.""",
         rationale="Merge requests need to be reviewed and approved. This metric allows for measuring the number "
         "of merge requests without the required approvals.",
         documentation="""In itself, the number of merge requests is not indicative of software quality. However,
-by setting the parameter "Minimum number of upvotes", the metric can report on merge requests that have fewer than the
-minimum number of upvotes. The parameter "Merge request state" can be used to exclude closed merge requests, for
+by setting the parameter "Required number of upvotes", the metric can report on merge requests that have fewer than the
+required number of upvotes. The parameter "Merge request state" can be used to exclude closed merge requests, for
 example. The parameter "Target branches to include" can be used to further limit the merge requests to only count merge
 requests that target specific branches, for example the "develop" branch.""",
         scales=["count", "percentage"],

--- a/components/shared_code/src/shared_data_model/parameters.py
+++ b/components/shared_code/src/shared_data_model/parameters.py
@@ -211,10 +211,10 @@ class TestResultAggregationStrategy(SingleChoiceParameter):
 
 
 class Upvotes(IntegerParameter):
-    """Minimum number of merge request up-votes parameter."""
+    """Required number of merge request up-votes parameter."""
 
-    name: str = "Minimum number of upvotes"
-    help: str = "Only count merge requests with fewer than the minimum number of upvotes."
+    name: str = "Required number of upvotes"
+    help: str | None = "Only count merge requests with fewer than the required number of upvotes."
     unit: Unit = Unit.UPVOTES
     metrics: list[str] = ["merge_requests"]
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,6 +14,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ### Fixed
 
+- Rename the merge requests parameter "Minimum number of upvotes" to "Required number of upvotes" to make the purpose of the parameter clearer. Fixes [#13016](https://github.com/ICTU/quality-time/issues/13016).
 - If an LDAP server does not return the user password attribute when Quality-time tries to authenticate a user, attempt an LDAP bind instead of throwing an exception. Fixes [#13305](https://github.com/ICTU/quality-time/issues/13305).
 
 ## v5.55.0 - 2026-05-21


### PR DESCRIPTION
Rename the merge requests parameter "Minimum number of upvotes" to "Required number of upvotes" to make the purpose of the parameter clearer.

Fixes #13016.