### PR TITLE
Add CSV export for reports

### DIFF
--- a/components/frontend/src/measurement/MeasurementTarget.jsx
+++ b/components/frontend/src/measurement/MeasurementTarget.jsx
@@ -3,15 +3,7 @@ import { useContext, useState } from "react"
 
 import { DataModelContext } from "../context/DataModel"
 import { metricPropType } from "../sharedPropTypes"
-import {
-    formatMetricDirection,
-    formatMetricScale,
-    formatMetricScaleAndUnit,
-    formatMetricValue,
-    getMetricScale,
-    getMetricTarget,
-    isValidISODate,
-} from "../utils"
+import { formatMetricDirection, formatMetricScaleAndUnit, getFormattedMetricTarget, isValidISODate } from "../utils"
 import { Label } from "../widgets/Label"
 
 function popupText(metric, debtEndDateInThePast, allIssuesDone, dataModel) {
@@ -45,18 +37,8 @@ export function MeasurementTarget({ metric }) {
     const [endDate] = useState(() =>
         metric.debt_end_date && isValidISODate(metric.debt_end_date) ? new Date(metric.debt_end_date) : new Date(),
     )
-    if (metric?.evaluate_targets === false) {
-        return null
-    }
-    const metricDirection = formatMetricDirection(metric, dataModel)
-    const scale = getMetricScale(metric, dataModel)
-    const valueAndScale = `${formatMetricValue(scale, getMetricTarget(metric))}${formatMetricScale(metric, dataModel)}`
-    const target = (
-        <>
-            {metricDirection}&nbsp;{valueAndScale}
-        </>
-    )
-    if (!metric.accept_debt) {
+    const target = getFormattedMetricTarget(metric, dataModel)
+    if (!target || !metric.accept_debt) {
         return target
     }
     const allIssuesDone =

--- a/components/frontend/src/measurement/MeasurementValue.jsx
+++ b/components/frontend/src/measurement/MeasurementValue.jsx
@@ -8,10 +8,8 @@ import { DataModelContext } from "../context/DataModel"
 import { datePropType, measurementPropType, metricPropType } from "../sharedPropTypes"
 import { IGNORABLE_SOURCE_ENTITY_STATUSES, SOURCE_ENTITY_STATUS_NAME } from "../source/source_entity_status"
 import {
-    formatMetricValue,
-    getMetricScale,
+    getFormattedMetricValue,
     getMetricUnit,
-    getMetricValue,
     isMeasurementOutdated,
     isMeasurementRequested,
     isMeasurementStale,
@@ -98,13 +96,7 @@ ignoredEntitiesMessage.propTypes = {
 
 export function MeasurementValue({ metric, reportDate }) {
     const dataModel = useContext(DataModelContext)
-    const metricValue = getMetricValue(metric, dataModel)
-    let value = metricValue || "?"
-    const scale = getMetricScale(metric, dataModel)
-    if (scale === "percentage") {
-        value += "%"
-    }
-    value = formatMetricValue(scale, value)
+    const value = getFormattedMetricValue(metric, dataModel)
     const unit = getMetricUnit(metric, dataModel, value)
     const stale = isMeasurementStale(metric, reportDate)
     const complete = isSourceConfigurationComplete(dataModel, metric)

--- a/components/frontend/src/measurement/Overrun.jsx
+++ b/components/frontend/src/measurement/Overrun.jsx
@@ -14,12 +14,8 @@ import { useContext } from "react"
 
 import { DataModelContext } from "../context/DataModel"
 import { datesPropType, measurementsPropType, metricPropType, reportPropType } from "../sharedPropTypes"
-import { getMetricResponseOverrun, pluralize } from "../utils"
+import { formatDays, getMetricResponseOverrun } from "../utils"
 import { StatusIcon } from "./StatusIcon"
-
-function formatDays(days) {
-    return `${days} ${pluralize("day", days)}`
-}
 
 export function Overrun({ metricUuid, metric, report, measurements, dates }) {
     const dataModel = useContext(DataModelContext)

--- a/components/frontend/src/measurement/TimeLeft.jsx
+++ b/components/frontend/src/measurement/TimeLeft.jsx
@@ -1,7 +1,7 @@
 import { Tooltip } from "@mui/material"
 
 import { metricPropType, reportPropType } from "../sharedPropTypes"
-import { days, getMetricResponseDeadline, getMetricResponseTimeLeft, pluralize } from "../utils"
+import { getFormattedMetricTimeLeft, getMetricResponseDeadline, getMetricResponseTimeLeft } from "../utils"
 import { Label } from "../widgets/Label"
 import { TimeAgoWithDate } from "../widgets/TimeAgoWithDate"
 
@@ -11,8 +11,7 @@ export function TimeLeft({ metric, report }) {
         return null
     }
     const timeLeft = getMetricResponseTimeLeft(metric, report)
-    const daysLeft = days(Math.max(0, timeLeft))
-    const triggerText = `${daysLeft} ${pluralize("day", daysLeft)}`
+    const triggerText = getFormattedMetricTimeLeft(metric, report)
     let deadlineLabel = "Deadline to address this metric was"
     let trigger = <Label color="error">{triggerText}</Label>
     if (timeLeft >= 0) {

--- a/components/frontend/src/metric/MetricConfigurationParameters.jsx
+++ b/components/frontend/src/metric/MetricConfigurationParameters.jsx
@@ -183,7 +183,7 @@ function UnitPlural({ metric, metricUuid, reload }) {
             disabled={disabled}
             label="Metric unit plural"
             placeholder={metricType.unit}
-            startAdornment={formatMetricScale(metric, dataModel, "2")}
+            startAdornment={formatMetricScale(metric, dataModel)}
             onChange={(value) => setMetricAttribute(metricUuid, "unit", value, reload)}
             value={metric.unit || metricType.unit}
         />
@@ -205,7 +205,7 @@ function UnitSingular({ metric, metricUuid, reload }) {
             disabled={disabled}
             label="Metric unit singular"
             placeholder={metricType.unit_singular}
-            startAdornment={formatMetricScale(metric, dataModel, "1")}
+            startAdornment={formatMetricScale(metric, dataModel)}
             onChange={(value) => setMetricAttribute(metricUuid, "unit_singular", value, reload)}
             value={metric.unit_singular || metricType.unit_singular}
         />

--- a/components/frontend/src/report/Report.jsx
+++ b/components/frontend/src/report/Report.jsx
@@ -17,6 +17,7 @@ import { SubjectsButtonRow } from "../subject/SubjectsButtonRow"
 import { getReportTags } from "../utils"
 import { CommentSegment } from "../widgets/CommentSegment"
 import { WarningMessage } from "../widgets/WarningMessage"
+import { reverseSortMeasurements } from "./report_utils"
 import { ReportDashboard } from "./ReportDashboard"
 import { ReportTitle } from "./ReportTitle"
 
@@ -46,13 +47,13 @@ export function Report({
             </WarningMessage>
         )
     }
-    // Sort measurements in reverse order so that if there multiple measurements on a day, we find the most recent one:
-    const reversedMeasurements = measurements.slice().sort((m1, m2) => (m1.start < m2.start ? 1 : -1))
     return (
         <div id="dashboard">
             <PageHeader lastUpdate={lastUpdate} report={report} reportDate={reportDate} />
             <Paper elevation={5} sx={{ marginTop: "20px" }}>
                 <ReportTitle
+                    dates={dates}
+                    measurements={measurements}
                     openReportsOverview={openReportsOverview}
                     reload={reload}
                     report={report}
@@ -62,7 +63,7 @@ export function Report({
                 <Divider sx={{ padding: "0px" }} />
                 <ReportDashboard
                     dates={dates}
-                    measurements={reversedMeasurements}
+                    measurements={reverseSortMeasurements(measurements)}
                     onClick={(e, s) => navigateToSubject(e, s)}
                     onClickTag={(tag) => {
                         // If there are hidden tags (hiddenTags.length > 0), show the hidden tags.

--- a/components/frontend/src/report/ReportTitle.jsx
+++ b/components/frontend/src/report/ReportTitle.jsx
@@ -11,10 +11,11 @@ import { deleteReport } from "../api/report"
 import { ChangeLog } from "../changelog/ChangeLog"
 import { EDIT_REPORT_PERMISSION, ReadOnlyOrEditable } from "../context/Permissions"
 import { NotificationDestinations } from "../notification/NotificationDestinations"
-import { reportPropType, settingsPropType } from "../sharedPropTypes"
+import { datesPropType, measurementsPropType, reportPropType, settingsPropType } from "../sharedPropTypes"
 import { ButtonRow } from "../widgets/ButtonRow"
 import { DeleteButton } from "../widgets/buttons/DeleteButton"
 import { ExportReportButton } from "../widgets/buttons/ExportReportButton"
+import { ExportReportCsvButton } from "../widgets/buttons/ExportReportCsvButton"
 import { PermLinkButton } from "../widgets/buttons/PermLinkButton"
 import { HeaderWithDetails } from "../widgets/HeaderWithDetails"
 import { Tabs } from "../widgets/Tabs"
@@ -25,7 +26,8 @@ import { ReportConfiguration } from "./ReportConfiguration"
 import { ReportSources } from "./ReportSources"
 import { Tags } from "./Tags"
 
-function ReportTitleButtonRow({ reportUuid, openReportsOverview, settings, url }) {
+function ReportTitleButtonRow({ report, measurements, dates, openReportsOverview, settings, url }) {
+    const reportUuid = report.report_uuid
     const deleteButton = (
         <DeleteButton
             itemType="report"
@@ -35,26 +37,41 @@ function ReportTitleButtonRow({ reportUuid, openReportsOverview, settings, url }
             }}
         />
     )
+    // The CSV export button is shown to all users because the CSV contains no credentials; the other buttons require
+    // edit permission.
     return (
-        <ReadOnlyOrEditable
-            requiredPermissions={[EDIT_REPORT_PERMISSION]}
-            editableComponent={
-                <ButtonRow rightButton={deleteButton} paddingBottom={2} paddingLeft={0} paddingRight={0} paddingTop={2}>
-                    <PermLinkButton itemType="report" url={url} />
-                    <ExportReportButton reportUuid={reportUuid} />
-                </ButtonRow>
+        <ButtonRow
+            rightButton={
+                <ReadOnlyOrEditable requiredPermissions={[EDIT_REPORT_PERMISSION]} editableComponent={deleteButton} />
             }
-        />
+            paddingBottom={2}
+            paddingLeft={0}
+            paddingRight={0}
+            paddingTop={2}
+        >
+            <ExportReportCsvButton report={report} measurements={measurements} dates={dates} settings={settings} />
+            <ReadOnlyOrEditable
+                requiredPermissions={[EDIT_REPORT_PERMISSION]}
+                editableComponent={
+                    <>
+                        <ExportReportButton reportUuid={reportUuid} />
+                        <PermLinkButton itemType="report" url={url} />
+                    </>
+                }
+            />
+        </ButtonRow>
     )
 }
 ReportTitleButtonRow.propTypes = {
-    reportUuid: string,
+    report: reportPropType,
+    measurements: measurementsPropType,
+    dates: datesPropType,
     openReportsOverview: func,
     settings: settingsPropType,
     url: string,
 }
 
-export function ReportTitle({ openReportsOverview, reload, report, settings }) {
+export function ReportTitle({ dates, measurements, openReportsOverview, reload, report, settings }) {
     const reportUuid = report.report_uuid
     const reportUrl = `${globalThis.location}`
     setDocumentTitle(report.title)
@@ -92,7 +109,9 @@ export function ReportTitle({ openReportsOverview, reload, report, settings }) {
                 <ChangeLog reportUuid={reportUuid} timestamp={report.timestamp} />
             </Tabs>
             <ReportTitleButtonRow
-                reportUuid={reportUuid}
+                report={report}
+                measurements={measurements}
+                dates={dates}
                 openReportsOverview={openReportsOverview}
                 settings={settings}
                 url={reportUrl}
@@ -101,6 +120,8 @@ export function ReportTitle({ openReportsOverview, reload, report, settings }) {
     )
 }
 ReportTitle.propTypes = {
+    dates: datesPropType,
+    measurements: measurementsPropType,
     openReportsOverview: func,
     reload: func,
     report: reportPropType,

--- a/components/frontend/src/report/ReportTitle.test.jsx
+++ b/components/frontend/src/report/ReportTitle.test.jsx
@@ -22,13 +22,17 @@ beforeEach(() => {
     vi.spyOn(fetchServerApi, "fetchServerApi").mockResolvedValue({ ok: true })
 })
 
-function ReportTitleWrapper({ issueTrackerType, tags }) {
+const reportDates = [new Date()]
+
+function ReportTitleWrapper({ issueTrackerType, permissions, tags }) {
     const settings = useSettings()
     return (
         <DataModelContext value={{ sources: { jira: { name: "Jira", issue_tracker: true } } }}>
-            <PermissionsContext value={[EDIT_REPORT_PERMISSION]}>
+            <PermissionsContext value={permissions}>
                 <SnackbarAlerts messages={[]} showMessage={vi.fn()}>
                     <ReportTitle
+                        dates={reportDates}
+                        measurements={[]}
                         report={{
                             issue_tracker: { type: issueTrackerType },
                             report_uuid: "report_uuid",
@@ -44,14 +48,22 @@ function ReportTitleWrapper({ issueTrackerType, tags }) {
     )
 }
 
-function renderReportTitle({ tags = ["foo"], issueTrackerType = null } = {}) {
-    return render(<ReportTitleWrapper issueTrackerType={issueTrackerType} tags={tags} />)
+function renderReportTitle({ tags = ["foo"], issueTrackerType = null, permissions = [EDIT_REPORT_PERMISSION] } = {}) {
+    return render(<ReportTitleWrapper issueTrackerType={issueTrackerType} permissions={permissions} tags={tags} />)
 }
 
 it("shows the export report button", async () => {
     history.push("?expanded=report_uuid:0")
     const { container } = renderReportTitle()
-    expect(screen.getByText(/Export report/)).toBeInTheDocument()
+    expect(screen.getByText(/Export as JSON/)).toBeInTheDocument()
+    await expectNoAccessibilityViolations(container)
+})
+
+it("shows the export as CSV button to all users", async () => {
+    history.push("?expanded=report_uuid:0")
+    const { container } = renderReportTitle({ permissions: [] })
+    expect(screen.getByText(/Export as CSV/)).toBeInTheDocument()
+    expect(screen.queryByText(/Export as JSON/)).not.toBeInTheDocument()
     await expectNoAccessibilityViolations(container)
 })
 

--- a/components/frontend/src/report/ReportsOverview.jsx
+++ b/components/frontend/src/report/ReportsOverview.jsx
@@ -23,6 +23,7 @@ import { ReportUploadButton } from "../widgets/buttons/ReportUploadButton"
 import { CommentSegment } from "../widgets/CommentSegment"
 import { reportOptions } from "../widgets/menu_options"
 import { WarningMessage } from "../widgets/WarningMessage"
+import { reverseSortMeasurements } from "./report_utils"
 import { ReportsOverviewDashboard } from "./ReportsOverviewDashboard"
 import { ReportsOverviewTitle } from "./ReportsOverviewTitle"
 
@@ -67,8 +68,6 @@ export function ReportsOverview({
     if (reports.length === 0 && reportDate !== null) {
         return <WarningMessage title="No reports found">{`Sorry, no reports existed at ${reportDate}`}</WarningMessage>
     }
-    // Sort measurements in reverse order so that if there multiple measurements on a day, we find the most recent one:
-    const reversedMeasurements = measurements.slice().sort((m1, m2) => (m1.start < m2.start ? 1 : -1))
     return (
         <div id="dashboard">
             <PageHeader lastUpdate={lastUpdate} reportDate={reportDate} />
@@ -77,7 +76,7 @@ export function ReportsOverview({
             <ReportsOverviewDashboard
                 dates={dates}
                 layout={reportsOverview.layout ?? []}
-                measurements={reversedMeasurements}
+                measurements={reverseSortMeasurements(measurements)}
                 onClickTag={(tag) => {
                     // If there are hidden tags (hiddenTags.length > 0), show the hidden tags.
                     // Otherwise, hide all tags in all reports except the one clicked on.

--- a/components/frontend/src/report/report_csv.js
+++ b/components/frontend/src/report/report_csv.js
@@ -1,0 +1,219 @@
+import { STATUS_NAME } from "../metric/status"
+import { sortMetrics, subjectIsEmptyDueToFilters } from "../subject/Subject"
+import { determineColumnsToHide } from "../subject/subject_column"
+import { metricDelta, metricValueAndStatusOnDate } from "../subject/SubjectTableRow"
+import {
+    formatDays,
+    formatMetricValueWithScale,
+    getFormattedMetricTarget,
+    getFormattedMetricTimeLeft,
+    getFormattedMetricValue,
+    getMetricComment,
+    getMetricIssueIds,
+    getMetricName,
+    getMetricResponseOverrun,
+    getMetricScale,
+    getMetricStatus,
+    getMetricTags,
+    getMetricUnit,
+    getSourceName,
+    getSubjectName,
+    identifyingParameterValues,
+    visibleMetrics,
+} from "../utils"
+import { reverseSortMeasurements } from "./report_utils"
+
+// The metric columns that can appear in the CSV, in the same order as the report table (the trend sparkline column is
+// omitted because it has no textual representation). Date columns are inserted between "Metric" and "Status" for
+// multi-date views, mirroring the table.
+const COLUMNS = [
+    { key: "status", label: "Status", value: (metric) => STATUS_NAME[getMetricStatus(metric)] },
+    {
+        key: "measurement",
+        label: "Measurement",
+        value: (metric, _uuid, { dataModel }) => getFormattedMetricValue(metric, dataModel),
+    },
+    {
+        key: "target",
+        label: "Target",
+        // Mirror MeasurementTarget, but join the direction and value with a regular space instead of a non-breaking one
+        value: (metric, _uuid, { dataModel }) => getFormattedMetricTarget(metric, dataModel, " "),
+    },
+    { key: "unit", label: "Unit", value: (metric, _uuid, { dataModel }) => getMetricUnit(metric, dataModel) },
+    { key: "source", label: "Sources", value: sourcesValue },
+    {
+        key: "time_left",
+        label: "Time left",
+        value: (metric, _uuid, { report }) => getFormattedMetricTimeLeft(metric, report),
+    },
+    { key: "overrun", label: "Overrun", value: overrunValue },
+    { key: "comment", label: "Comment", value: (metric) => htmlToText(getMetricComment(metric)) },
+    { key: "issues", label: "Issues", value: (metric) => getMetricIssueIds(metric).join(", ") },
+    { key: "tags", label: "Tags", value: (metric) => getMetricTags(metric).join(", ") },
+]
+
+function metricName(metric, dataModel) {
+    // Mirror MetricName: the secondary name is shown on a second line below the metric name
+    const name = getMetricName(metric, dataModel)
+    return metric.secondary_name ? `${name}\n${metric.secondary_name}` : name
+}
+
+function sourcesValue(metric, _uuid, { dataModel }) {
+    // Mirror SourceStatus: show the source name, followed by its identifying parameter values (such as the date of a
+    // calendar source) on a second line, if any
+    return Object.values(metric.sources ?? {})
+        .map((source) => {
+            const name = getSourceName(source, dataModel)
+            const identifyingValues = identifyingParameterValues(source, dataModel.sources?.[source.type])
+            return identifyingValues.length > 0 ? `${name}\n${identifyingValues.join(", ")}` : name
+        })
+        .join(", ")
+}
+
+function overrunValue(metric, metricUuid, { dataModel, report, measurements }) {
+    // Mirror Overrun
+    const { totalOverrun } = getMetricResponseOverrun(metricUuid, metric, report, measurements, dataModel)
+    return totalOverrun === 0 ? "" : formatDays(totalOverrun)
+}
+
+function htmlToText(html) {
+    // Convert the HTML comment to plain text so it fits in a single CSV cell. Links are kept by rewriting them as
+    // "text (url)", or just the URL when the link text and the URL are equal, so the URL is not lost.
+    if (!html) {
+        return ""
+    }
+    const element = document.createElement("div")
+    element.innerHTML = html
+    element.querySelectorAll("a").forEach((anchor) => {
+        const url = anchor.getAttribute("href")
+        const text = anchor.textContent.trim()
+        let replacement = text
+        if (url) {
+            replacement = text && text !== url ? `${text} (${url})` : url
+        }
+        anchor.replaceWith(replacement)
+    })
+    return element.textContent.replaceAll(/\s+/g, " ").trim()
+}
+
+function dateColumns(dates, showDelta) {
+    // The date columns shown for a multi-date view, mirroring MeasurementHeaderCells: a delta (𝚫) column precedes each
+    // value column except the first
+    const columns = []
+    dates.forEach((date, index) => {
+        if (showDelta && index > 0) {
+            columns.push({ delta: true, label: "𝚫" })
+        }
+        columns.push({ delta: false, label: date.toLocaleDateString() })
+    })
+    return columns
+}
+
+function dateCellValues(metric, metricUuid, csvContext, dates, showDelta) {
+    // The measurement (and delta) values for a metric in a multi-date view, mirroring MeasurementCells
+    const { dataModel, reversedMeasurements, dateOrderAscending } = csvContext
+    const scale = getMetricScale(metric, dataModel)
+    const values = []
+    let previousValue = "?"
+    dates.forEach((date, index) => {
+        const [metricValue] = metricValueAndStatusOnDate(dataModel, metric, metricUuid, reversedMeasurements, date)
+        if (showDelta && index > 0) {
+            values.push(metricDelta(scale, metricValue, previousValue, dateOrderAscending))
+        }
+        values.push(formatMetricValueWithScale(metric, dataModel, metricValue))
+        previousValue = metricValue === "?" ? previousValue : metricValue
+    })
+    return values
+}
+
+function visibleSubjectSections(report, measurements, nrDates, settings, dataModel) {
+    // Return the subjects to export, in report order, with their filtered and sorted metrics and the columns hidden in
+    // that subject, mirroring Subject.jsx and SubjectTable.jsx
+    const sections = []
+    Object.values(report.subjects ?? {}).forEach((subject) => {
+        const metrics = visibleMetrics(subject.metrics, settings.metricsToHide.value, settings.hiddenTags.value)
+        if (subjectIsEmptyDueToFilters(false, metrics, subject.metrics, settings)) {
+            return
+        }
+        const metricEntries = Object.entries(metrics)
+        if (settings.sortColumn.value !== "") {
+            sortMetrics(
+                dataModel,
+                metricEntries,
+                settings.sortDirection.value,
+                settings.sortColumn.value,
+                report,
+                measurements,
+            )
+        }
+        const columnsToHide = determineColumnsToHide(dataModel, measurements, metricEntries, nrDates, report, settings)
+        sections.push({ subject, metricEntries, columnsToHide })
+    })
+    return sections
+}
+
+function columnVisible(key, sections) {
+    // A column is included if it is visible in at least one of the exported subjects (mirroring the per-subject
+    // "hide empty columns" behavior across the unified table)
+    return sections.some((section) => !section.columnsToHide.includes(key))
+}
+
+function neutralizeFormula(value) {
+    // Prevent CSV injection: a spreadsheet interprets a field starting with =, @, tab, or carriage return, or with + or
+    // - when it is not a number, as a formula. Prefix such fields with a single quote so they are treated as text.
+    const looksLikeFormula = /^[=@\t\r]/.test(value) || (/^[+-]/.test(value) && Number.isNaN(Number(value)))
+    return looksLikeFormula ? `'${value}` : value
+}
+
+function csvField(value, delimiter) {
+    // Escape a field according to RFC 4180: quote it if it contains the delimiter, a double quote, or a line break
+    const field = neutralizeFormula(value)
+    return field.includes(delimiter) || field.includes('"') || /[\r\n]/.test(field)
+        ? `"${field.replaceAll('"', '""')}"`
+        : field
+}
+
+export function listSeparator(locale) {
+    // Excel opens a double-clicked CSV using the regional list separator. That separator is a semicolon in locales that
+    // use a comma as decimal separator (such as Dutch and German) and a comma otherwise. Match it so the columns are
+    // separated correctly, without resorting to a "sep=" line (which would make Excel ignore the UTF-8 byte order mark
+    // and garble non-ASCII characters such as ≦ and ≧).
+    return new Intl.NumberFormat(locale).format(1.1).charAt(1) === "," ? ";" : ","
+}
+
+export function reportToCSV(report, measurements, dates, settings, dataModel, delimiter = ",") {
+    // Convert the report to a CSV string that mirrors the report table as currently displayed: the same subjects,
+    // metrics (filtered, sorted), columns (hidden/empty), and date(s)
+    const nrDates = dates.length
+    const sections = visibleSubjectSections(report, measurements, nrDates, settings, dataModel)
+    const showDates = nrDates > 1
+    const showDelta = showDates && columnVisible("delta", sections)
+    const dateCols = showDates ? dateColumns(dates, showDelta) : []
+    const metricColumns = COLUMNS.filter((column) => columnVisible(column.key, sections))
+    const csvContext = {
+        dataModel: dataModel,
+        report: report,
+        measurements: measurements,
+        reversedMeasurements: reverseSortMeasurements(measurements),
+        dateOrderAscending: settings.dateOrder.value === "ascending",
+    }
+    const header = [
+        "Subject",
+        "Metric",
+        ...dateCols.map((column) => column.label),
+        ...metricColumns.map((c) => c.label),
+    ]
+    const rows = [header]
+    sections.forEach((section) => {
+        const subjectName = getSubjectName(section.subject, dataModel)
+        section.metricEntries.forEach(([metricUuid, metric]) => {
+            const row = [subjectName, metricName(metric, dataModel)]
+            if (showDates) {
+                row.push(...dateCellValues(metric, metricUuid, csvContext, dates, showDelta))
+            }
+            metricColumns.forEach((column) => row.push(column.value(metric, metricUuid, csvContext)))
+            rows.push(row)
+        })
+    })
+    return rows.map((row) => row.map((field) => csvField(field, delimiter)).join(delimiter)).join("\r\n")
+}

--- a/components/frontend/src/report/report_csv.test.js
+++ b/components/frontend/src/report/report_csv.test.js
@@ -1,0 +1,383 @@
+import { listSeparator, reportToCSV } from "./report_csv"
+
+const dataModel = {
+    metrics: {
+        violations: {
+            name: "Violations",
+            default_scale: "count",
+            direction: "<",
+            unit: "violations",
+            unit_singular: "violation",
+            sources: ["sonarqube"],
+        },
+    },
+    sources: { sonarqube: { name: "SonarQube" } },
+}
+
+function makeReport() {
+    return {
+        report_uuid: "r1",
+        subjects: {
+            s1: {
+                name: "Subject 1",
+                type: "software",
+                metrics: {
+                    m1: {
+                        type: "violations",
+                        name: "M1",
+                        status: "target_not_met",
+                        target: "10",
+                        latest_measurement: { count: { value: "20", status: "target_not_met" } },
+                        sources: { src1: { type: "sonarqube", name: "Src" } },
+                        tags: ["security"],
+                        comment: "<b>bold</b> comment",
+                        issue_ids: ["ISSUE-1"],
+                    },
+                    m2: {
+                        type: "violations",
+                        name: "M2",
+                        status: "target_met",
+                        target: "0",
+                        latest_measurement: { count: { value: "0", status: "target_met" } },
+                        sources: {},
+                        tags: ["performance"],
+                        comment: "",
+                        issue_ids: [],
+                    },
+                },
+            },
+        },
+    }
+}
+
+function makeSettings(overrides = {}) {
+    const settings = {
+        metricsToHide: { value: "none", isDefault: () => true },
+        hiddenTags: { value: [], isDefault: () => true },
+        sortColumn: { value: "" },
+        sortDirection: { value: "ascending" },
+        hiddenColumns: { value: [] },
+        hideEmptyColumns: { value: false },
+        dateOrder: { value: "ascending" },
+    }
+    return { ...settings, ...overrides }
+}
+
+function rows(csv) {
+    return csv.split("\r\n")
+}
+
+it("exports a header and a row per visible metric", () => {
+    const csv = reportToCSV(makeReport(), [], [new Date()], makeSettings(), dataModel)
+    const lines = rows(csv)
+    expect(lines[0]).toBe("Subject,Metric,Status,Measurement,Target,Unit,Sources,Time left,Comment,Issues,Tags")
+    expect(lines[1]).toBe("Subject 1,M1,Target not met,20,≦ 10,violations,Src,,bold comment,ISSUE-1,security")
+    expect(lines[2]).toBe("Subject 1,M2,Target met,0,≦ 0,violations,,,,,performance")
+})
+
+it("omits the overrun column in single-date view and the trend column always", () => {
+    const csv = reportToCSV(makeReport(), [], [new Date()], makeSettings(), dataModel)
+    expect(rows(csv)[0]).not.toContain("Overrun")
+    expect(rows(csv)[0]).not.toContain("Trend")
+})
+
+it("honors explicitly hidden columns", () => {
+    const settings = makeSettings({ hiddenColumns: { value: ["comment", "tags"] } })
+    const csv = reportToCSV(makeReport(), [], [new Date()], settings, dataModel)
+    expect(rows(csv)[0]).toBe("Subject,Metric,Status,Measurement,Target,Unit,Sources,Time left,Issues")
+})
+
+it("hides empty columns when requested", () => {
+    const report = makeReport()
+    // No metric has tags, so the tags column should disappear when hiding empty columns
+    report.subjects.s1.metrics.m1.tags = []
+    report.subjects.s1.metrics.m2.tags = []
+    const settings = makeSettings({ hideEmptyColumns: { value: true } })
+    const csv = reportToCSV(report, [], [new Date()], settings, dataModel)
+    expect(rows(csv)[0]).not.toContain("Tags")
+})
+
+it("hides metrics filtered out by tag", () => {
+    const settings = makeSettings({ hiddenTags: { value: ["performance"], isDefault: () => false } })
+    const csv = reportToCSV(makeReport(), [], [new Date()], settings, dataModel)
+    const lines = rows(csv)
+    expect(lines).toHaveLength(2) // header + M1 only
+    expect(lines[1]).toContain("M1")
+})
+
+it("sorts metrics like the table", () => {
+    const settings = makeSettings({ sortColumn: { value: "name" }, sortDirection: { value: "descending" } })
+    const csv = reportToCSV(makeReport(), [], [new Date()], settings, dataModel)
+    const lines = rows(csv)
+    expect(lines[1]).toContain("M2")
+    expect(lines[2]).toContain("M1")
+})
+
+it("produces value and delta columns for a multi-date view", () => {
+    const dates = [new Date("2024-01-01T12:00:00Z"), new Date("2024-01-08T12:00:00Z")]
+    const measurements = [
+        {
+            metric_uuid: "m1",
+            start: "2024-01-01T00:00:00+00:00",
+            end: "2024-01-01T23:59:59+00:00",
+            count: { value: "20", status: "target_not_met" },
+        },
+        {
+            metric_uuid: "m1",
+            start: "2024-01-08T00:00:00+00:00",
+            end: "2024-01-08T23:59:59+00:00",
+            count: { value: "15", status: "near_target_met" },
+        },
+    ]
+    const csv = reportToCSV(makeReport(), measurements, dates, makeSettings(), dataModel)
+    const lines = rows(csv)
+    const expectedHeader = [
+        "Subject",
+        "Metric",
+        dates[0].toLocaleDateString(),
+        "𝚫",
+        dates[1].toLocaleDateString(),
+        "Unit",
+        "Sources",
+        "Time left",
+        "Overrun",
+        "Comment",
+        "Issues",
+        "Tags",
+    ].join(",")
+    expect(lines[0]).toBe(expectedHeader)
+    // M1 has a measurement on both dates: value 20, delta -5, value 15
+    expect(lines[1]).toContain("20,-5,15")
+    // M2 has no measurements on these dates: ?, no delta, ?
+    expect(lines[2]).toContain("?,,?")
+})
+
+it("escapes fields containing commas, quotes, and newlines", () => {
+    const report = makeReport()
+    report.subjects.s1.metrics.m1.comment = 'a, "b"\nc'
+    const csv = reportToCSV(report, [], [new Date()], makeSettings(), dataModel)
+    expect(csv).toContain('"a, ""b"" c"') // newline collapsed to space by htmlToText, comma/quotes escaped
+})
+
+it("neutralizes fields that a spreadsheet would interpret as a formula", () => {
+    const report = makeReport()
+    report.subjects.s1.metrics.m1.comment = "=1+2"
+    report.subjects.s1.metrics.m2.comment = "-cmd" // starts with - but is not a number
+    const csv = reportToCSV(report, [], [new Date()], makeSettings(), dataModel)
+    expect(rows(csv)[1].split(",").at(-3)).toBe("'=1+2")
+    expect(rows(csv)[2].split(",").at(-3)).toBe("'-cmd")
+})
+
+it("does not neutralize negative numbers", () => {
+    // The delta value -5 in a multi-date view must remain a number, not be quoted as text
+    const report = makeReport()
+    report.subjects.s1.metrics = {
+        m1: {
+            type: "violations",
+            name: "M1",
+            status: "target_not_met",
+            target: "10",
+            latest_measurement: { count: { value: "20", status: "target_not_met" } },
+            sources: {},
+        },
+    }
+    const dates = [new Date("2024-01-01T12:00:00Z"), new Date("2024-01-08T12:00:00Z")]
+    const measurements = [
+        {
+            metric_uuid: "m1",
+            start: "2024-01-01T00:00:00+00:00",
+            end: "2024-01-01T23:59:59+00:00",
+            count: { value: "20", status: "target_not_met" },
+        },
+        {
+            metric_uuid: "m1",
+            start: "2024-01-08T00:00:00+00:00",
+            end: "2024-01-08T23:59:59+00:00",
+            count: { value: "15", status: "near_target_met" },
+        },
+    ]
+    const csv = reportToCSV(report, measurements, dates, makeSettings(), dataModel)
+    expect(rows(csv)[1]).toContain("20,-5,15")
+})
+
+it("uses the given delimiter and only quotes fields that contain it", () => {
+    const report = makeReport()
+    report.subjects.s1.metrics.m1.comment = "a, b" // contains a comma but not the semicolon delimiter
+    report.subjects.s1.metrics.m2.comment = "x; y" // contains the semicolon delimiter
+    const csv = reportToCSV(report, [], [new Date()], makeSettings(), dataModel, ";")
+    expect(csv.split("\r\n")[0]).toContain("Subject;Metric;Status")
+    expect(csv).toContain("a, b") // not quoted, the comma is not the delimiter
+    expect(csv).toContain('"x; y"') // quoted, contains the delimiter
+})
+
+it("determines the list separator from the locale", () => {
+    expect(listSeparator("en-US")).toBe(",")
+    expect(listSeparator("en-GB")).toBe(",")
+    expect(listSeparator("nl-NL")).toBe(";")
+    expect(listSeparator("de-DE")).toBe(";")
+})
+
+it("strips HTML from comments but keeps link text and URL", () => {
+    const report = makeReport()
+    report.subjects.s1.metrics.m1.comment = "<a href='http://x'>link</a> and <em>emphasis</em>"
+    const csv = reportToCSV(report, [], [new Date()], makeSettings(), dataModel)
+    expect(rows(csv)[1]).toContain("link (http://x) and emphasis")
+})
+
+it("outputs only the URL when a link's text equals its URL", () => {
+    const report = makeReport()
+    report.subjects.s1.metrics.m1.comment = '<a href="http://x">http://x</a>'
+    const csv = reportToCSV(report, [], [new Date()], makeSettings(), dataModel)
+    const comment = rows(csv)[1].split(",").at(-3) // comment is the third-to-last column (before issues and tags)
+    expect(comment).toBe("http://x")
+})
+
+it("keeps the text of a link without an href", () => {
+    const report = makeReport()
+    report.subjects.s1.metrics.m1.comment = "<a>just text</a>"
+    const csv = reportToCSV(report, [], [new Date()], makeSettings(), dataModel)
+    expect(rows(csv)[1]).toContain("just text")
+})
+
+it("outputs the URL of a link without link text", () => {
+    const report = makeReport()
+    report.subjects.s1.metrics.m1.comment = '<a href="http://x"></a>'
+    const csv = reportToCSV(report, [], [new Date()], makeSettings(), dataModel)
+    const comment = rows(csv)[1].split(",").at(-3)
+    expect(comment).toBe("http://x")
+})
+
+it("includes the secondary name on a second line in the metric cell", () => {
+    const report = makeReport()
+    report.subjects.s1.metrics.m1.secondary_name = "secondary"
+    const csv = reportToCSV(report, [], [new Date()], makeSettings(), dataModel)
+    expect(csv).toContain('"M1\nsecondary"')
+})
+
+it("formats percentage measurements with a percent sign", () => {
+    const report = makeReport()
+    const metric = report.subjects.s1.metrics.m1
+    metric.scale = "percentage"
+    metric.latest_measurement = { percentage: { value: "42", status: "target_not_met" } }
+    const csv = reportToCSV(report, [], [new Date()], makeSettings(), dataModel)
+    expect(rows(csv)[1]).toContain("42%")
+})
+
+it("leaves the target empty when the metric does not evaluate targets", () => {
+    const report = makeReport()
+    report.subjects.s1.metrics.m1.evaluate_targets = false
+    const csv = reportToCSV(report, [], [new Date()], makeSettings(), dataModel)
+    // The target column is the fifth field; it should be empty for M1
+    expect(rows(csv)[1].split(",")[4]).toBe("")
+})
+
+it("shows the time left for a metric with technical debt", () => {
+    const report = makeReport()
+    const metric = report.subjects.s1.metrics.m1
+    metric.status = "debt_target_met"
+    metric.debt_end_date = "3000-01-01"
+    const csv = reportToCSV(report, [], [new Date()], makeSettings(), dataModel)
+    expect(rows(csv)[1]).toMatch(/\d+ days/)
+})
+
+it("includes the identifying parameter values of a source on a second line", () => {
+    const dataModelWithIdentifyingParameter = {
+        ...dataModel,
+        sources: { calendar: { name: "Calendar", identifying_parameters: ["branch"], parameters: { branch: {} } } },
+    }
+    const report = makeReport()
+    report.subjects.s1.metrics.m1.sources = { src1: { type: "calendar", parameters: { branch: "main" } } }
+    const csv = reportToCSV(report, [], [new Date()], makeSettings(), dataModelWithIdentifyingParameter)
+    expect(csv).toContain('"Calendar\nmain"')
+})
+
+it("handles metrics without a measurement or sources", () => {
+    const report = makeReport()
+    report.subjects.s1.metrics.m1 = { type: "violations", name: "M1", status: "unknown", target: "10" }
+    const csv = reportToCSV(report, [], [new Date()], makeSettings(), dataModel)
+    const fields = rows(csv)[1].split(",")
+    expect(fields[3]).toBe("?") // measurement
+    expect(fields[6]).toBe("") // sources
+})
+
+it("shows the overrun for a metric that exceeded its desired reaction time", () => {
+    const report = {
+        report_uuid: "r1",
+        subjects: {
+            s1: {
+                name: "Subject 1",
+                metrics: {
+                    m1: {
+                        type: "violations",
+                        name: "M1",
+                        status: "target_not_met",
+                        target: "10",
+                        latest_measurement: { count: { value: "20", status: "target_not_met" } },
+                        sources: {},
+                    },
+                },
+            },
+        },
+    }
+    const dates = [new Date("2024-01-01T12:00:00Z"), new Date("2024-06-01T12:00:00Z")]
+    const measurements = [
+        {
+            metric_uuid: "m1",
+            start: "2020-01-01T00:00:00+00:00",
+            end: "2024-12-31T23:59:59+00:00",
+            count: { value: "20", status: "target_not_met" },
+        },
+    ]
+    const csv = reportToCSV(report, measurements, dates, makeSettings(), dataModel)
+    expect(rows(csv)[1]).toMatch(/\d+ days/) // the overrun column
+})
+
+it("sorts measurements in reverse so the most recent measurement of a day is used", () => {
+    const report = makeReport()
+    report.subjects.s1.metrics = {
+        m1: {
+            type: "violations",
+            name: "M1",
+            status: "target_not_met",
+            target: "10",
+            latest_measurement: { count: { value: "20", status: "target_not_met" } },
+            sources: {},
+        },
+    }
+    const dates = [new Date("2024-01-01T12:00:00Z"), new Date("2024-01-08T12:00:00Z")]
+    // Multiple, unordered measurements (two on the first day) exercise both branches of the reverse sort
+    const measurements = [
+        {
+            metric_uuid: "m1",
+            start: "2024-01-01T08:00:00+00:00",
+            end: "2024-01-01T09:00:00+00:00",
+            count: { value: "10", status: "target_not_met" },
+        },
+        {
+            metric_uuid: "m1",
+            start: "2024-01-08T00:00:00+00:00",
+            end: "2024-01-08T23:59:59+00:00",
+            count: { value: "15", status: "near_target_met" },
+        },
+        {
+            metric_uuid: "m1",
+            start: "2024-01-01T20:00:00+00:00",
+            end: "2024-01-01T23:59:59+00:00",
+            count: { value: "12", status: "target_not_met" },
+        },
+    ]
+    const csv = reportToCSV(report, measurements, dates, makeSettings(), dataModel)
+    // The most recent measurement on 2024-01-01 (value 12) is used, not the earlier one (value 10)
+    expect(rows(csv)[1]).toContain("12,")
+})
+
+it("returns only a header for a report without subjects", () => {
+    const csv = reportToCSV({ report_uuid: "r1" }, [], [new Date()], makeSettings(), dataModel)
+    expect(csv).toBe("Subject,Metric")
+})
+
+it("returns only a header when all metrics are hidden", () => {
+    const settings = makeSettings({ metricsToHide: { value: "all", isDefault: () => false } })
+    const csv = reportToCSV(makeReport(), [], [new Date()], settings, dataModel)
+    expect(rows(csv)).toHaveLength(1)
+})

--- a/components/frontend/src/report/report_utils.jsx
+++ b/components/frontend/src/report/report_utils.jsx
@@ -23,6 +23,15 @@ import {
     visibleMetrics,
 } from "../utils"
 
+export function reverseSortMeasurements(measurements) {
+    // Sort measurements in reverse order so that if there are multiple measurements on a day, measurementOnDate finds
+    // the most recent one
+    return measurements.slice().sort((m1, m2) => (m1.start < m2.start ? 1 : -1))
+}
+reverseSortMeasurements.propTypes = {
+    measurements: measurementsPropType,
+}
+
 export function measurementOnDate(date, measurements, metricUuid) {
     const isoDateString = date.toISOString().split("T")[0]
     return measurements?.find((m) => {

--- a/components/frontend/src/source/SourceEntityDetails.jsx
+++ b/components/frontend/src/source/SourceEntityDetails.jsx
@@ -9,7 +9,7 @@ import { setSourceEntityAttribute } from "../api/source"
 import { accessGranted, EDIT_ENTITY_PERMISSION, PermissionsContext } from "../context/Permissions"
 import { TextField } from "../fields/TextField"
 import { entityPropType, entityStatusPropType, reportPropType } from "../sharedPropTypes"
-import { capitalize, getDesiredResponseTime } from "../utils"
+import { capitalize, formatDays, getDesiredResponseTime } from "../utils"
 import { Header } from "../widgets/Header"
 import { SOURCE_ENTITY_STATUS_ACTION, SOURCE_ENTITY_STATUS_NAME } from "./source_entity_status"
 
@@ -28,7 +28,7 @@ entityStatusOption.propTypes = {
 
 function responseTimeClause(report, status, prefix = "for") {
     const responseTime = getDesiredResponseTime(report, status)
-    return responseTime === null ? "" : ` ${prefix} ${responseTime} days`
+    return responseTime === null ? "" : ` ${prefix} ${formatDays(responseTime)}`
 }
 responseTimeClause.propTypes = {
     status: entityStatusPropType,

--- a/components/frontend/src/subject/Subject.jsx
+++ b/components/frontend/src/subject/Subject.jsx
@@ -32,7 +32,7 @@ import { CommentSegment } from "../widgets/CommentSegment"
 import { SubjectTable } from "./SubjectTable"
 import { SubjectTitle } from "./SubjectTitle"
 
-function sortMetrics(dataModel, metrics, sortDirection, sortColumn, report, measurements) {
+export function sortMetrics(dataModel, metrics, sortDirection, sortColumn, report, measurements) {
     const statusOrder = {
         unknown: "0",
         target_not_met: "1",
@@ -106,7 +106,7 @@ function sortMetrics(dataModel, metrics, sortDirection, sortColumn, report, meas
     }
 }
 
-function subjectIsEmptyDueToFilters(atReportsOverview, filteredMetrics, metrics, settings) {
+export function subjectIsEmptyDueToFilters(atReportsOverview, filteredMetrics, metrics, settings) {
     // Hide the subject if it has no metrics after filtering and at least one of the following conditions holds:
     // - the user is at the reports overview page
     // - the user is hiding all metrics or metrics that don't require action

--- a/components/frontend/src/subject/SubjectTable.jsx
+++ b/components/frontend/src/subject/SubjectTable.jsx
@@ -5,6 +5,7 @@ import { array, func, object, string } from "prop-types"
 import { useContext } from "react"
 
 import { DataModelContext } from "../context/DataModel"
+import { reverseSortMeasurements } from "../report/report_utils"
 import {
     availabilityMessagePropType,
     datesPropType,
@@ -34,8 +35,6 @@ export function SubjectTable({
     subjectUuid,
 }) {
     const dataModel = useContext(DataModelContext)
-    // Sort measurements in reverse order so that if there multiple measurements on a day, we find the most recent one:
-    const reversedMeasurements = measurements.slice().sort((m1, m2) => (m1.start < m2.start ? 1 : -1))
     const columnsToHide = determineColumnsToHide(dataModel, measurements, metricEntries, dates.length, report, settings)
     return (
         <TableContainer sx={{ overflowX: "visible" }}>
@@ -57,7 +56,7 @@ export function SubjectTable({
                     report={report}
                     reportDate={reportDate}
                     reports={reports}
-                    reversedMeasurements={reversedMeasurements}
+                    reversedMeasurements={reverseSortMeasurements(measurements)}
                     settings={settings}
                     subjectUuid={subjectUuid}
                 />

--- a/components/frontend/src/subject/SubjectTableRow.jsx
+++ b/components/frontend/src/subject/SubjectTableRow.jsx
@@ -38,9 +38,9 @@ import {
     stringsPropType,
 } from "../sharedPropTypes"
 import {
-    formatMetricScale,
     formatMetricScaleAndUnit,
     formatMetricValue,
+    formatMetricValueWithScale,
     getMetricDirection,
     getMetricName,
     getMetricScale,
@@ -127,14 +127,30 @@ deltaLabel.propTypes = {
     previousValue: string,
 }
 
-function DeltaCell({ dateOrderAscending, index, metric, metricValue, previousValue }) {
+export function metricDelta(scale, metricValue, previousValue, dateOrderAscending) {
+    // Return the delta label between the previous and current value (e.g. "+5"), or "" when there is no meaningful
+    // delta (a value is unknown, or the values are equal)
+    if (previousValue === "?" || metricValue === "?" || previousValue === metricValue) {
+        return ""
+    }
+    const increased = didValueIncrease(dateOrderAscending, metricValue, previousValue, scale)
+    return deltaLabel(increased, scale, metricValue, previousValue)
+}
+metricDelta.propTypes = {
+    scale: scalePropType,
+    metricValue: string,
+    previousValue: string,
+    dateOrderAscending: bool,
+}
+
+function DeltaCell({ dateOrderAscending, metric, metricValue, previousValue }) {
     const dataModel = useContext(DataModelContext)
+    const scale = getMetricScale(metric, dataModel)
+    // Note that the delta cell only gets content if the previous and current values are both available and unequal
+    const delta = metricDelta(scale, metricValue, previousValue, dateOrderAscending)
     let label = null
-    if (index > 0 && previousValue !== "?" && metricValue !== "?" && previousValue !== metricValue) {
-        // Note that the delta cell only gets content if the previous and current values are both available and unequal
-        const scale = getMetricScale(metric, dataModel)
+    if (delta) {
         const increased = didValueIncrease(dateOrderAscending, metricValue, previousValue, scale)
-        const delta = deltaLabel(increased, scale, metricValue, previousValue)
         const oldValue = dateOrderAscending ? previousValue : metricValue
         const newValue = dateOrderAscending ? metricValue : previousValue
         const direction = getMetricDirection(metric, dataModel)
@@ -152,12 +168,11 @@ function DeltaCell({ dateOrderAscending, index, metric, metricValue, previousVal
 DeltaCell.propTypes = {
     dateOrderAscending: bool,
     metric: metricPropType,
-    index: number,
     metricValue: string,
     previousValue: string,
 }
 
-function metricValueAndStatusOnDate(dataModel, metric, metricUuid, measurements, date) {
+export function metricValueAndStatusOnDate(dataModel, metric, metricUuid, measurements, date) {
     const measurement = measurementOnDate(date, measurements, metricUuid)
     const scale = getMetricScale(metric, dataModel)
     return [measurement?.[scale]?.value ?? "?", measurement?.[scale]?.status ?? "unknown"]
@@ -174,7 +189,6 @@ function MeasurementCells({ dates, metric, metricUuid, measurements, settings })
     const dataModel = useContext(DataModelContext)
     const showDeltaColumns = settings.hiddenColumns.excludes("delta")
     const dateOrderAscending = settings.dateOrder.value === "ascending"
-    const scale = getMetricScale(metric, dataModel)
     const cells = []
     let previousValue = "?"
     dates.forEach((date, index) => {
@@ -183,7 +197,6 @@ function MeasurementCells({ dates, metric, metricUuid, measurements, settings })
             cells.push(
                 <DeltaCell
                     dateOrderAscending={dateOrderAscending}
-                    index={index}
                     key={`${date}-delta`}
                     metric={metric}
                     metricValue={metricValue}
@@ -204,8 +217,7 @@ function MeasurementCells({ dates, metric, metricUuid, measurements, settings })
                     },
                 }}
             >
-                {formatMetricValue(scale, metricValue)}
-                {formatMetricScale(metric, dataModel)}
+                {formatMetricValueWithScale(metric, dataModel, metricValue)}
             </TableCell>,
         )
         previousValue = metricValue === "?" ? previousValue : metricValue

--- a/components/frontend/src/utils.jsx
+++ b/components/frontend/src/utils.jsx
@@ -211,7 +211,7 @@ export function getMetricResponseDeadline(metric, report) {
         const desiredResponseTime = getDesiredResponseTime(report, status)
         if (Number.isInteger(desiredResponseTime)) {
             deadline = new Date(metric.status_start)
-            deadline.setDate(deadline.getDate() + getDesiredResponseTime(report, status))
+            deadline.setDate(deadline.getDate() + desiredResponseTime)
         }
     }
     return deadline
@@ -221,6 +221,17 @@ export function getMetricResponseTimeLeft(metric, report) {
     const deadline = getMetricResponseDeadline(metric, report)
     const now = new Date()
     return deadline === null ? null : deadline.getTime() - now.getTime()
+}
+
+export function formatDays(numberOfDays) {
+    // Format a number of days as e.g. "1 day" or "5 days"
+    return `${numberOfDays} ${pluralize("day", numberOfDays)}`
+}
+
+export function getFormattedMetricTimeLeft(metric, report) {
+    // Return the number of days left to address the metric, formatted as e.g. "5 days", or "" if there is no deadline
+    const timeLeft = getMetricResponseTimeLeft(metric, report)
+    return timeLeft === null ? "" : formatDays(days(Math.max(0, timeLeft)))
 }
 
 function getMetricResponseOverruns(metricUuid, metric, measurements, dataModel) {
@@ -279,9 +290,31 @@ export function getDesiredResponseTime(report, status) {
     return desiredResponseTime === null ? null : Number.parseInt(desiredResponseTime)
 }
 
-export function getMetricValue(metric, dataModel) {
+export function getMetricValue(metric, dataModel, defaultValue = "") {
     const scale = getMetricScale(metric, dataModel)
-    return metric?.latest_measurement?.[scale]?.value ?? ""
+    // Return the default value if the metric has no value, including an empty string value
+    return metric?.latest_measurement?.[scale]?.value || defaultValue
+}
+
+export function getFormattedMetricValue(metric, dataModel, defaultValue = "?") {
+    // Return the metric's latest measurement value, formatted with its scale (e.g. "42", "50%", or "?")
+    return formatMetricValueWithScale(metric, dataModel, getMetricValue(metric, dataModel, defaultValue))
+}
+
+export function formatMetricValueWithScale(metric, dataModel, value) {
+    // Format a value with the metric's scale, e.g. "42" (count) or "42%" (percentage)
+    return `${formatMetricValue(getMetricScale(metric, dataModel), value)}${formatMetricScale(metric, dataModel)}`
+}
+
+export function getFormattedMetricTarget(metric, dataModel, separator = "\u00a0") {
+    // Return the metric's target, formatted with its direction and scale (e.g. "≦ 10" or "≧ 50%"), or "" if the
+    // metric does not evaluate targets. The separator
+    // defaults to "\u00a0" (a non-breaking space, i.e. &nbsp;) so the direction and value don't wrap to separate lines.
+    if (metric?.evaluate_targets === false) {
+        return ""
+    }
+    const direction = formatMetricDirection(metric, dataModel)
+    return `${direction}${separator}${formatMetricValueWithScale(metric, dataModel, getMetricTarget(metric))}`
 }
 
 export function getMetricComment(metric) {

--- a/components/frontend/src/utils.test.jsx
+++ b/components/frontend/src/utils.test.jsx
@@ -9,12 +9,18 @@ import {
     createDragGhost,
     DOCUMENTATION_URL,
     endOfDayFromISODateString,
+    formatDays,
+    formatMetricValueWithScale,
     formatParameterValue,
+    getFormattedMetricTarget,
+    getFormattedMetricTimeLeft,
+    getFormattedMetricValue,
     getMetricResponseDeadline,
     getMetricResponseOverrun,
     getMetricTags,
     getMetricTarget,
     getMetricUnit,
+    getMetricValue,
     getReportTags,
     getSourceName,
     getSubjectName,
@@ -149,6 +155,87 @@ it("gets the metric target", () => {
 
 it("gets the metric target, even if the target is missing", () => {
     expect(getMetricTarget({})).toStrictEqual("0")
+})
+
+it("gets the metric value", () => {
+    expect(
+        getMetricValue({ type: "metric_type", latest_measurement: { count: { value: "42" } } }, dataModel),
+    ).toStrictEqual("42")
+})
+
+it("returns an empty string by default if the metric has no value", () => {
+    expect(getMetricValue({ type: "metric_type" }, dataModel)).toStrictEqual("")
+})
+
+it("returns the default value if the metric has no measurement", () => {
+    expect(getMetricValue({ type: "metric_type" }, dataModel, "?")).toStrictEqual("?")
+})
+
+it("returns the default value if the metric value is empty", () => {
+    expect(
+        getMetricValue({ type: "metric_type", latest_measurement: { count: { value: "" } } }, dataModel, "?"),
+    ).toStrictEqual("?")
+})
+
+it("gets the formatted metric value", () => {
+    expect(
+        getFormattedMetricValue({ type: "metric_type", latest_measurement: { count: { value: "42" } } }, dataModel),
+    ).toStrictEqual("42")
+})
+
+it("gets the formatted metric value of a percentage metric", () => {
+    expect(
+        getFormattedMetricValue(
+            { scale: "percentage", latest_measurement: { percentage: { value: "42" } } },
+            dataModel,
+        ),
+    ).toStrictEqual("42%")
+})
+
+it("gets a question mark as formatted metric value if the metric has no value", () => {
+    expect(getFormattedMetricValue({ type: "metric_type" }, dataModel)).toStrictEqual("?")
+})
+
+it("gets the formatted metric target, joined with a non-breaking space by default", () => {
+    expect(getFormattedMetricTarget({ type: "metric_type", direction: "<", target: "10" }, dataModel)).toStrictEqual(
+        "≦\u00a010",
+    )
+})
+
+it("gets the formatted metric target, joined with the given separator", () => {
+    expect(
+        getFormattedMetricTarget({ type: "metric_type", direction: "<", target: "10" }, dataModel, " "),
+    ).toStrictEqual("≦ 10")
+})
+
+it("gets an empty formatted metric target if the metric does not evaluate targets", () => {
+    expect(
+        getFormattedMetricTarget(
+            { type: "metric_type", direction: "<", target: "10", evaluate_targets: false },
+            dataModel,
+        ),
+    ).toStrictEqual("")
+})
+
+it("formats a metric value with its scale", () => {
+    expect(formatMetricValueWithScale({ type: "metric_type" }, dataModel, "42")).toStrictEqual("42")
+    expect(formatMetricValueWithScale({ scale: "percentage" }, dataModel, "42")).toStrictEqual("42%")
+})
+
+it("formats a number of days, singular and plural", () => {
+    expect(formatDays(0)).toStrictEqual("0 days")
+    expect(formatDays(1)).toStrictEqual("1 day")
+    expect(formatDays(5)).toStrictEqual("5 days")
+})
+
+it("gets the formatted time left, clamped to zero for an overdue metric", () => {
+    expect(getFormattedMetricTimeLeft({ status: "target_not_met", status_start: "2000-01-01" }, {})).toStrictEqual(
+        "0 days",
+    )
+})
+
+it("gets an empty formatted time left if the metric has no deadline", () => {
+    expect(getFormattedMetricTimeLeft({}, {})).toStrictEqual("")
 })
 
 it("gets the source name", () => {

--- a/components/frontend/src/widgets/buttons/ExportReportButton.jsx
+++ b/components/frontend/src/widgets/buttons/ExportReportButton.jsx
@@ -46,7 +46,7 @@ export function ExportReportButton({ reportUuid }) {
                 startIcon={<DownloadIcon />}
                 variant="outlined"
             >
-                {"Export report"}
+                {"Export as JSON"}
             </Button>
         </Tooltip>
     )

--- a/components/frontend/src/widgets/buttons/ExportReportButton.test.jsx
+++ b/components/frontend/src/widgets/buttons/ExportReportButton.test.jsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event"
 import { vi } from "vitest"
 
 import * as fetchServerApi from "../../api/fetch_server_api"
-import { expectFetch, expectText } from "../../testUtils"
+import { expectFetch } from "../../testUtils"
 import { SnackbarAlerts } from "../SnackbarAlerts"
 import { ExportReportButton } from "./ExportReportButton"
 
@@ -24,15 +24,10 @@ function renderExportReportButton({ showMessage = vi.fn() } = {}) {
     )
 }
 
-it("has the correct label", () => {
-    renderExportReportButton()
-    expectText(/Export report/)
-})
-
 it("exports a report", async () => {
     const showMessage = vi.fn()
     renderExportReportButton({ showMessage: showMessage })
-    await userEvent.click(screen.getByText(/Export report/))
+    await userEvent.click(screen.getByText(/Export as JSON/))
     expectFetch("get", "report/report_uuid/json")
     expect(showMessage).not.toHaveBeenCalled()
 })
@@ -43,7 +38,7 @@ it("shows message when export fails", async () => {
         Promise.resolve({ ok: false, status: 500, statusText: "Internal Server Error" }),
     )
     renderExportReportButton({ showMessage: showMessage })
-    await userEvent.click(screen.getByText(/Export report/))
+    await userEvent.click(screen.getByText(/Export as JSON/))
     expectFetch("get", "report/report_uuid/json")
     expect(showMessage).toHaveBeenCalledWith({
         severity: "error",
@@ -56,7 +51,7 @@ it("shows message when fetch throws", async () => {
     const showMessage = vi.fn()
     vi.spyOn(fetchServerApi, "fetchServerApi").mockImplementation(() => Promise.reject(new Error("Network error")))
     renderExportReportButton({ showMessage: showMessage })
-    await userEvent.click(screen.getByText(/Export report/))
+    await userEvent.click(screen.getByText(/Export as JSON/))
     expect(showMessage).toHaveBeenCalledWith({
         severity: "error",
         title: "Could not export report",

--- a/components/frontend/src/widgets/buttons/ExportReportCsvButton.jsx
+++ b/components/frontend/src/widgets/buttons/ExportReportCsvButton.jsx
@@ -1,0 +1,44 @@
+import DownloadIcon from "@mui/icons-material/Download"
+import { Button, Tooltip } from "@mui/material"
+import { useContext, useRef } from "react"
+
+import { DataModelContext } from "../../context/DataModel"
+import { SnackbarContext } from "../../context/Snackbar"
+import { listSeparator, reportToCSV } from "../../report/report_csv"
+import { datesPropType, measurementsPropType, reportPropType, settingsPropType } from "../../sharedPropTypes"
+import { localTimestamp, triggerDownload } from "../download"
+
+function downloadCsv(report, measurements, dates, settings, dataModel, showMessage) {
+    try {
+        // Use the list separator of the user's locale as column delimiter, so Excel splits the columns correctly when
+        // the file is opened by double-clicking
+        const csv = reportToCSV(report, measurements, dates, settings, dataModel, listSeparator(navigator.language))
+        // Prefix with a UTF-8 byte order mark so spreadsheet applications read the file as UTF-8
+        const blob = new Blob([`\uFEFF${csv}`], { type: "text/csv;charset=utf-8" })
+        triggerDownload(blob, `Quality-time-report-${report.report_uuid}-${localTimestamp()}.csv`)
+    } catch (error) {
+        showMessage({ severity: "error", title: "Could not export report to CSV", description: `${error}` })
+    }
+}
+
+export function ExportReportCsvButton({ report, measurements, dates, settings }) {
+    const dataModel = useContext(DataModelContext)
+    const showMessageRef = useRef(useContext(SnackbarContext))
+    return (
+        <Tooltip title="Export this report to a CSV file, mirroring the report as currently displayed.">
+            <Button
+                onClick={() => downloadCsv(report, measurements, dates, settings, dataModel, showMessageRef.current)}
+                startIcon={<DownloadIcon />}
+                variant="outlined"
+            >
+                {"Export as CSV"}
+            </Button>
+        </Tooltip>
+    )
+}
+ExportReportCsvButton.propTypes = {
+    report: reportPropType,
+    measurements: measurementsPropType,
+    dates: datesPropType,
+    settings: settingsPropType,
+}

--- a/components/frontend/src/widgets/buttons/ExportReportCsvButton.test.jsx
+++ b/components/frontend/src/widgets/buttons/ExportReportCsvButton.test.jsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { vi } from "vitest"
+
+import { DataModelContext } from "../../context/DataModel"
+import * as reportCsv from "../../report/report_csv"
+import * as download from "../download"
+import { SnackbarAlerts } from "../SnackbarAlerts"
+import { ExportReportCsvButton } from "./ExportReportCsvButton"
+
+beforeEach(() => {
+    globalThis.URL.createObjectURL = vi.fn(() => "#dummy")
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+function renderButton({ showMessage = vi.fn() } = {}) {
+    render(
+        <DataModelContext value={{}}>
+            <SnackbarAlerts messages={[]} showMessage={showMessage}>
+                <ExportReportCsvButton report={{ report_uuid: "report_uuid" }} measurements={[]} dates={[new Date()]} />
+            </SnackbarAlerts>
+        </DataModelContext>,
+    )
+}
+
+it("downloads a CSV file", async () => {
+    const triggerDownload = vi.spyOn(download, "triggerDownload").mockImplementation(() => {})
+    vi.spyOn(reportCsv, "reportToCSV").mockReturnValue("Subject,Metric\r\nSubject 1,M1")
+    renderButton()
+    await userEvent.click(screen.getByText(/Export as CSV/))
+    expect(triggerDownload).toHaveBeenCalledTimes(1)
+    const [blob, filename] = triggerDownload.mock.calls[0]
+    expect(blob.type).toContain("text/csv")
+    expect(filename).toMatch(/^Quality-time-report-report_uuid-.*\.csv$/)
+    // The CSV is generated with the list separator of the user's locale (a comma in the test environment's en-US locale)
+    expect(reportCsv.reportToCSV).toHaveBeenCalledWith(expect.anything(), [], [expect.any(Date)], undefined, {}, ",")
+    // The file content equals the generated CSV (the leading UTF-8 BOM is stripped by Blob.text() when decoding)
+    expect(await blob.text()).toBe("Subject,Metric\r\nSubject 1,M1")
+})
+
+it("shows a message when CSV generation fails", async () => {
+    const showMessage = vi.fn()
+    vi.spyOn(reportCsv, "reportToCSV").mockImplementation(() => {
+        throw new Error("Boom")
+    })
+    renderButton({ showMessage: showMessage })
+    await userEvent.click(screen.getByText(/Export as CSV/))
+    expect(showMessage).toHaveBeenCalledWith({
+        severity: "error",
+        title: "Could not export report to CSV",
+        description: "Error: Boom",
+    })
+})

--- a/components/frontend/src/widgets/buttons/ReportUploadButton.test.jsx
+++ b/components/frontend/src/widgets/buttons/ReportUploadButton.test.jsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event"
 import { vi } from "vitest"
 
 import * as fetchServerApi from "../../api/fetch_server_api"
-import { expectFetch, expectNoFetch, expectText } from "../../testUtils"
+import { expectFetch, expectNoFetch } from "../../testUtils"
 import { SnackbarAlerts } from "../SnackbarAlerts"
 import { ReportUploadButton } from "./ReportUploadButton"
 
@@ -30,11 +30,6 @@ function renderReportUploadButton({ showMessage = vi.fn() } = {}) {
     )
     return [reload, screen.getByTestId("report-import-input")]
 }
-
-it("has the correct label", () => {
-    renderReportUploadButton()
-    expectText(/Import report/)
-})
 
 it("imports a report", async () => {
     const showMessage = vi.fn()

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -132,7 +132,7 @@ The parameters for exporting a report, listed above, can also be used when expor
 
 *Quality-time* provides functionality for importing and exporting reports in JSON format.
 This functionality can be used for backing up reports or for transferring reports from one *Quality-time* instance to another one.
-This functionality is available both via the user interface and via the API. Use the "Export report" button in the report header and the "Import report" button on the reports overview page to export and import reports via the user interface. The API provides one endpoint for importing and one for exporting the JSON reports.
+This functionality is available both via the user interface and via the API. Use the "Export as JSON" button in the report header and the "Import report" button on the reports overview page to export and import reports via the user interface. The API provides one endpoint for importing and one for exporting the JSON reports.
 
 A *Quality-time* report in JSON format contains the latest configuration of the report, with all its subjects, metrics and sources.
 It does not contain any actual measurements. The credentials of configured sources are encrypted on export to protect sensitive data.

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -10,6 +10,16 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the tools/release/src/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Added
+
+- Add an "Export as CSV" button to the report header to export the report to a CSV file, mirroring the report as currently displayed (sort order, visible columns, hidden tags, and date(s)). Closes [#13324](https://github.com/ICTU/quality-time/issues/13324).
+
+### Changed
+
+- Rename the "Export report" button in the report header to "Export as JSON", to distinguish it from the new "Export as CSV" button. Closes [#13324](https://github.com/ICTU/quality-time/issues/13324).
+
 ## v5.55.1 - 2026-06-04
 
 ### Fixed

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -94,6 +94,7 @@ Implemented features include:
 - Generic false-positive management.
 - Metric tags can be used to summarize metrics with the same tag across subjects, e.g. to summarize all security metrics.
 - Export of reports to PDF, both via the UI as well as via the API.
+- Export of reports to CSV via the UI.
 - Notifications of events, such as metrics turning red, to Microsoft Teams.
 - Side-by-side comparison of measurements at different points in time.
 - Integration with issue tracker (Jira only at the moment) to manage actions and technical debt.

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -487,13 +487,29 @@ See the [API-documentation](api.md#export-to-pdf) for exporting reports via the 
 
 *Quality-time* provides functionality for importing and exporting reports in JSON format. This functionality can be used to import template reports, to back up reports, or for transferring reports from one *Quality-time* instance to another one.
 
-To export a report, use the "Export report" button in the report header. The exported JSON file contains the report configuration but does not include measurements. Source credentials in the exported report are encrypted using the public key of the exporting *Quality-time* instance. This means that an exported report *including its credentials* can only be re-imported into the same instance. To transfer a report including its credentials to a different *Quality-time* instance, use the [API](api.md#export-and-import-reports-as-json) to encrypt the credentials with the public key of the destination instance. It is possible to import a report in a Quality-time instance whose public key was not used to encrypt the credentials, but in that case the credentials will not be imported.
+To export a report, use the "Export as JSON" button in the report header. The exported JSON file contains the report configuration but does not include measurements. Source credentials in the exported report are encrypted using the public key of the exporting *Quality-time* instance. This means that an exported report *including its credentials* can only be re-imported into the same instance. To transfer a report including its credentials to a different *Quality-time* instance, use the [API](api.md#export-and-import-reports-as-json) to encrypt the credentials with the public key of the destination instance. It is possible to import a report in a Quality-time instance whose public key was not used to encrypt the credentials, but in that case the credentials will not be imported.
 
 To import a report, use the "Import report" button on the reports overview page to select a report in JSON format and import it.
 
 The export and the import buttons are only available to logged-in users.
 
 Both the import and the export functionality are also available via the [API](api.md#export-and-import-reports-as-json).
+
+```{index} Export report
+```
+
+```{index} CSV
+```
+
+## Export reports as CSV
+
+*Quality-time* reports can be downloaded as a CSV (comma-separated values) file, for example to import the report into a spreadsheet.
+
+To export a report as CSV, navigate to the report and click the "Export as CSV" button in the report header.
+
+The exported CSV mirrors the report as currently displayed: it contains the same subjects and metrics, honors the current sort order, hidden tags, and hidden or empty columns, and contains a column for each visible date (the same contract as the [PDF export](#export-reports-as-pdf)). The trend sparkline column is not included because it has no textual representation.
+
+As the CSV contains no source credentials, the "Export as CSV" button is available to all users, also when not logged in.
 
 ```{index} Issue tracker
 ```


### PR DESCRIPTION
- Add an "Export as CSV" button to the report header, shown to all users, that exports the report as currently displayed (sort order, hidden/empty columns, hidden tags, and selected date(s))
- Generate the CSV client-side, mirroring the metric table; sources include their identifying parameter values and comments keep links as "text (url)"
- Use the locale's list separator and a UTF-8 BOM so the file opens correctly in Excel, and neutralize fields a spreadsheet would interpret as formulas
- Rename the "Export report" button to "Export as JSON" and order the report header buttons as CSV, JSON, Share report
- Extract reverseSortMeasurements into report_utils and reuse it across the report, reports overview, and subject table
- Document the CSV export and update the changelog

Closes #13324.