### PR TITLE
Strip the container images

### DIFF
--- a/components/api_server/Dockerfile
+++ b/components/api_server/Dockerfile
@@ -3,25 +3,33 @@ FROM python:3.14.5-alpine3.23@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6cce
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time API-server"
 
-RUN apk add --no-cache tzdata=2026b-r0
-
 ENV UV_COMPILE_BYTECODE=1 UV_NO_CACHE=1 UV_PYTHON_DOWNLOADS=0 VIRTUAL_ENV=/home/server/venv
 
 WORKDIR /home/server
 
+# After installing the API-server, reduce the attack surface to approximate a hardened base image: remove the package
+# manager, the shell, and the Python installer and developer tools, none of which are needed to run the API-server.
+# Note that this means the running container has no shell, so `docker exec <container> sh` will not work.
 RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv \
     --mount=type=bind,source=tools/third_party,target=/tools/third_party,rw \
     --mount=type=bind,source=components/shared_code,target=/home/shared_code,rw \
     --mount=type=bind,source=components/api_server/uv.lock,target=/home/server/uv.lock \
     --mount=type=bind,source=components/api_server/pyproject.toml,target=/home/server/pyproject.toml \
-    uv sync --active --frozen --no-dev --no-install-project
+    uv sync --active --frozen --no-dev --no-install-project && \
+    apk add --no-cache tzdata=2026b-r0 && \
+    adduser -S server && \
+    rm -rf /usr/local/bin/pip* /usr/local/bin/idle* /usr/local/bin/pydoc* /usr/local/bin/2to3* \
+        /usr/local/lib/python*/site-packages/pip \
+        /usr/local/lib/python*/site-packages/pip-* \
+        /usr/local/lib/python*/ensurepip /usr/local/lib/python*/idlelib && \
+    apk --purge --quiet del apk-tools alpine-keys musl-utils scanelf ssl_client && \
+    rm -rf /etc/apk /lib/apk /var/cache/apk /bin/sh /bin/busybox
 
-RUN adduser -S server
 USER server
 
-COPY components/api_server/src /home/server
-
 HEALTHCHECK CMD ["python", "/home/server/healthcheck.py"]
+
+COPY components/api_server/src /home/server
 
 ENV PATH="/home/server/venv/bin:$PATH"
 CMD ["python", "/home/server/quality_time_server.py"]

--- a/components/collector/Dockerfile
+++ b/components/collector/Dockerfile
@@ -3,21 +3,28 @@ FROM python:3.14.5-alpine3.23@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6cce
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time collector"
 
-RUN apk add --no-cache tzdata=2026b-r0
-
-ENV UV_COMPILE_BYTECODE=1 UV_NO_CACHE=1 UV_PYTHON_DOWNLOADS=0 VIRTUAL_ENV=/home/collector/venv
+ENV UV_COMPILE_BYTECODE=1 UV_NO_CACHE=1 UV_PYTHON_DOWNLOADS=0 VIRTUAL_ENV=/home/collector/venv HEALTH_CHECK_FILE=/tmp/health_check.txt
 
 WORKDIR /home/collector
 
+# After installing the collector, reduce the attack surface to approximate a hardened base image: remove the package
+# manager, the shell, and the Python installer and developer tools, none of which are needed to run the collector.
+# Note that this means the running container has no shell, so `docker exec <container> sh` will not work.
 RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv \
     --mount=type=bind,source=tools/third_party,target=/tools/third_party,rw \
     --mount=type=bind,source=components/shared_code,target=/home/shared_code,rw \
     --mount=type=bind,source=components/collector/uv.lock,target=/home/collector/uv.lock \
     --mount=type=bind,source=components/collector/pyproject.toml,target=/home/collector/pyproject.toml \
-    uv sync --active --frozen --no-dev --no-install-project
+    uv sync --active --frozen --no-dev --no-install-project && \
+    apk add --no-cache tzdata=2026b-r0 && \
+    adduser -S collector && \
+    rm -rf /usr/local/bin/pip* /usr/local/bin/idle* /usr/local/bin/pydoc* /usr/local/bin/2to3* \
+        /usr/local/lib/python*/site-packages/pip \
+        /usr/local/lib/python*/site-packages/pip-* \
+        /usr/local/lib/python*/ensurepip /usr/local/lib/python*/idlelib && \
+    apk --purge --quiet del apk-tools alpine-keys musl-utils scanelf ssl_client && \
+    rm -rf /etc/apk /lib/apk /var/cache/apk /bin/sh /bin/busybox
 
