### PR TITLE
Fix `just start-hybrid`

### DIFF
--- a/tools/just/deploy.just
+++ b/tools/just/deploy.just
@@ -20,7 +20,7 @@ start-docker-component mode *components:
 [private]
 start-py-component mode="attach": install-py-dependencies
     ?[ {{ pyproject_toml_exists }} = true ]
-    {{ python }} src/quality_time*.py {{ record_pid(mode) }}
+    {{ python }} src/main.py {{ record_pid(mode) }}
 
 # Start the JavaScript component.
 [no-cd]


### PR DESCRIPTION
Running `just start-hybrid` would not start the Python components due to a recent rename of the main scripts not having been applied to the justfile.

Thanks @wbahadoer for the fix.