### PR TITLE
Read-only filesystem for containers

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -17,6 +17,9 @@ jobs:
           persist-credentials: false
 
       - name: Set yaml value change dict with random generated secrets
+        # Use printf instead of echo so the base64-encoded secrets do not contain a trailing newline;
+        # MongoDB rejects usernames and passwords with control characters (SASLprep), which would prevent
+        # the root user from being created and make all database authentication fail
         # yamllint disable rule:line-length
         run: |
           echo "VALUE_CHANGES={\"[0].data.DATABASE_USERNAME\":\"$(printf "%s" ${RANDOM} | base64)\",\"[0].data.DATABASE_PASSWORD\":\"$(printf "%s" ${RANDOM} | base64)\",\"[1].data.LDAP_LOOKUP_USER_PASSWORD\":\"$(printf "%s" ${RANDOM} | base64)\"}" >> $GITHUB_ENV
@@ -43,6 +46,18 @@ jobs:
           kubectl apply -f helm/deploy-ci.yaml
           helm dependency build helm
           helm upgrade --install --render-subchart-notes quality-time helm
-          kubectl wait --all pods --timeout=2m --for=condition=Ready
+          # The timeout needs to accommodate pulling all images and the readiness probes passing
+          kubectl wait --all pods --timeout=5m --for=condition=Ready
           kubectl wait --all deployments --timeout=30s --for=condition=Available
-        timeout-minutes: 3
+        timeout-minutes: 7
+
+      - name: Show diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get pods
+          kubectl get events --sort-by=.lastTimestamp | tail -50
+          kubectl describe pods
+          for pod in $(kubectl get pods --output name); do
+            echo "=== Logs for ${pod}"
+            kubectl logs --all-containers --prefix --tail=50 ${pod} || true
+          done

--- a/components/renderer/Dockerfile
+++ b/components/renderer/Dockerfile
@@ -19,4 +19,9 @@ HEALTHCHECK CMD ["node", "/home/renderer/healthcheck.cjs"]
 
 ENV NODE_ENV=production
 
+# Point the configuration and cache folders of Chromium, which include the Crashpad crash handler database and
+# the fontconfig cache, to /tmp, the only writable folder when the container runs with a read-only root filesystem
+ENV XDG_CONFIG_HOME=/tmp
+ENV XDG_CACHE_HOME=/tmp
+
 CMD ["node", "/home/renderer/index.js"]

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -47,6 +47,7 @@ services:
     cap_drop:
       - ALL
     security_opt: *security-opt
+    read_only: true
   mongo-express:
     image: mongo-express:1.0.2@sha256:1b23d7976f0210dbec74045c209e52fbb26d29b2e873d6c6fa3d3f0ae32c2a64
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,6 +4,14 @@
 x-security-opt: &security-opt
   - no-new-privileges:true
 
+# The Nginx-based images render their configuration templates into /etc/nginx/conf.d at startup,
+# so that folder needs to be writable for the non-root Nginx user, also with a read-only root filesystem
+x-nginx-config-dir: &nginx-config-dir
+  - type: tmpfs
+    target: /etc/nginx/conf.d
+    tmpfs:
+      mode: 0o1777
+
 x-tz: &tz TZ=${TZ:-Europe/Amsterdam} # Timezone for log timestamps and date formatting; installed in each image
 
 services:
@@ -24,10 +32,14 @@ services:
     cap_drop:
       - ALL
     cap_add:
-      # nginx binary has CAP_NET_BIND_SERVICE via setcap (see components/proxy/Dockerfile)
+      # Nginx binary has CAP_NET_BIND_SERVICE via setcap (see components/proxy/Dockerfile)
       # so it can listen on port 80 as non-root
       - NET_BIND_SERVICE
     security_opt: *security-opt
+    read_only: true
+    tmpfs:
+      - /tmp # Nginx writes its pid file and temporary files to /tmp
+    volumes: *nginx-config-dir
   frontend:
     image: ictu/quality-time_frontend:${QUALITY_TIME_VERSION}
     environment:
@@ -38,6 +50,10 @@ services:
     cap_drop:
       - ALL
     security_opt: *security-opt
