### PR TITLE
Fix GitLab failed jobs false positives

### DIFF
--- a/components/collector/src/source_collectors/gitlab/failed_jobs.py
+++ b/components/collector/src/source_collectors/gitlab/failed_jobs.py
@@ -2,8 +2,6 @@
 
 from typing import TYPE_CHECKING
 
-from collector_utilities.type import URL
-
 from .base import GitLabJobsBase
 
 if TYPE_CHECKING:
@@ -12,12 +10,6 @@ if TYPE_CHECKING:
 
 class GitLabFailedJobs(GitLabJobsBase):
     """Collector class to get failed job counts from GitLab."""
-
-    async def _api_url(self) -> URL:
-        """Extend to add the scope parameter of the jobs API."""
-        failure_types = list(self._parameter("failure_type"))
-        scopes = "&".join([f"scope[]={failure_type}" for failure_type in failure_types])
-        return URL(f"{await super()._api_url()}&{scopes}")
 
     def _include_entity(self, entity: Entity) -> bool:
         """Return whether the job has failed."""

--- a/components/collector/tests/source_collectors/gitlab/test_failed_jobs.py
+++ b/components/collector/tests/source_collectors/gitlab/test_failed_jobs.py
@@ -62,9 +62,6 @@ class GitLabFailedJobsTest(CommonGitLabJobsTestsMixin, GitLabJobsTestCase):
         self.assert_measurement(
             measurement,
             value="2",
-            api_url=(
-                "https://gitlab/api/v4/projects/namespace%2Fproject/jobs?per_page=100&"
-                "scope[]=canceled&scope[]=failed&scope[]=skipped"
-            ),
+            api_url="https://gitlab/api/v4/projects/namespace%2Fproject/jobs?per_page=100",
             landing_url=self.LANDING_URL,
         )

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -10,6 +10,12 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 <!-- The line "## <square-bracket>Unreleased</square-bracket>" is replaced by the tools/release/src/release.py script with the new release version and release date. -->
 
+## [Unreleased]
+
+### Fixed
+
+- When using GitLab as source for the 'failed jobs' metric, instead of asking GitLab for only failed jobs, fetch all jobs within the look-back period and then filter them for status so that jobs that first fail and then pass are not reported as failed. Fixes [#13478](https://github.com/ICTU/quality-time/issues/13478).
+
 ## v5.56.0 - 2026-06-11
 
 ### Added


### PR DESCRIPTION
When using GitLab as source for the 'failed jobs' metric, instead of asking GitLab for only failed jobs, fetch all jobs within the lookback period and then filter them for status so that jobs that first fail and then pass are not reported as failed.

Fixes #13478.