-ENV HEALTH_CHECK_FILE=/tmp/health_check.txt
-RUN adduser -S collector
 USER collector
 
 HEALTHCHECK CMD ["python", "-c", "from datetime import datetime as dt, timedelta, UTC; import os, sys; sys.exit(dt.now(tz=UTC) - dt.fromisoformat(open(os.environ['HEALTH_CHECK_FILE'], encoding='utf-8').read().strip()) > timedelta(seconds=600))"]

--- a/components/database/Dockerfile
+++ b/components/database/Dockerfile
@@ -2,3 +2,10 @@ FROM mongo:8.3.2@sha256:94b405c5aa83d5160e6dd97383c4687d471f8a6bd247ed3ff6463c09
 
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time database"
+
+# Remove the MongoDB database tools (mongodump, mongorestore, mongoexport, mongostat, etc.). They are not used
+# by the server, by Quality-time (the components connect via PyMongo), or for backups (which use a separate
+# mongo container, see the deployment documentation), and they ship with their own vulnerabilities. The server
+# (mongod) and the shell (mongosh, needed by the entrypoint to create the root user) are kept.
+RUN apt-get purge --yes mongodb-database-tools mongodb-org-database-tools-extra && \
+    rm -rf /var/lib/apt/lists/*

--- a/components/frontend/Dockerfile
+++ b/components/frontend/Dockerfile
@@ -19,6 +19,13 @@ LABEL description="Quality-time frontend"
 
 ENV FRONTEND_PORT=5000
 
+# Reduce the attack surface by removing the package manager, which the Nginx runtime does not need. The
+# shell is kept because the Nginx entrypoint renders the configuration templates with it at startup.
+USER root
+RUN apk --purge --quiet del apk-tools alpine-keys scanelf && \
+    rm -rf /etc/apk /lib/apk /var/cache/apk
+USER 101
+
 COPY --from=compile-image /home/frontend/dist /usr/share/nginx/html
 COPY --from=compile-image /usr/share/zoneinfo /usr/share/zoneinfo
 

--- a/components/notifier/Dockerfile
+++ b/components/notifier/Dockerfile
@@ -3,21 +3,28 @@ FROM python:3.14.5-alpine3.23@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6cce
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time notifier"
 
-RUN apk add --no-cache tzdata=2026b-r0
-
-ENV UV_COMPILE_BYTECODE=1 UV_NO_CACHE=1 UV_PYTHON_DOWNLOADS=0 VIRTUAL_ENV=/home/notifier/venv
+ENV UV_COMPILE_BYTECODE=1 UV_NO_CACHE=1 UV_PYTHON_DOWNLOADS=0 VIRTUAL_ENV=/home/notifier/venv HEALTH_CHECK_FILE=/tmp/health_check.txt
 
 WORKDIR /home/notifier
 
+# After installing the notifier, reduce the attack surface to approximate a hardened base image: remove the package
+# manager, the shell, and the Python installer and developer tools, none of which are needed to run the notifier.
+# Note that this means the running container has no shell, so `docker exec <container> sh` will not work.
 RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv \
     --mount=type=bind,source=tools/third_party,target=/tools/third_party,rw \
     --mount=type=bind,source=components/shared_code,target=/home/shared_code,rw \
     --mount=type=bind,source=components/notifier/uv.lock,target=/home/notifier/uv.lock \
     --mount=type=bind,source=components/notifier/pyproject.toml,target=/home/notifier/pyproject.toml \
-    uv sync --active --frozen --no-dev --no-install-project
+    uv sync --active --frozen --no-dev --no-install-project && \
+    apk add --no-cache tzdata=2026b-r0 && \
+    adduser -S notifier && \
+    rm -rf /usr/local/bin/pip* /usr/local/bin/idle* /usr/local/bin/pydoc* /usr/local/bin/2to3* \
+        /usr/local/lib/python*/site-packages/pip \
+        /usr/local/lib/python*/site-packages/pip-* \
+        /usr/local/lib/python*/ensurepip /usr/local/lib/python*/idlelib && \
+    apk --purge --quiet del apk-tools alpine-keys musl-utils scanelf ssl_client && \
+    rm -rf /etc/apk /lib/apk /var/cache/apk /bin/sh /bin/busybox
 
-ENV HEALTH_CHECK_FILE=/tmp/health_check.txt
-RUN adduser -S notifier
 USER notifier
 
 HEALTHCHECK CMD ["python", "-c", "from datetime import datetime as dt, timedelta, UTC; import os, sys; sys.exit(dt.now(tz=UTC) - dt.fromisoformat(open(os.environ['HEALTH_CHECK_FILE'], encoding='utf-8').read().strip()) > timedelta(seconds=600))"]

