### PR TITLE
Make update dependencies script stand-alone

### DIFF
--- a/tools/just/dependencies.just
+++ b/tools/just/dependencies.just
@@ -2,17 +2,9 @@ import 'utils.just'
 
 # === Update dependencies ===
 
-# Update dependencies of type.
-[private]
-update dependency_type:
-    {{ uv_run }} --project tools/update_dependencies tools/update_dependencies/src/update_{{ dependency_type }}.py
-
 # Update direct and indirect dependencies. Set GITHUB_TOKEN, DOCKER_HUB_USERNAME, and DOCKER_HUB_TOKEN to prevent hitting rate limits.
-[parallel]
-update-dependencies: (update "dockerfile_base_image") (update "pyproject_toml") (update "github_action") (update "circle_ci_config") (update "manifest_images") (update "jsdelivr")
-    # node_engine and package_json both rewrite the package.json files, so they run sequentially here (not as parallel dependencies) to avoid concurrent writes to the same files.
-    just update "node_engine"
-    just update "package_json"
+update-dependencies:
+    {{ uv_run }} --project tools/update_dependencies tools/update_dependencies/src/update.py
 
 alias update-deps := update-dependencies
 

--- a/tools/update_dependencies/src/update.py
+++ b/tools/update_dependencies/src/update.py
@@ -1,0 +1,38 @@
+"""Update all dependencies by running the individual updater scripts."""
+
+import subprocess  # nosec B404
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+SRC = Path(__file__).parent
+
+# These scripts update different files, so they can run concurrently.
+PARALLEL_SCRIPTS = (
+    "dockerfile_base_image",
+    "pyproject_toml",
+    "github_action",
+    "circle_ci_config",
+    "manifest_images",
+    "jsdelivr",
+)
+# node_engine and package_json both rewrite the package.json files, so they run sequentially (after the
+# parallel scripts and after each other) to avoid concurrent writes to the same files.
+SEQUENTIAL_SCRIPTS = ("node_engine", "package_json")
+
+
+def run_script(name: str) -> int:
+    """Run the updater script with the given name and return its exit code."""
+    return subprocess.run([sys.executable, str(SRC / f"update_{name}.py")], check=False).returncode  # noqa: S603 # nosec: B603
+
+
+def update_dependencies() -> int:
+    """Run all updater scripts and return the highest exit code."""
+    with ThreadPoolExecutor() as executor:
+        results = list(executor.map(run_script, PARALLEL_SCRIPTS))
+    results.extend(run_script(name) for name in SEQUENTIAL_SCRIPTS)
+    return max(results, default=0)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(update_dependencies())

--- a/tools/update_dependencies/src/update_jsdelivr.py
+++ b/tools/update_dependencies/src/update_jsdelivr.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import requests
 from packaging.version import InvalidVersion, Version
 
+from filesystem import glob
 from log import get_logger
 from npmjs import get_publication_datetime
 from version import DependencyVersion
@@ -68,11 +69,16 @@ def update_jsdelivr(content: str) -> str:
     return JSDELIVR_RE.sub(replace, content)
 
 
+def update_jsdelivrs() -> int:
+    """Find the Sphinx config files under docs/ and update the jsDelivr URLs in them."""
+    for sphinx_config_py in glob("conf.py", start=Path.cwd() / "docs"):
+        LOG.path(sphinx_config_py)
+        old_content = sphinx_config_py.read_text()
+        new_content = update_jsdelivr(old_content)
+        if new_content != old_content:
+            sphinx_config_py.write_text(new_content)
+    return 0
+
+
 if __name__ == "__main__":  # pragma: no cover
-    sphinx_config_py = Path.cwd() / "docs" / "src" / "conf.py"
-    LOG.path(sphinx_config_py)
-    old_content = sphinx_config_py.read_text()
-    new_content = update_jsdelivr(old_content)
-    if new_content != old_content:
-        sphinx_config_py.write_text(new_content)
-    sys.exit(0)
+    sys.exit(update_jsdelivrs())

