### PR TITLE
Move collector and notifier healthcheck to script

### DIFF
--- a/components/collector/.vulture-whitelist.py
+++ b/components/collector/.vulture-whitelist.py
@@ -59,7 +59,7 @@ GatlingSourceVersion  # unused class (src/source_collectors/gatling/source_versi
 GenericJSONSecurityWarnings  # unused class (src/source_collectors/generic_json/security_warnings.py:12)
 GitHubMergeRequests  # unused class (src/source_collectors/github/merge_requests.py:60)
 GitLabChangeFailureRate  # unused class (src/source_collectors/gitlab/change_failure_rate.py:6)
-GitLabFailedJobs  # unused class (src/source_collectors/gitlab/failed_jobs.py:13)
+GitLabFailedJobs  # unused class (src/source_collectors/gitlab/failed_jobs.py:11)
 commit  # unused variable (src/source_collectors/gitlab/inactive_branches.py:24)
 GitLabInactiveBranches  # unused class (src/source_collectors/gitlab/inactive_branches.py:30)
 GitLabMergeRequests  # unused class (src/source_collectors/gitlab/merge_requests.py:61)

--- a/components/collector/Dockerfile
+++ b/components/collector/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv \
 
 USER collector
 
-HEALTHCHECK CMD ["python", "-c", "from datetime import datetime as dt, timedelta, UTC; import os, sys; sys.exit(dt.now(tz=UTC) - dt.fromisoformat(open(os.environ['HEALTH_CHECK_FILE'], encoding='utf-8').read().strip()) > timedelta(seconds=600))"]
+HEALTHCHECK CMD ["python", "/home/collector/healthcheck.py"]
 
 COPY components/collector/src /home/collector
 

--- a/components/collector/src/healthcheck.py
+++ b/components/collector/src/healthcheck.py
@@ -1,0 +1,16 @@
+"""Health check."""
+
+import os
+import pathlib
+import sys
+import tempfile
+from datetime import UTC, datetime, timedelta
+
+health_check_file = os.getenv("HEALTH_CHECK_FILE", str(tempfile.gettempdir() + "/health_check.txt"))
+exit_code = 1
+try:
+    timestamp = pathlib.Path(health_check_file).read_text().strip()
+    last_healthy = datetime.fromisoformat(timestamp)
+    exit_code = 0 if datetime.now(tz=UTC) - last_healthy <= timedelta(seconds=600) else 1
+finally:
+    sys.exit(exit_code)

--- a/components/collector/tests/test_healthcheck.py
+++ b/components/collector/tests/test_healthcheck.py
@@ -1,0 +1,39 @@
+"""Unit tests for the collector healthcheck script."""
+
+import sys
+import unittest
+from datetime import UTC, datetime
+from unittest.mock import Mock, patch
+
+
+@patch("sys.exit")
+@patch("pathlib.Path.read_text")
+class CollectorHealthcheckTestCase(unittest.TestCase):
+    """Unit tests for the collector healthcheck."""
+
+    def run_healthcheck(self) -> None:
+        """Run the healthcheck."""
+        import healthcheck  # noqa: F401,PLC0415
+
+    def tearDown(self) -> None:
+        """Remove the healthcheck module."""
+        if "healthcheck" in sys.modules:
+            del sys.modules["healthcheck"]
+
+    def test_healthy(self, mock_read_text: Mock, mock_exit: Mock):
+        """Test that the collector is healthy if the timestamp is recent."""
+        mock_read_text.return_value = datetime.now(tz=UTC).isoformat()
+        self.run_healthcheck()
+        mock_exit.assert_called_once_with(0)
+
+    def test_unhealthy(self, mock_read_text: Mock, mock_exit: Mock):
+        """Test that the collector is unhealthy if the timestamp is old."""
+        mock_read_text.return_value = datetime(2026, 6, 18, 0, 0, 0, tzinfo=UTC).isoformat()
+        self.run_healthcheck()
+        mock_exit.assert_called_once_with(1)
+
+    def test_empty_file(self, mock_read_text: Mock, mock_exit: Mock):
+        """Test that the collector is unhealthy if the timestamp is missing."""
+        mock_read_text.return_value = ""
+        self.assertRaises(ValueError, self.run_healthcheck)
+        mock_exit.assert_called_once_with(1)

--- a/components/notifier/Dockerfile
+++ b/components/notifier/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv \
 
 USER notifier
 