--- a/components/proxy/Dockerfile
+++ b/components/proxy/Dockerfile
@@ -16,6 +16,13 @@ ENV FRONTEND_PORT=5000
 ENV API_SERVER_HOST=api_server
 ENV API_SERVER_PORT=5001
 
+# Reduce the attack surface by removing the package manager, which the Nginx runtime does not need. The
+# shell is kept because the Nginx entrypoint renders the configuration templates with it at startup.
+USER root
+RUN apk --purge --quiet del apk-tools alpine-keys scanelf && \
+    rm -rf /etc/apk /lib/apk /var/cache/apk
+USER 101
+
 COPY --from=compile-image /usr/sbin/nginx /usr/sbin/nginx
 COPY --from=compile-image /usr/share/zoneinfo /usr/share/zoneinfo
 COPY *.template /etc/nginx/templates/

--- a/components/renderer/Dockerfile
+++ b/components/renderer/Dockerfile
@@ -3,16 +3,22 @@ FROM node:26.3.0-alpine3.23@sha256:144769ec3f32e8ee36b3cfde91e82bee25d9367b20f31
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time PDF render service"
 
-# hadolint ignore=DL3018
-RUN apk add --no-cache chromium tzdata=2026b-r0
-
 WORKDIR /home/renderer
 COPY package*.json /home/renderer/
-RUN npm ci --ignore-scripts
+
+# Install, then reduce the attack surface: remove npm/corepack (not needed at runtime) and the package
+# manager. The shell is kept because Chromium's launcher (/usr/bin/chromium-browser) is a shell script.
+# hadolint ignore=DL3018
+RUN apk add --no-cache chromium tzdata=2026b-r0 && \
+    npm ci --ignore-scripts && \
+    adduser -S renderer && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
+        /usr/local/lib/node_modules/corepack /usr/local/bin/corepack && \
+    apk --purge --quiet del apk-tools alpine-keys scanelf && \
+    rm -rf /etc/apk /lib/apk /var/cache/apk
 
 COPY src/*js /home/renderer/
 
-RUN adduser renderer --disabled-password
 USER renderer
 
 HEALTHCHECK CMD ["node", "/home/renderer/healthcheck.cjs"]

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,9 +14,15 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ### Changed
 
-- Run all containers in both the Docker-composition and the Helm chart with a read-only root filesystem (except the development-only LDAP and Mongo Express containers in the Docker-composition), with mounts for the locations the components write to, such as `/tmp`. The database data is unaffected as it is stored on a volume. Partially realizes [#13477](https://github.com/ICTU/quality-time/issues/13477).
-- Collector and notifier now write the health check file to `/tmp`. The `HEALTH_CHECK_FILE` environment variable can still be used to configure a different location. Partially realizes [#13477](https://github.com/ICTU/quality-time/issues/13477).
-- Add liveness probes (all components) and readiness probes (all components that serve traffic) to the Helm chart, mirroring the Docker health checks. Partially realizes [#13477](https://github.com/ICTU/quality-time/issues/13477).
+- Harden the production container images. Closes [#13477](https://github.com/ICTU/quality-time/issues/13477). Changes made:
+  - Run all containers in both the Docker-composition and the Helm chart with a read-only root filesystem (except the development-only LDAP and Mongo Express containers in the Docker-composition), with mounts for the locations the components write to, such as `/tmp`.
+  - Collector and notifier now write the health check file to `/tmp`. The `HEALTH_CHECK_FILE` environment variable can still be used to configure a different location if needed.
+  - Add liveness probes (all components) and readiness probes (all components that serve traffic) to the Helm chart, mirroring the Docker health checks.
+  - Remove the shell, package manager, and Python installer and developer tools from the production Python container images to reduce their attack surface. As a result, the running container no longer has a shell, so opening a shell in it (for example with `docker exec` or `kubectl exec`) is no longer possible.
+  - Remove the package manager from the frontend and proxy container images to reduce their attack surface.
+  - Remove npm and the package manager from the renderer container image to reduce its attack surface.
+  - Run the renderer container as a non-login system user, consistent with the other components.
+  - Remove the unused MongoDB database tools (`mongodump`, `mongorestore`, `mongoexport`, `mongostat`, and so on) from the database container image to reduce its attack surface. Backups continue to work as documented, using a separate Mongo container.
 
 ### Fixed
 


### PR DESCRIPTION
Remove the shell, package manager, and Python installer and developer tools from the Python production container images to reduce their attack surface. As a result, running containers no longer has a shell, so opening a shell in it (for example with `docker exec` or `kubectl exec`) is no longer possible.

Partially realizes #13477.