### PR TITLE
Prevent trailing newline in generated credentials

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set yaml value change dict with random generated secrets
         # yamllint disable rule:line-length
         run: |
-          echo "VALUE_CHANGES={\"[0].data.DATABASE_USERNAME\":\"$(echo ${RANDOM} | base64)\",\"[0].data.DATABASE_PASSWORD\":\"$(echo ${RANDOM} | base64)\",\"[1].data.LDAP_LOOKUP_USER_PASSWORD\":\"$(echo ${RANDOM} | base64)\"}" >> $GITHUB_ENV
+          echo "VALUE_CHANGES={\"[0].data.DATABASE_USERNAME\":\"$(printf "%s" ${RANDOM} | base64)\",\"[0].data.DATABASE_PASSWORD\":\"$(printf "%s" ${RANDOM} | base64)\",\"[1].data.LDAP_LOOKUP_USER_PASSWORD\":\"$(printf "%s" ${RANDOM} | base64)\"}" >> $GITHUB_ENV
         # yamllint enable rule:line-length
       - name: Update values.yaml
         uses: fjogeleit/yaml-update-action@dffe9a5223d84653c13374032382f6bb5de8e5ef # v0.17.0


### PR DESCRIPTION
Use printf instead of echo so the base64-encoded secrets do not contain a trailing newline. MongoDB rejects usernames and passwords with control characters (SASLprep), which prevents the root user from being created and make all database authentication fail.