### PR TITLE
Fix API-server inconsistent internal names

### DIFF
--- a/components/api_server/Dockerfile
+++ b/components/api_server/Dockerfile
@@ -3,9 +3,9 @@ FROM python:3.14.5-alpine3.23@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6cce
 LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time API-server"
 
-ENV UV_COMPILE_BYTECODE=1 UV_NO_CACHE=1 UV_PYTHON_DOWNLOADS=0 VIRTUAL_ENV=/home/server/venv
+ENV UV_COMPILE_BYTECODE=1 UV_NO_CACHE=1 UV_PYTHON_DOWNLOADS=0 VIRTUAL_ENV=/home/api_server/venv
 
-WORKDIR /home/server
+WORKDIR /home/api_server
 
 # After installing the API-server, reduce the attack surface to approximate a hardened base image: remove the package
 # manager, the shell, and the Python installer and developer tools, none of which are needed to run the API-server.
@@ -13,11 +13,11 @@ WORKDIR /home/server
 RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv \
     --mount=type=bind,source=tools/third_party,target=/tools/third_party,rw \
     --mount=type=bind,source=components/shared_code,target=/home/shared_code,rw \
-    --mount=type=bind,source=components/api_server/uv.lock,target=/home/server/uv.lock \
-    --mount=type=bind,source=components/api_server/pyproject.toml,target=/home/server/pyproject.toml \
+    --mount=type=bind,source=components/api_server/uv.lock,target=/home/api_server/uv.lock \
+    --mount=type=bind,source=components/api_server/pyproject.toml,target=/home/api_server/pyproject.toml \
     uv sync --active --frozen --no-dev --no-install-project && \
     apk add --no-cache tzdata=2026b-r0 && \
-    adduser -S server && \
+    adduser -S api_server && \
     rm -rf /usr/local/bin/pip* /usr/local/bin/idle* /usr/local/bin/pydoc* /usr/local/bin/2to3* \
         /usr/local/lib/python*/site-packages/pip \
         /usr/local/lib/python*/site-packages/pip-* \
@@ -25,11 +25,11 @@ RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv \
     apk --purge --quiet del apk-tools alpine-keys musl-utils scanelf ssl_client && \
     rm -rf /etc/apk /lib/apk /var/cache/apk /bin/sh /bin/busybox
 
-USER server
+USER api_server
 
-HEALTHCHECK CMD ["python", "/home/server/healthcheck.py"]
+HEALTHCHECK CMD ["python", "/home/api_server/healthcheck.py"]
 
-COPY components/api_server/src /home/server
+COPY components/api_server/src /home/api_server
 
-ENV PATH="/home/server/venv/bin:$PATH"
-CMD ["python", "/home/server/quality_time_server.py"]
+ENV PATH="/home/api_server/venv/bin:$PATH"
+CMD ["python", "/home/api_server/quality_time_api_server.py"]

--- a/components/api_server/pyproject.toml
+++ b/components/api_server/pyproject.toml
@@ -73,7 +73,7 @@ lint.per-file-ignores."__init__.py" = [
 lint.per-file-ignores."src/model/issue_tracker.py" = [
     "BLE001", # https://docs.astral.sh/ruff/rules/blind-except/ - allow for catching blind exception `Exception`
 ]
-lint.per-file-ignores."src/quality_time_server.py" = [
+lint.per-file-ignores."src/quality_time_api_server.py" = [
     "E402",
     "INP001", # https://docs.astral.sh/ruff/rules/implicit-namespace-package/ - false positive because this is the main script
 ]

--- a/components/api_server/src/quality_time_api_server.py
+++ b/components/api_server/src/quality_time_api_server.py
@@ -1,4 +1,4 @@
-"""Quality-time server."""
+"""Quality-time API-server."""
 
 from gevent import monkey
 
@@ -16,7 +16,7 @@ from initialization.bottle import init_bottle
 
 
 def serve() -> None:  # pragma: no feature-test-cover
-    """Connect to the database and start the application server."""
+    """Connect to the database and start the API-server."""
     logger = init_logging(str(os.getenv("API_SERVER_LOG_LEVEL", "WARNING")))
     with mongo_client() as client:
         admin_database = get_database(client, "admin")

--- a/components/api_server/tests/quality_time_api_server_under_coverage.py
+++ b/components/api_server/tests/quality_time_api_server_under_coverage.py
@@ -1,4 +1,4 @@
-"""Quality-time server, with coverage measurement."""
+"""Quality-time API-server, with coverage measurement."""
 
 import signal
 import sys
@@ -26,7 +26,7 @@ def signal_handler(*_args):
 if __name__ == "__main__":
     signal.signal(signal.SIGTERM, signal_handler)
     cov.start()
-    from quality_time_server import serve
+    from quality_time_api_server import serve
 
     try:
         serve()

--- a/components/api_server/tests/test_quality_time_api_server.py
+++ b/components/api_server/tests/test_quality_time_api_server.py
@@ -4,28 +4,28 @@ import logging
 import unittest
 from unittest.mock import patch, MagicMock, Mock
 
-from quality_time_server import serve
+from quality_time_api_server import serve
 
 
-@patch("quality_time_server.mongo_client", MagicMock())
-@patch("quality_time_server.init_database", Mock())
+@patch("quality_time_api_server.mongo_client", MagicMock())
+@patch("quality_time_api_server.init_database", Mock())
 @patch("bottle.install", Mock())
 class APIServerTestCase(unittest.TestCase):
     """Unit tests for starting the API-server."""
 
-    @patch("quality_time_server.run")
+    @patch("quality_time_api_server.run")
     def test_start(self, mocked_run):
         """Test that the server is started."""
         serve()
         mocked_run.assert_called_once()
 
-    @patch("quality_time_server.run", Mock())
+    @patch("quality_time_api_server.run", Mock())
     def test_default_log_level(self):
         """Test the default logging level."""
         serve()
         self.assertEqual("WARNING", logging.getLevelName(logging.getLogger().getEffectiveLevel()))
 
-    @patch("quality_time_server.run", Mock())
+    @patch("quality_time_api_server.run", Mock())
     @patch(
         "os.getenv",
         Mock(side_effect=lambda key, default=None: "DEBUG" if key == "API_SERVER_LOG_LEVEL" else default),

--- a/tests/feature_tests/test.sh
+++ b/tests/feature_tests/test.sh
@@ -44,7 +44,7 @@ done
 tests/feature_tests/.venv/bin/coverage erase
 result=0
 tests/feature_tests/.venv/bin/coverage run -m behave --format pretty "${1:-tests/feature_tests/src/features}" || result=$?
-# Bottle's reloader (reloader=True in quality_time_server.serve) runs the server
+# Bottle's reloader (reloader=True in quality_time_api_server.serve) runs the server
 # in a child process; the parent (captured in $api_server_pid) is just a monitor.
 # Signal the child so its signal handler saves the API-server's coverage data,
 # then wait for the parent to exit, which happens once the child is gone.


### PR DESCRIPTION
- Rename the Docker user from `server` to `api_server`.
- Rename the Docker homedir from `server` to `api_server`.
- Rename the app script from `quality_time_server.py` to `quality_time_api_server.py`.

Closes #13534.