### PR TITLE
Truncate long titles on the dashboard cards

### DIFF
--- a/components/frontend/src/dashboard/DashboardCard.jsx
+++ b/components/frontend/src/dashboard/DashboardCard.jsx
@@ -1,15 +1,48 @@
-import { Card, CardActionArea, CardContent, CardHeader } from "@mui/material"
+import { Card, CardActionArea, CardContent, CardHeader, Tooltip } from "@mui/material"
 import { bool, element, func, oneOfType, string } from "prop-types"
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react"
 
 import { childrenPropType } from "../sharedPropTypes"
 
 export function DashboardCard({ children, onClick, selected, title, titleFirst }) {
     const color = selected ? "info.main" : "divider"
-    const header = (
+    const titleRef = useRef(null)
+    const [isTruncated, setIsTruncated] = useState(false)
+    const measureTitle = useCallback(() => {
+        const el = titleRef.current
+        const truncated = Boolean(el) && el.scrollWidth > el.clientWidth
+        // Measuring truncation requires reading the laid-out DOM and updating state; the guard keeps it to a single
+        // extra render, only when the truncation actually changes.
+        // eslint-disable-next-line @eslint-react/set-state-in-effect -- intentional measure-then-set, guarded above
+        setIsTruncated((wasTruncated) => (wasTruncated === truncated ? wasTruncated : truncated))
+    }, [])
+    // Recompute after each render (e.g. when the title changes) and whenever the window is resized.
+    useLayoutEffect(measureTitle)
+    useEffect(() => {
+        globalThis.addEventListener("resize", measureTitle)
+        globalThis.addEventListener("fullscreenchange", measureTitle)
+        return () => {
+            globalThis.removeEventListener("resize", measureTitle)
+            globalThis.removeEventListener("fullscreenchange", measureTitle)
+        }
+    }, [measureTitle])
+    const cardHeader = (
         <CardHeader
             title={title}
-            // The selected class is for test purposes only
-            slotProps={{ title: { className: selected ? "selected" : "", noWrap: true, variant: "h6" } }}
+            slotProps={{
+                // The selected class is for test purposes only.
+                title: {
+                    className: selected ? "selected" : "",
+                    noWrap: true,
+                    ref: titleRef,
+                    variant: "h6",
+                    // Hide Safari's native tooltip on truncated text (it ignores an empty title); the MUI tooltip
+                    // below replaces it with consistent cross-browser behavior. The card stays clickable because the
+                    // CardActionArea ancestor still receives the events that fall through the title.
+                    sx: { pointerEvents: "none" },
+                },
+                content: { sx: { minWidth: 0 } }, // Without min-width: 0 the title overflows instead of truncating
+            }}
             sx={{
                 padding: "0px",
                 paddingTop: titleFirst ? "10px" : "0px",
@@ -18,6 +51,16 @@ export function DashboardCard({ children, onClick, selected, title, titleFirst }
             }}
         />
     )
+    // Long titles are truncated with an ellipsis (noWrap); show the full title in a tooltip, but only when it's a
+    // string that is actually truncated, so cards with short titles don't get a redundant tooltip.
+    const header =
+        typeof title === "string" && isTruncated ? (
+            <Tooltip placement="top" title={title}>
+                <div>{cardHeader}</div>
+            </Tooltip>
+        ) : (
+            cardHeader
+        )
     // The components below get a height of 100% to make sure they fill the available space of their container
     return (
         <Card

--- a/components/frontend/src/dashboard/DashboardCard.test.jsx
+++ b/components/frontend/src/dashboard/DashboardCard.test.jsx
@@ -1,0 +1,69 @@
+import { ThemeProvider } from "@mui/material/styles"
+import { act, render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { vi } from "vitest"
+
+import { expectNoAccessibilityViolations } from "../testUtils"
+import { theme } from "../theme"
+import { DashboardCard } from "./DashboardCard"
+
+function renderDashboardCard(props = {}) {
+    return render(
+        <ThemeProvider theme={theme}>
+            <DashboardCard title="Card title" {...props}>
+                <div>Card contents</div>
+            </DashboardCard>
+        </ThemeProvider>,
+    )
+}
+
+// jsdom does not do layout, so fake every element being wider than its container and trigger a re-measure.
+function fakeTruncation() {
+    vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(200)
+    vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(100)
+    act(() => {
+        globalThis.dispatchEvent(new Event("resize"))
+    })
+}
+
+// The title has pointer-events: none (to suppress Safari's native tooltip), so hover the card header instead, which
+// lets the event bubble to the MUI tooltip wrapper.
+function hoverHeader(text) {
+    return userEvent.hover(screen.getByText(text).closest(".MuiCardHeader-root"))
+}
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+it("shows the title", () => {
+    renderDashboardCard()
+    expect(screen.getByText("Card title")).toBeInTheDocument()
+})
+
+it("does not show a tooltip when the title fits", async () => {
+    renderDashboardCard({ title: "Short" })
+    await hoverHeader("Short")
+    expect(screen.queryByRole("tooltip")).toBeNull()
+})
+
+it("shows a tooltip with the full title when the title is truncated", async () => {
+    const longTitle = "A very long subject title that does not fit on a single line in the card"
+    renderDashboardCard({ title: longTitle })
+    fakeTruncation()
+    await hoverHeader(longTitle)
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(longTitle)
+})
+
+it("does not show a tooltip when the title is not a string", async () => {
+    const elementTitle = "Element title"
+    renderDashboardCard({ title: <span>{elementTitle}</span> })
+    fakeTruncation()
+    await hoverHeader(elementTitle)
+    expect(screen.queryByRole("tooltip")).toBeNull()
+})
+
+it("has no accessibility violations", async () => {
+    const { container } = renderDashboardCard()
+    await expectNoAccessibilityViolations(container)
+})

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -30,6 +30,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 - When using GitLab as source for the 'failed jobs' metric, instead of asking GitLab for only failed jobs, fetch all jobs within the look-back period and then filter them for status so that jobs that first fail and then pass are not reported as failed. Fixes [#13478](https://github.com/ICTU/quality-time/issues/13478).
 - Show the singular version of the metric unit when the measurement value is one. Note: when multiple dates are shown, the plural version of the unit is used regardless of the measurement values. Fixes [#13479](https://github.com/ICTU/quality-time/issues/13479).
 - When using Dependency-Track as source for the 'security warnings' metric, don't fail when a vulnerability has no description or severity. Fixes [#13608](https://github.com/ICTU/quality-time/issues/13608).
+- Truncate long titles on the dashboard cards with an ellipsis. The full title is shown in a tooltip on hover. Fixes [#10841](https://github.com/ICTU/quality-time/issues/10841).
 
 ## v5.56.0 - 2026-06-11
 

--- a/tools/just/deploy.just
+++ b/tools/just/deploy.just
@@ -65,7 +65,7 @@ stop-docker-component *components:
     ?[ {{ docker_folder_exists }} = true ]
     docker compose stop {{ components }}
 
-# Stop one or more component(s).
+# Stop one or more component(s). Run `just help stop` for more information.
 [arg("all", long="all", short="a", value="all", help="Also stop the local processes started by `just start-hybrid`")]
 stop all="" *components: stop-component (stop-docker-component components)
     {{ if all == "all" { "just stop-app-folders" } else { "" } }}


### PR DESCRIPTION
Truncate long titles on the dashboard cards with an ellipsis. The full title is shown in a tooltip on hover.

Fixes #10841.