### PR TITLE
Save healthcheck files in /tmp

### DIFF
--- a/components/collector/Dockerfile
+++ b/components/collector/Dockerfile
@@ -16,11 +16,10 @@ RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv \
     --mount=type=bind,source=components/collector/pyproject.toml,target=/home/collector/pyproject.toml \
     uv sync --active --frozen --no-dev --no-install-project
 
-ENV HEALTH_CHECK_FILE=/home/collector/health_check.txt
-RUN adduser -S collector && adduser collector root
+ENV HEALTH_CHECK_FILE=/tmp/health_check.txt
+RUN adduser -S collector
 USER collector
 
-RUN touch "${HEALTH_CHECK_FILE}" && chmod g+w "${HEALTH_CHECK_FILE}" && chgrp root "${HEALTH_CHECK_FILE}"
 HEALTHCHECK CMD ["python", "-c", "from datetime import datetime as dt, timedelta, UTC; import os, sys; sys.exit(dt.now(tz=UTC) - dt.fromisoformat(open(os.environ['HEALTH_CHECK_FILE'], encoding='utf-8').read().strip()) > timedelta(seconds=600))"]
 
 COPY components/collector/src /home/collector

--- a/components/collector/src/base_collectors/config.py
+++ b/components/collector/src/base_collectors/config.py
@@ -1,9 +1,11 @@
 """Configuration."""
 
 import os
+import pathlib
+import tempfile
 
 LOG_LEVEL = os.getenv("COLLECTOR_LOG_LEVEL", "WARNING")
-HEALTH_CHECK_FILE = os.getenv("HEALTH_CHECK_FILE", "/home/collector/health_check.txt")
+HEALTH_CHECK_FILE = os.getenv("HEALTH_CHECK_FILE", str(pathlib.Path(tempfile.gettempdir()) / "health_check.txt"))
 SLEEP_DURATION = int(os.getenv("COLLECTOR_SLEEP_DURATION", "20"))
 MEASUREMENT_LIMIT = int(os.getenv("COLLECTOR_MEASUREMENT_LIMIT", "30"))
 MEASUREMENT_FREQUENCY = int(os.getenv("COLLECTOR_MEASUREMENT_FREQUENCY", str(15 * 60)))

--- a/components/collector/tests/base_collectors/test_collector.py
+++ b/components/collector/tests/base_collectors/test_collector.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import pathlib
+import tempfile
 import unittest
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock, _patch, call, mock_open, patch
@@ -319,5 +320,5 @@ class CollectorTest(unittest.IsolatedAsyncioTestCase):
         self.collector.record_health()
         logger.exception.assert_called_once_with(
             "Could not write health check time stamp to %s",
-            pathlib.Path("/home/collector/health_check.txt"),
+            pathlib.Path(tempfile.gettempdir()) / "health_check.txt",
         )

--- a/components/notifier/Dockerfile
+++ b/components/notifier/Dockerfile
@@ -16,11 +16,10 @@ RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv \
     --mount=type=bind,source=components/notifier/pyproject.toml,target=/home/notifier/pyproject.toml \
     uv sync --active --frozen --no-dev --no-install-project
 
-ENV HEALTH_CHECK_FILE=/home/notifier/health_check.txt
-RUN adduser -S notifier && adduser notifier root
+ENV HEALTH_CHECK_FILE=/tmp/health_check.txt
+RUN adduser -S notifier
 USER notifier
 
-RUN touch "${HEALTH_CHECK_FILE}" && chmod g+w "${HEALTH_CHECK_FILE}" && chgrp root "${HEALTH_CHECK_FILE}"
 HEALTHCHECK CMD ["python", "-c", "from datetime import datetime as dt, timedelta, UTC; import os, sys; sys.exit(dt.now(tz=UTC) - dt.fromisoformat(open(os.environ['HEALTH_CHECK_FILE'], encoding='utf-8').read().strip()) > timedelta(seconds=600))"]
 
 COPY components/notifier/src /home/notifier

--- a/components/notifier/src/notifier/notifier.py
+++ b/components/notifier/src/notifier/notifier.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import pathlib
+import tempfile
 from datetime import datetime
 from os import getenv
 from typing import TYPE_CHECKING, NoReturn
@@ -46,7 +47,7 @@ async def notify(database: Database, sleep_duration: int = 60) -> NoReturn:
 def record_health() -> None:
     """Record the current date and time in a file to allow for health checks."""
     logger = get_logger()
-    filepath = pathlib.Path(getenv("HEALTH_CHECK_FILE", "/home/notifier/health_check.txt"))
+    filepath = pathlib.Path(getenv("HEALTH_CHECK_FILE", pathlib.Path(tempfile.gettempdir()) / "health_check.txt"))
     try:
         with filepath.open("w", encoding="utf-8") as health_check:
             health_check.write(iso_timestamp())