-HEALTHCHECK CMD ["python", "-c", "from datetime import datetime as dt, timedelta, UTC; import os, sys; sys.exit(dt.now(tz=UTC) - dt.fromisoformat(open(os.environ['HEALTH_CHECK_FILE'], encoding='utf-8').read().strip()) > timedelta(seconds=600))"]
+HEALTHCHECK CMD ["python", "/home/notifier/healthcheck.py"]
 
 COPY components/notifier/src /home/notifier
 

--- a/components/notifier/src/healthcheck.py
+++ b/components/notifier/src/healthcheck.py
@@ -1,0 +1,16 @@
+"""Health check."""
+
+import os
+import pathlib
+import sys
+import tempfile
+from datetime import UTC, datetime, timedelta
+
+health_check_file = os.getenv("HEALTH_CHECK_FILE", str(tempfile.gettempdir() + "/health_check.txt"))
+exit_code = 1
+try:
+    timestamp = pathlib.Path(health_check_file).read_text().strip()
+    last_healthy = datetime.fromisoformat(timestamp)
+    exit_code = 0 if datetime.now(tz=UTC) - last_healthy <= timedelta(seconds=600) else 1
+finally:
+    sys.exit(exit_code)

--- a/components/notifier/tests/test_healthcheck.py
+++ b/components/notifier/tests/test_healthcheck.py
@@ -1,0 +1,39 @@
+"""Unit tests for the notifier healthcheck script."""
+
+import sys
+import unittest
+from datetime import UTC, datetime
+from unittest.mock import Mock, patch
+
+
+@patch("sys.exit")
+@patch("pathlib.Path.read_text")
+class NotifierHealthcheckTestCase(unittest.TestCase):
+    """Unit tests for the notifier healthcheck."""
+
+    def run_healthcheck(self) -> None:
+        """Run the healthcheck."""
+        import healthcheck  # noqa: F401,PLC0415
+
+    def tearDown(self) -> None:
+        """Remove the healthcheck module."""
+        if "healthcheck" in sys.modules:
+            del sys.modules["healthcheck"]
+
+    def test_healthy(self, mock_read_text: Mock, mock_exit: Mock):
+        """Test that the notifier is healthy if the timestamp is recent."""
+        mock_read_text.return_value = datetime.now(tz=UTC).isoformat()
+        self.run_healthcheck()
+        mock_exit.assert_called_once_with(0)
+
+    def test_unhealthy(self, mock_read_text: Mock, mock_exit: Mock):
+        """Test that the notifier is unhealthy if the timestamp is old."""
+        mock_read_text.return_value = datetime(2026, 6, 18, 0, 0, 0, tzinfo=UTC).isoformat()
+        self.run_healthcheck()
+        mock_exit.assert_called_once_with(1)
+
+    def test_empty_file(self, mock_read_text: Mock, mock_exit: Mock):
+        """Test that the notifier is unhealthy if the timestamp is missing."""
+        mock_read_text.return_value = ""
+        self.assertRaises(ValueError, self.run_healthcheck)
+        mock_exit.assert_called_once_with(1)

--- a/helm/templates/collector.yaml
+++ b/helm/templates/collector.yaml
@@ -56,8 +56,7 @@ spec:
             exec:
               command:
                 - python
-                - -c
-                - "from datetime import datetime as dt, timedelta, UTC; import os, sys; sys.exit(dt.now(tz=UTC) - dt.fromisoformat(open(os.environ['HEALTH_CHECK_FILE'], encoding='utf-8').read().strip()) > timedelta(seconds=600))"
+                - healthcheck.py
             initialDelaySeconds: 10
             periodSeconds: 30
             timeoutSeconds: 10

--- a/helm/templates/notifier.yaml
+++ b/helm/templates/notifier.yaml
@@ -56,8 +56,7 @@ spec:
             exec:
               command:
                 - python
-                - -c
-                - "from datetime import datetime as dt, timedelta, UTC; import os, sys; sys.exit(dt.now(tz=UTC) - dt.fromisoformat(open(os.environ['HEALTH_CHECK_FILE'], encoding='utf-8').read().strip()) > timedelta(seconds=600))"
+                - healthcheck.py
             initialDelaySeconds: 10
             periodSeconds: 30
             timeoutSeconds: 10


### PR DESCRIPTION
Move the collector and notifier healthcheck from inline Python code to a separate script so all three Python components have the same HEALTHCHECK command in their Dockerfile.

Closes #13533.