### PR TITLE
Harden database image

### DIFF
--- a/components/database/Dockerfile
+++ b/components/database/Dockerfile
@@ -7,5 +7,15 @@ LABEL description="Quality-time database"
 # by the server, by Quality-time (the components connect via PyMongo), or for backups (which use a separate
 # mongo container, see the deployment documentation), and they ship with their own vulnerabilities. The server
 # (mongod) and the shell (mongosh, needed by the entrypoint to create the root user) are kept.
+# Make the data directories group-owned by the root group (GID 0) and group-writable so the container can run
+# as an arbitrary non-root user (some platforms, such as OpenShift, assign a random high UID with GID 0). This,
+# combined with running as non-root, means gosu is no longer needed and can be removed to reduce the attack surface.
 RUN apt-get purge --yes mongodb-database-tools mongodb-org-database-tools-extra && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /usr/local/bin/gosu && \
+    chgrp -R 0 /data/db /data/configdb && \
+    chmod -R g=u /data/db /data/configdb
+
+# Run as the non-root MongoDB user by default. Platforms that require a UID >= 1000 can override this with a
+# securityContext (see the deployment documentation); the data directories above are group-writable for GID 0.
+USER 999

--- a/docker/.compose-lint.yml
+++ b/docker/.compose-lint.yml
@@ -1,10 +1,6 @@
 ---
 # Configuration for compose-lint (https://github.com/tmatens/compose-lint).
 #
-# Only docker-compose.yml is linted (the canonical Compose file).
-# docker-compose.override.yml and docker-compose.ci.yml are layered fragments,
-# never used standalone, so linting them as standalone files is not meaningful.
-#
 # The rules disabled below reflect deliberate trade-offs for docker-compose.yml
 # as shipped: it serves both local development and as a starting point for
 # production-style deployments (Compose-based or Helm-based). Operators are
@@ -22,26 +18,24 @@ rules:
         override file or Helm chart.
   CL-0006:
     exclude_services:
-      database: >-
-        mongo's entrypoint chowns /data/db to the mongodb user on first
-        run, which needs CAP_CHOWN. cap_drop ALL would prevent volume
-        initialization. Hardening this would require running as a fixed
-        UID/GID and pre-creating the volume with correct ownership.
       ldap: >-
         Test LDAP service from docker-compose.override.yml /
+        docker-compose.ci.yml; not part of the product and never run in
+        production.
+  CL-0007:
+    exclude_services:
+      ldap: >-
+        Test LDAP service from docker-compose.override.yml /
+        docker-compose.ci.yml; not part of the product and never run in
+        production.
+      mongo-express: >-
+        MongoDB viewer service from docker-compose.override.yml /
         docker-compose.ci.yml; not part of the product and never run in
         production.
       selenium: >-
         Browser-based test runner from docker-compose.ci.yml. Chromium /
         Firefox sandboxing typically needs specific caps; cap_drop ALL would
         likely break test execution.
-  CL-0007:
-    enabled: false
-    reason: >-
-      Services do not set read_only on the root filesystem. Each service's
-      writable paths have not been audited and declared via tmpfs/volumes;
-      operators running in production are expected to add this hardening
-      in their own override file or in the Helm chart.
   CL-0019:
     enabled: false
     reason: >-

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -45,4 +45,6 @@ services:
     shm_size: 2gb
     ports:
       - "127.0.0.1:4444:4444"
+    cap_drop:
+      - ALL
     security_opt: *security-opt

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -146,6 +146,8 @@ services:
       - database_password
     volumes:
       - "dbdata:/data/db"
+    cap_drop:
+      - ALL
     security_opt: *security-opt
     read_only: true
     tmpfs:

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -23,6 +23,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
   - Remove npm and the package manager from the renderer container image to reduce its attack surface.
   - Run the renderer container as a non-login system user, consistent with the other components.
   - Remove the unused MongoDB database tools (`mongodump`, `mongorestore`, `mongoexport`, `mongostat`, and so on) from the database container image to reduce its attack surface. Backups continue to work as documented, using a separate Mongo container.
+  - Use the default non-root `mongodb` user (UID 999) so that `gosu` can be removed from the database container image to reduce its attack surface. The database image also supports running as a UID >= 1000 or an arbitrary UID (for example on OpenShift); see the "Customizing" section in the Helm chart README.
 
 ### Fixed
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -38,4 +38,48 @@ kubectl get pods | grep quality-time-www
 
 ## Customizing
 