+    read_only: true
+    tmpfs:
+      - /tmp # Nginx writes its pid file and temporary files to /tmp
+    volumes: *nginx-config-dir
   collector:
     image: ictu/quality-time_collector:${QUALITY_TIME_VERSION}
     environment:
@@ -60,6 +76,9 @@ services:
     cap_drop:
       - ALL
     security_opt: *security-opt
+    read_only: true
+    tmpfs:
+      - /tmp # The collector writes its health check file to /tmp
   notifier:
     image: ictu/quality-time_notifier:${QUALITY_TIME_VERSION}
     environment:
@@ -79,6 +98,9 @@ services:
     cap_drop:
       - ALL
     security_opt: *security-opt
+    read_only: true
+    tmpfs:
+      - /tmp # The notifier writes its health check file to /tmp
   api_server:
     image: ictu/quality-time_api_server:${QUALITY_TIME_VERSION}
     environment:
@@ -109,6 +131,9 @@ services:
     cap_drop:
       - ALL
     security_opt: *security-opt
+    read_only: true
+    tmpfs:
+      - /tmp # Bottle buffers large request bodies, such as imported reports, in temporary files
   database:
     image: ictu/quality-time_database:${QUALITY_TIME_VERSION}
     command: --quiet
@@ -122,6 +147,9 @@ services:
     volumes:
       - "dbdata:/data/db"
     security_opt: *security-opt
+    read_only: true
+    tmpfs:
+      - /tmp # MongoDB creates its Unix domain socket in /tmp
   renderer:
     image: ictu/quality-time_renderer:${QUALITY_TIME_VERSION}
     environment:
@@ -132,6 +160,9 @@ services:
     cap_drop:
       - ALL
     security_opt: *security-opt
+    read_only: true
+    tmpfs:
+      - /tmp # Chromium, used to render PDFs, writes temporary files to /tmp
 volumes:
   dbdata:
 secrets:

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,7 +14,9 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ### Changed
 