--- a/components/notifier/tests/notifier/test_notifier.py
+++ b/components/notifier/tests/notifier/test_notifier.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import pathlib
+import tempfile
 import unittest
 from datetime import datetime, timedelta
 from unittest.mock import Mock, mock_open, patch
@@ -41,7 +42,7 @@ class HealthCheckTest(unittest.TestCase):
 
     def setUp(self):
         """Set variables required by testcases."""
-        self.filename = pathlib.Path("/home/notifier/health_check.txt")
+        self.filename = pathlib.Path(tempfile.gettempdir()) / "health_check.txt"
 
     @patch("pathlib.Path.open", new_callable=mock_open)
     @patch("notifier.notifier.iso_timestamp")

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ## [Unreleased]
 
+### Changed
+
+- Change the default location of the health check file that the collector and notifier write, from the home directory of the user running the component to the system temporary directory (`/tmp` in the containers). The `HEALTH_CHECK_FILE` environment variable can still be used to configure a different location.
+
 ### Fixed
 
 - When using GitLab as source for the 'failed jobs' metric, instead of asking GitLab for only failed jobs, fetch all jobs within the look-back period and then filter them for status so that jobs that first fail and then pass are not reported as failed. Fixes [#13478](https://github.com/ICTU/quality-time/issues/13478).

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -91,18 +91,6 @@ cd components/collector
 just start
 ```
 
-By default, the collector attempts to write a health check time stamp to `/home/collector/health_check.txt` every few seconds. If that fails, you'll see these messages in the log:
-
-```console
-Could not write health check time stamp to /home/collector/health_check.txt: [Errno 2] No such file or directory: '/home/collector/health_check.txt'
-```
-
-To prevent the error and the resulting log messages, set the `HEALTH_CHECK_FILE` environment variable to a location that can be written on your machine, for example:
-
-```console
-export HEALTH_CHECK_FILE=/tmp/health_check.txt
-```
-
 ##### Start the {index}`frontend <Frontend component>`
 
 Open another terminal and start the frontend:

--- a/docs/src/software.md
+++ b/docs/src/software.md
@@ -136,7 +136,7 @@ The collector uses the following environment variables:
 | `DATABASE_PASSWORD`               | `root`                                | Mongo database connection password. This value is only used when `DATABASE_URL` and `DATABASE_PASSWORD_FILE` are not provided.                                                    |
 | `DATABASE_HOST`                   | `localhost`                           | Mongo database connection hostname. This value is only used when `DATABASE_URL` is not provided.                                                                                  |
 | `DATABASE_PORT`                   | `27017`                               | Mongo database connection port. This value is only used when `DATABASE_URL` is not provided.                                                                                      |
-| `HEALTH_CHECK_FILE`               | `/home/collector/health_check.txt`    | Path to the file used for health check.                                                                                                                                           |
+| `HEALTH_CHECK_FILE`               | `/tmp/health_check.txt`               | Path to the file used for health check.                                                                                                                                           |
 | `HTTP(S)_PROXY`                   |                                       | Proxy to use by the collector.                                                                                                                                                    |
 
 ```{seealso}
@@ -164,7 +164,7 @@ The notifier uses the following environment variables:
 | `DATABASE_PASSWORD`       | `root`                                | Mongo database connection password. This value is only used when `DATABASE_URL` and `DATABASE_PASSWORD_FILE` are not provided. |
 | `DATABASE_HOST`           | `localhost`                           | Mongo database connection hostname. This value is only used when `DATABASE_URL` is not provided.                               |
 | `DATABASE_PORT`           | `27017`                               | Mongo database connection port. This value is only used when `DATABASE_URL` is not provided.                                   |
-| `HEALTH_CHECK_FILE`       | `/home/notifier/health_check.txt`     | Path to the file used for health check.                                                                                        |
+| `HEALTH_CHECK_FILE`       | `/tmp/health_check.txt`               | Path to the file used for health check.                                                                                        |
 | `NOTIFIER_LOG_LEVEL`      | `WARNING`                             | Log level. Allowed values are `DEBUG`, `INFO`, `WARNING`, `ERROR`, and `CRITICAL`.                                             |
 | `NOTIFIER_SLEEP_DURATION` | `60`                                  | The amount of time (in seconds) that the notifier sleeps between sending notifications.                                        |
 


### PR DESCRIPTION
Change the default location of the health check file that the collector and notifier write, from the home directory of the user running the component to the system temporary directory (`/tmp` in the containers). The `HEALTH_CHECK_FILE` environment variable can still be used to configure a different location.

Prepares for #13477.