-Note that the `securityContext` of each component in the Helm chart values contains `readOnlyRootFilesystem: true`; when overriding the `securityContext` of a component, include `readOnlyRootFilesystem: true` in the override to keep the read-only root filesystem, as overrides replace the whole `securityContext`.
+The chart sets a `securityContext` on each component (and, for the database, also a `podSecurityContext`), including `readOnlyRootFilesystem: true`. Helm deep-merges your overrides onto these defaults, so you only need to specify the keys you want to change; the other defaults stay in place. To *remove* a default key, set it to `null` in your override — omitting it leaves the default unchanged. Note that lists, such as `capabilities.drop`, are replaced rather than merged when you override them.
+
+### Running the database as a different user
+
+By default the database container runs as the `mongodb` user (UID 999). Some platforms (such as OpenShift) require containers to run with a UID >= 1000 or assign an arbitrary high UID. The database image supports this: its data directories (`/data/db` and `/data/configdb`) are group-owned by the root group (GID 0) and group-writable, so the container can run as any non-root user that belongs to GID 0.
+
+To run the database as a fixed UID >= 1000, override the user in the `securityContext` and set a matching `fsGroup` in the `podSecurityContext` so the platform makes the persistent volume writable for that user:
+
+```yaml
+database:
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsUser: 1000 # any value >= 1000
+    runAsGroup: 0
+  podSecurityContext:
+    fsGroup: 1000
+    fsGroupChangePolicy: OnRootMismatch
+```
+
+### Running the database with an arbitrary UID (OpenShift)
+
+On platforms that assign an arbitrary UID (such as OpenShift with the default `restricted-v2` SCC), don't pin the UID or group at all: the platform picks the UID, runs it with GID 0, and the data directories are already group-writable for GID 0. Because the chart ships `runAsUser: 999`, `runAsGroup: 999`, `fsGroup: 999`, and `fsGroupChangePolicy` as defaults, and Helm keeps unspecified defaults, you have to *remove* all four by setting them to `null`:
+
+```yaml
+database:
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsUser: null
+    runAsGroup: null
+  podSecurityContext:
+    fsGroup: null
+    fsGroupChangePolicy: null
+```
+
+This leaves only `capabilities` and `readOnlyRootFilesystem` in the `securityContext` and an empty `podSecurityContext`. OpenShift then injects the UID and, via its `MustRunAs` `fsGroup` strategy, an allowed `fsGroup` of its own. Hardcoding `runAsUser` or `fsGroup` to a value outside the namespace's allowed range would get the pod rejected, which is why they are removed rather than set.
+
+### Migrating an existing deployment
+
+When changing the UID of an *existing* deployment, the data files are owned by UID 999, so an `fsGroup` must be set to let the platform re-own the volume's group on mount; otherwise the new user cannot read the existing data. On a fixed-UID platform, set `fsGroup` to the new UID (as in the example above). On OpenShift, set it to a value within the namespace's allowed range (see the namespace's `openshift.io/sa.scc.supplemental-groups` annotation) rather than letting it default, and not to `999`. Fresh installs are not affected.

--- a/helm/templates/database.yaml
+++ b/helm/templates/database.yaml
@@ -23,6 +23,8 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: {{ template "database_name" . }}
     spec:
+      securityContext:
+        {{- toYaml .Values.database.podSecurityContext | nindent 8 }}
       volumes:
         - name: {{ .Release.Name }}-{{ template "database_name" . }}
           persistentVolumeClaim:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -42,16 +42,19 @@ collector:
 
 database:
   storageSize: "1Gi"
+  # The database runs as the non-root mongodb user (UID 999) by default. To run it as a UID >= 1000 or an
+  # arbitrary UID (for example on OpenShift), override runAsUser and fsGroup; see the "Customizing" section
+  # in helm/README.md.
   securityContext:
     capabilities:
-      add:
-        - CHOWN
-        - DAC_OVERRIDE
-        - SETGID
-        - SETUID
       drop:
         - ALL
     readOnlyRootFilesystem: true
+    runAsUser: 999
+    runAsGroup: 999
+  podSecurityContext:
+    fsGroup: 999
+    fsGroupChangePolicy: OnRootMismatch
   image:
     pullPolicy: "Always"
     repository: "ictu/quality-time_database"


### PR DESCRIPTION
Run the MongoDB with user 999 so that `gosu` can be removed from the database container image to reduce its attack surface.

Closes #13514.