-- Change the default location of the health check file that the collector and notifier write, from the home directory of the user running the component to the system temporary directory (`/tmp` in the containers). The `HEALTH_CHECK_FILE` environment variable can still be used to configure a different location.
+- Run all containers in both the Docker-composition and the Helm chart with a read-only root filesystem (except the development-only LDAP and Mongo Express containers in the Docker-composition), with mounts for the locations the components write to, such as `/tmp`. The database data is unaffected as it is stored on a volume. Partially realizes [#13477](https://github.com/ICTU/quality-time/issues/13477).
+- Collector and notifier now write the health check file to `/tmp`. The `HEALTH_CHECK_FILE` environment variable can still be used to configure a different location. Partially realizes [#13477](https://github.com/ICTU/quality-time/issues/13477).
+- Add liveness probes (all components) and readiness probes (all components that serve traffic) to the Helm chart, mirroring the Docker health checks. Partially realizes [#13477](https://github.com/ICTU/quality-time/issues/13477).
 
 ### Fixed
 

--- a/docs/styles/config/vocabularies/Base/accept.txt
+++ b/docs/styles/config/vocabularies/Base/accept.txt
@@ -44,11 +44,13 @@ config
 coroutine
 discoverability
 donut
+emptyDir
 errored
 favicon
 fixme
 hostnames?
 hotspots?
+liveness
 mimetype
 misconfigured
 mypy

--- a/helm/README.md
+++ b/helm/README.md
@@ -24,7 +24,7 @@ helm upgrade quality-time helm
 
 ## Set up port-forwarding
 
-Finally, enable port-forwarding on the proxy pod to make Quality-time reachable: 
+Finally, enable port-forwarding on the proxy pod to make Quality-time reachable:
 
 ```console
 kubectl port-forward quality-time-www-pod-suffix 8080:8080
@@ -35,3 +35,7 @@ If you don't have tab completion working for kubectl you can find out the pod-su
 ```console
 kubectl get pods | grep quality-time-www
 ```
+
+## Customizing
+
+Note that the `securityContext` of each component in the Helm chart values contains `readOnlyRootFilesystem: true`; when overriding the `securityContext` of a component, include `readOnlyRootFilesystem: true` in the override to keep the read-only root filesystem, as overrides replace the whole `securityContext`.

--- a/helm/templates/api_server.yaml
+++ b/helm/templates/api_server.yaml
@@ -62,16 +62,46 @@ spec:
             - name: LDAP_SEARCH_FILTER  # override to make sure that double dollar signs are processed like in docker
               value: {{ .Values.api_server.env.LDAP_SEARCH_FILTER }}
           securityContext: {{- toYaml .Values.api_server.securityContext | nindent 12 }}
-          {{- with .Values.api_server.extraVolumeMounts }}
-          volumeMounts: {{- toYaml . | nindent 12 }}
-          {{- end }}
+          volumeMounts:
+            # Bottle, the web framework used by the API-server, buffers large request bodies,
+            # such as imported reports, in temporary files
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.api_server.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          # The API-server has a variable, potentially long startup (loading example reports, connecting
+          # to LDAP and the database, database migrations), so gate the liveness probe behind a startup
+          # probe to avoid restarts during startup
+          startupProbe:
+            httpGet:
+              path: /api/internal/health
+              port: 5001
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/internal/health
+              port: 5001
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /api/internal/health
+              port: 5001
+            periodSeconds: 10
+            timeoutSeconds: 10
           {{- with .Values.api_server.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
       restartPolicy: Always
-      {{- with .Values.api_server.extraVolumes }}
-      volumes: {{- toYaml . | nindent 8 }}
-      {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- with .Values.api_server.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm/templates/collector.yaml
+++ b/helm/templates/collector.yaml
@@ -49,6 +49,21 @@ spec:
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
           securityContext: {{- toYaml .Values.collector.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          livenessProbe:
+            exec:
+              command:
+                - python
+                - -c
+                - "from datetime import datetime as dt, timedelta, UTC; import os, sys; sys.exit(dt.now(tz=UTC) - dt.fromisoformat(open(os.environ['HEALTH_CHECK_FILE'], encoding='utf-8').read().strip()) > timedelta(seconds=600))"
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 10
+      volumes:
+        - name: tmp
+          emptyDir: {}
       restartPolicy: Always
 ---
 {{- if .Values.collector.env }}

--- a/helm/templates/database.yaml
+++ b/helm/templates/database.yaml
@@ -32,6 +32,12 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.database.backupVol.claimName }}
         {{- end }}
+        - name: tmp
+          emptyDir: {}
+        # The MongoDB image declares /data/configdb as a volume; Docker creates it automatically,
+        # Kubernetes does not, so mount it explicitly to keep it writable with a read-only root filesystem
+        - name: configdb
+          emptyDir: {}
       containers:
         - name: {{ template "database_name" . }}
           image: "{{ .Values.database.image.repository }}:{{ .Values.database.image.tag | default .Chart.AppVersion }}"
@@ -64,6 +70,21 @@ spec:
             - mountPath: {{ .Values.database.backupVol.mountPath }}
               name: backups
             {{- end }}
+            - mountPath: /tmp # MongoDB creates its Unix domain socket in /tmp
+              name: tmp
+            - mountPath: /data/configdb
+              name: configdb
+          livenessProbe:
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 27017
+            periodSeconds: 10
+            timeoutSeconds: 10
       restartPolicy: Always
 ---
 apiVersion: v1

--- a/helm/templates/frontend.yaml
+++ b/helm/templates/frontend.yaml
@@ -34,6 +34,30 @@ spec:
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
           securityContext: {{- toYaml .Values.frontend.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            # Nginx renders its configuration templates into /etc/nginx/conf.d at startup
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+          livenessProbe:
+            httpGet:
+              path: /favicon.ico
+              port: 5000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /favicon.ico
+              port: 5000
+            periodSeconds: 10
+            timeoutSeconds: 10
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: nginx-config
+          emptyDir: {}
       restartPolicy: Always
 ---
 apiVersion: v1

--- a/helm/templates/notifier.yaml
+++ b/helm/templates/notifier.yaml
@@ -49,6 +49,21 @@ spec:
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
           securityContext: {{- toYaml .Values.notifier.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          livenessProbe:
+            exec:
+              command:
+                - python
+                - -c
+                - "from datetime import datetime as dt, timedelta, UTC; import os, sys; sys.exit(dt.now(tz=UTC) - dt.fromisoformat(open(os.environ['HEALTH_CHECK_FILE'], encoding='utf-8').read().strip()) > timedelta(seconds=600))"
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 10
+      volumes:
+        - name: tmp
+          emptyDir: {}
       restartPolicy: Always
 ---
 {{- if .Values.notifier.env }}

--- a/helm/templates/renderer.yaml
+++ b/helm/templates/renderer.yaml
@@ -39,6 +39,27 @@ spec:
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
           securityContext: {{- toYaml .Values.renderer.securityContext | nindent 12 }}
+          volumeMounts:
+            # Chromium, used to render PDFs, writes its temporary files, crash handler database,
+            # and caches to /tmp
+            - name: tmp
+              mountPath: /tmp
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 9000
+            periodSeconds: 10
+            timeoutSeconds: 10
+      volumes:
+        - name: tmp
+          emptyDir: {}
       restartPolicy: Always
 ---
 apiVersion: v1

--- a/helm/templates/www.yaml
+++ b/helm/templates/www.yaml
@@ -44,6 +44,30 @@ spec:
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
           securityContext: {{- toYaml .Values.www.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            # Nginx renders its configuration templates into /etc/nginx/conf.d at startup
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+          # Restart the proxy only when nginx itself is down, not when an upstream component is down
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /favicon.ico
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 10
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: nginx-config
+          emptyDir: {}
       restartPolicy: Always
 {{- end }}
 ---

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,6 +8,7 @@ api_server:
     capabilities:
       drop:
         - ALL
+    readOnlyRootFilesystem: true
   extraVolumes: []
   #    - name: cert-config-map
   #      configMap:
@@ -29,8 +30,13 @@ collector:
     capabilities:
       drop:
         - ALL
+    readOnlyRootFilesystem: true
   image:
     repository: "ictu/quality-time_collector"
+  env:
+    # The health check file is written to /tmp because that is the only writable folder
+    # with a read-only root filesystem; the liveness probe reads the same environment variable
+    HEALTH_CHECK_FILE: "/tmp/health_check.txt"
 
 database:
   storageSize: "1Gi"
@@ -43,6 +49,7 @@ database:
         - SETUID
       drop:
         - ALL
+    readOnlyRootFilesystem: true
   image:
     repository: "ictu/quality-time_database"
   resources:
@@ -58,6 +65,7 @@ frontend:
     capabilities:
       drop:
         - ALL
+    readOnlyRootFilesystem: true
   image:
     repository: "ictu/quality-time_frontend"
 
@@ -66,19 +74,29 @@ notifier:
     capabilities:
       drop:
         - ALL
+    readOnlyRootFilesystem: true
   image:
     repository: "ictu/quality-time_notifier"
+  env:
+    # The health check file is written to /tmp because that is the only writable folder
+    # with a read-only root filesystem; the liveness probe reads the same environment variable
+    HEALTH_CHECK_FILE: "/tmp/health_check.txt"
 
 renderer:
   securityContext:
     capabilities:
       drop:
         - ALL
+    readOnlyRootFilesystem: true
   image:
     repository: "ictu/quality-time_renderer"
   env:
     LC_ALL: "en_GB.UTF-8"
     TZ: "Europe/Amsterdam"
+    # Point the configuration and cache folders of Chromium, which include the Crashpad crash handler
+    # database and the fontconfig cache, to /tmp, the only writable folder with a read-only root filesystem
+    XDG_CONFIG_HOME: "/tmp"
+    XDG_CACHE_HOME: "/tmp"
 
 www:
   securityContext:
@@ -90,6 +108,7 @@ www:
         - NET_BIND_SERVICE
       drop:
         - ALL
+    readOnlyRootFilesystem: true
   # -- When www.deployProxy is false the quality-time_proxy is not used and ingress is pointed directly to the backend api and frontend. Note that this breaks PDF-exports. See https://github.com/ICTU/quality-time/issues/13065.
   deployProxy: true
   image:


### PR DESCRIPTION
Run the containers with a read-only root filesystem, with a tmpfs mounted at `/tmp` for the files these components write.

Prepares for #13477.