### PR TITLE
Fix missing Dependency-Track vulnerability info

### DIFF
--- a/components/collector/src/source_collectors/dependency_track/security_warnings.py
+++ b/components/collector/src/source_collectors/dependency_track/security_warnings.py
@@ -1,6 +1,6 @@
 """Dependency-Track security warnings collector."""
 
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from base_collectors import SecurityWarningsSourceCollector
 from collector_utilities.type import URL
@@ -23,8 +23,8 @@ class DependencyTrackVulnerability(TypedDict):
     """Vulnerability as returned by Dependency-Track."""
 
     vulnId: str
-    description: str
-    severity: str
+    description: NotRequired[str]
+    severity: NotRequired[str]
 
 
 class DependencyTrackFinding(TypedDict):
@@ -66,7 +66,7 @@ class DependencyTrackSecurityWarnings(SecurityWarningsSourceCollector, Dependenc
         return Entity(
             component=component["name"],
             component_landing_url=f"{landing_url}/components/{component['uuid']}",
-            description=vulnerability["description"],
+            description=vulnerability.get("description", ""),
             identifier=vulnerability["vulnId"],
             key=finding["matrix"],  # Matrix is a combination of project, component, and vulnerability
             latest=latest_version,
@@ -74,6 +74,6 @@ class DependencyTrackSecurityWarnings(SecurityWarningsSourceCollector, Dependenc
             project=self._projects[project_uuid]["name"],
             project_landing_url=f"{landing_url}/projects/{project_uuid}",
             project_version=self._projects[project_uuid].get("version", ""),
-            severity=vulnerability["severity"].capitalize(),
+            severity=vulnerability.get("severity", "UNASSIGNED").capitalize(),
             version=current_version,
         )

--- a/components/collector/tests/source_collectors/dependency_track/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/dependency_track/test_security_warnings.py
@@ -1,5 +1,7 @@
 """Unit tests for the Dependency-Track security warnings collector."""
 
+from typing import TYPE_CHECKING
+
 from aiohttp import BasicAuth
 
 from source_collectors.dependency_track.base import DependencyTrackBase
@@ -11,14 +13,27 @@ from source_collectors.dependency_track.security_warnings import (
 
 from .base_test import DependencyTrackTestCase
 
+if TYPE_CHECKING:
+    from model.measurement import MetricMeasurement
+    from source_collectors.dependency_track.json_types import DependencyTrackProject
+
 
 class DependencyTrackSecurityWarningsTest(DependencyTrackTestCase):
     """Unit tests for the Dependency-Track security warnings collector."""
 
     METRIC_TYPE = "security_warnings"
 
-    def findings(self) -> list[DependencyTrackFinding]:
-        """Create the Dependency-Track findings fixture."""
+    def findings(
+        self,
+        description: str | None = "description",
+        severity: str | None = "UNASSIGNED",
+    ) -> list[DependencyTrackFinding]:
+        """Create the Dependency-Track findings fixture. Pass None to omit the description or severity."""
+        vulnerability = DependencyTrackVulnerability(vulnId="CVE-123")
+        if description is not None:
+            vulnerability["description"] = description
+        if severity is not None:
+            vulnerability["severity"] = severity
         return [
             DependencyTrackFinding(
                 component=DependencyTrackComponent(
@@ -29,21 +44,17 @@ class DependencyTrackSecurityWarningsTest(DependencyTrackTestCase):
                     version="1",
                 ),
                 matrix="matrix",
-                vulnerability=DependencyTrackVulnerability(
-                    description="vulnerability description",
-                    severity="UNASSIGNED",
-                    vulnId="CVE-123",
-                ),
+                vulnerability=vulnerability,
             ),
         ]
 
-    def entities(self) -> list[dict[str, str]]:
+    def entities(self, description: str = "description", severity: str = "Unassigned") -> list[dict[str, str]]:
         """Create the expected entities."""
         return [
             {
                 "component": "component name",
                 "component_landing_url": f"{self.landing_url}/components/component-uuid",
-                "description": "vulnerability description",
+                "description": description,
                 "identifier": "CVE-123",
                 "key": "matrix",
                 "latest": "2",
@@ -51,10 +62,23 @@ class DependencyTrackSecurityWarningsTest(DependencyTrackTestCase):
                 "project": "project name",
                 "project_landing_url": f"{self.landing_url}/projects/project uuid",
                 "project_version": "1.4",
-                "severity": "Unassigned",
+                "severity": severity,
                 "version": "1",
             },
         ]
+
+    async def collect_findings(
+        self,
+        projects: list[DependencyTrackProject] | None = None,
+        findings: list[DependencyTrackFinding] | None = None,
+    ) -> MetricMeasurement:
+        """Collect a measurement for the given projects and findings, defaulting to the fixtures."""
+        return await self.collect_measurement(
+            get_request_json_side_effect=[
+                self.projects() if projects is None else projects,
+                self.findings() if findings is None else findings,
+            ],
+        )
 
     async def test_no_projects(self):
         """Test that an error is thrown if there are no projects."""
@@ -63,93 +87,107 @@ class DependencyTrackSecurityWarningsTest(DependencyTrackTestCase):
 
     async def test_one_project_without_vulnerabilities(self):
         """Test one project without vulnerabilities."""
-        measurement = await self.collect_measurement(get_request_json_side_effect=[self.projects(), []])
+        measurement = await self.collect_findings(findings=[])
         self.assert_measurement(measurement, value="0", entities=[])
 
     async def test_one_project_with_vulnerabilities(self):
         """Test one project with vulnerabilities."""
-        measurement = await self.collect_measurement(get_request_json_side_effect=[self.projects(), self.findings()])
+        measurement = await self.collect_findings()
+        self.assert_measurement(measurement, value="1", entities=self.entities())
+
+    async def test_vulnerability_without_description(self):
+        """Test that a vulnerability without a description does not cause a failure."""
+        measurement = await self.collect_findings(findings=self.findings(description=None))
+        self.assert_measurement(measurement, value="1", entities=self.entities(description=""))
+
+    async def test_vulnerability_without_severity(self):
+        """Test that a vulnerability without a severity does not cause a failure."""
+        measurement = await self.collect_findings(findings=self.findings(severity=None))
         self.assert_measurement(measurement, value="1", entities=self.entities())
 
     async def test_filter_by_severity(self):
-        """Test that vulnerabilities can be filtered."""
+        """Test that vulnerabilities can be filtered out by severity."""
         self.set_source_parameter("severities", ["High", "Critical"])
-        measurement = await self.collect_measurement(get_request_json_side_effect=[self.projects(), self.findings()])
+        measurement = await self.collect_findings()
         self.assert_measurement(measurement, value="0", entities=[])
+
+    async def test_filter_by_matching_severity(self):
+        """Test that vulnerabilities with a matching severity are included."""
+        self.set_source_parameter("severities", ["High", "Critical"])
+        measurement = await self.collect_findings(findings=self.findings(severity="HIGH"))
+        self.assert_measurement(measurement, value="1", entities=self.entities(severity="High"))
 
     async def test_filter_by_project_name(self):
         """Test filtering projects by name."""
         self.set_source_parameter("project_names", ["project name"])
-        measurement = await self.collect_measurement(get_request_json_side_effect=[self.projects(), self.findings()])
+        measurement = await self.collect_findings()
         self.assert_measurement(measurement, value="1", entities=self.entities())
 
     async def test_filter_by_project_name_without_match(self):
         """Test filtering projects by name."""
         self.set_source_parameter("project_names", ["other project"])
-        measurement = await self.collect_measurement(get_request_json_side_effect=[self.projects(), self.findings()])
+        measurement = await self.collect_findings()
         self.assert_no_projects_found(measurement)
 
     async def test_filter_by_project_regular_expression(self):
         """Test filtering projects by regular expression."""
         self.set_source_parameter("project_names", ["project .*"])
-        measurement = await self.collect_measurement(get_request_json_side_effect=[self.projects(), self.findings()])
+        measurement = await self.collect_findings()
         self.assert_measurement(measurement, value="1", entities=self.entities())
 
     async def test_filter_by_project_version(self):
         """Test filtering projects by version."""
         self.set_source_parameter("project_versions", ["1.2", "1.3", "1.4"])
-        measurement = await self.collect_measurement(get_request_json_side_effect=[self.projects(), self.findings()])
+        measurement = await self.collect_findings()
         self.assert_measurement(measurement, value="1", entities=self.entities())
 
     async def test_filter_by_project_version_without_match(self):
         """Test filtering projects by version."""
         self.set_source_parameter("project_versions", ["1.2", "1.3"])
-        measurement = await self.collect_measurement(get_request_json_side_effect=[self.projects(), self.findings()])
+        measurement = await self.collect_findings()
         self.assert_no_projects_found(measurement)
 
     async def test_filter_by_project_name_and_version(self):
         """Test filtering projects by name and version."""
         self.set_source_parameter("project_names", ["project .*"])
         self.set_source_parameter("project_versions", ["1.3", "1.4"])
-        measurement = await self.collect_measurement(get_request_json_side_effect=[self.projects(), self.findings()])
+        measurement = await self.collect_findings()
         self.assert_measurement(measurement, value="1", entities=self.entities())
 
     async def test_filter_by_latest_project(self):
         """Test that projects can be filtered by being the latest project version."""
         self.set_source_parameter("only_include_latest_project_versions", "yes")
-        measurement = await self.collect_measurement(
-            get_request_json_side_effect=[self.projects(is_latest=True), self.findings()]
-        )
+        measurement = await self.collect_findings(projects=self.projects(is_latest=True))
         self.assert_measurement(measurement, value="1", entities=self.entities())
 
     async def test_filter_by_latest_project_without_match(self):
         """Test that projects can be filtered by being the latest project version."""
         self.set_source_parameter("only_include_latest_project_versions", "yes")
-        measurement = await self.collect_measurement(get_request_json_side_effect=[self.projects(), self.findings()])
+        measurement = await self.collect_findings()
         self.assert_no_projects_found(measurement)
 
     async def test_include_by_component_name(self):
         """Test filtering by component name."""
         self.set_source_parameter("components_to_include", ["other component"])
-        measurement = await self.collect_measurement(get_request_json_side_effect=[self.projects(), self.findings()])
+        measurement = await self.collect_findings()
         self.assert_measurement(measurement, value="0", entities=[])
 
     async def test_include_by_component_name_regular_expression(self):
         """Test filtering by component name regular expression."""
         self.set_source_parameter("components_to_include", ["component.*"])
-        measurement = await self.collect_measurement(get_request_json_side_effect=[self.projects(), self.findings()])
+        measurement = await self.collect_findings()
         self.assert_measurement(measurement, value="1", entities=self.entities())
 
     async def test_exclude_by_component_name(self):
         """Test filtering by component name."""
         self.set_source_parameter("components_to_ignore", ["component name"])
-        measurement = await self.collect_measurement(get_request_json_side_effect=[self.projects(), self.findings()])
+        measurement = await self.collect_findings()
         self.assert_measurement(measurement, value="0", entities=[])
 
     async def test_exclude_by_component_name_regular_expression(self):
         """Test filtering by component name regular expression."""
         self.set_source_parameter("components_to_ignore", ["other.*"])
-        measurement = await self.collect_measurement(get_request_json_side_effect=[self.projects(), self.findings()])
+        measurement = await self.collect_findings()
         self.assert_measurement(measurement, value="1", entities=self.entities())
 
     async def test_api_key(self):

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -29,6 +29,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - When using GitLab as source for the 'failed jobs' metric, instead of asking GitLab for only failed jobs, fetch all jobs within the look-back period and then filter them for status so that jobs that first fail and then pass are not reported as failed. Fixes [#13478](https://github.com/ICTU/quality-time/issues/13478).
 - Show the singular version of the metric unit when the measurement value is one. Note: when multiple dates are shown, the plural version of the unit is used regardless of the measurement values. Fixes [#13479](https://github.com/ICTU/quality-time/issues/13479).
+- When using Dependency-Track as source for the 'security warnings' metric, don't fail when a vulnerability has no description or severity. Fixes [#13608](https://github.com/ICTU/quality-time/issues/13608).
 
 ## v5.56.0 - 2026-06-11
 


### PR DESCRIPTION
When using Dependency-Track as source for the 'security warnings' metric, don't fail when a vulnerability has no description or severity.

Fixes #13608.