--- a/tools/update_dependencies/tests/test_update.py
+++ b/tools/update_dependencies/tests/test_update.py
@@ -1,0 +1,41 @@
+"""Unit tests for the update script that runs all updater scripts."""
+
+import unittest
+from unittest.mock import Mock, call, patch
+
+from update import PARALLEL_SCRIPTS, SEQUENTIAL_SCRIPTS, run_script, update_dependencies
+
+
+@patch("subprocess.run")
+class UpdateTest(unittest.TestCase):
+    """Unit tests for the update_dependencies function."""
+
+    def test_run_script(self, mock_run: Mock):
+        """Test that a script is run and its exit code is returned."""
+        mock_run.return_value = Mock(returncode=0)
+        self.assertEqual(0, run_script("dockerfile_base_image"))
+        args = mock_run.call_args.args[0]
+        self.assertEqual("update_dockerfile_base_image.py", args[-1].split("/")[-1])
+
+    def test_all_scripts_are_run(self, mock_run: Mock):
+        """Test that all updater scripts are run, the parallel ones before the sequential ones."""
+        mock_run.return_value = Mock(returncode=0)
+        self.assertEqual(0, update_dependencies())
+        scripts_run = [run_call.args[0][-1].split("/")[-1] for run_call in mock_run.call_args_list]
+        expected = [f"update_{name}.py" for name in (*PARALLEL_SCRIPTS, *SEQUENTIAL_SCRIPTS)]
+        self.assertEqual(sorted(expected), sorted(scripts_run))
+        self.assertEqual([f"update_{name}.py" for name in SEQUENTIAL_SCRIPTS], scripts_run[-len(SEQUENTIAL_SCRIPTS) :])
+
+    def test_sequential_scripts_run_in_order(self, mock_run: Mock):
+        """Test that the sequential scripts run after the parallel ones, node_engine before package_json."""
+        mock_run.return_value = Mock(returncode=0)
+        update_dependencies()
+        self.assertEqual(
+            [call("update_node_engine.py"), call("update_package_json.py")],
+            [call(run_call.args[0][-1].split("/")[-1]) for run_call in mock_run.call_args_list[-2:]],
+        )
+
+    def test_highest_exit_code_is_returned(self, mock_run: Mock):
+        """Test that the highest exit code of all scripts is returned."""
+        mock_run.return_value = Mock(returncode=1)
+        self.assertEqual(1, update_dependencies())

--- a/tools/update_dependencies/tests/test_update_jsdelivr.py
+++ b/tools/update_dependencies/tests/test_update_jsdelivr.py
@@ -3,10 +3,10 @@
 import unittest
 from unittest.mock import ANY, Mock, patch
 
-from update_jsdelivr import get_latest_version, update_jsdelivr
+from update_jsdelivr import get_latest_version, update_jsdelivr, update_jsdelivrs
 
 from .fixtures import HASH1, HASH2
-from .helpers import assert_new_version_logged, mock_response
+from .helpers import assert_new_version_logged, assert_path_logged, mock_path, mock_response
 
 # A flat package listing as returned by the jsDelivr API with the ?structure=flat query parameter.
 FLAT_FILES = {"default": "/dist/clipboard.min.js", "files": [{"name": "/dist/clipboard.min.js", "hash": HASH2}]}
@@ -94,4 +94,41 @@ class UpdateJsdelivrTest(unittest.TestCase):
             mock_response({"time": {"2.0.11": "20260530T10:14:40.567Z"}}),
         ]
         self.assertEqual(CONF, update_jsdelivr(CONF))
+        mock_warning.assert_not_called()
+
+
+@patch("logging.Logger.warning")
+@patch("logging.Logger.info")
+@patch("pathlib.Path.rglob")
+@patch("requests.get")
+class UpdateJsdelivrsTest(unittest.TestCase):
+    """Unit tests for discovering and updating the Sphinx config files under docs/."""
+
+    def test_changes(self, mock_get: Mock, mock_glob: Mock, mock_info: Mock, mock_warning: Mock):
+        """Test that a discovered Sphinx config is updated when a new version is available."""
+        mock_get.side_effect = [
+            mock_response({"tags": {"latest": "2.0.12"}}),
+            mock_response(FLAT_FILES),
+            mock_response({"time": {"2.0.12": "20260530T10:14:40.567Z"}}),
+        ]
+        mock_conf = mock_path(CONF)
+        mock_glob.return_value = [mock_conf]
+        self.assertEqual(0, update_jsdelivrs())
+        written = mock_conf.write_text.call_args.args[0]
+        self.assertIn("clipboard@2.0.12/dist/clipboard.min.js", written)
+        self.assertIn(f'"integrity": "sha256-{HASH2}"', written)
+        assert_path_logged(mock_info, mock_conf.relative_to())
+        assert_new_version_logged(mock_warning, "clipboard", ANY, ANY)
+
+    def test_no_changes(self, mock_get: Mock, mock_glob: Mock, mock_info: Mock, mock_warning: Mock):
+        """Test that a discovered Sphinx config is not rewritten when there is no new version."""
+        mock_get.side_effect = [
+            mock_response({"tags": {"latest": "2.0.11"}}),
+            mock_response({"time": {"2.0.11": "20260530T10:14:40.567Z"}}),
+        ]
+        mock_conf = mock_path(CONF)
+        mock_glob.return_value = [mock_conf]
+        self.assertEqual(0, update_jsdelivrs())
+        mock_conf.write_text.assert_not_called()
+        assert_path_logged(mock_info, mock_conf.relative_to())
         mock_warning.assert_not_called()


### PR DESCRIPTION
Remove the dependency on just for running the different update scripts in preparation of moving the update script(s) to its own repository.