### PR TITLE
Extract ItemSelector component

### DIFF
--- a/components/frontend/src/widgets/ItemSelector.jsx
+++ b/components/frontend/src/widgets/ItemSelector.jsx
@@ -1,0 +1,169 @@
+import {
+    Checkbox,
+    FormControlLabel,
+    FormGroup,
+    MenuItem,
+    MenuList,
+    Popover,
+    Radio,
+    RadioGroup,
+    TextField,
+    Tooltip,
+    Typography,
+} from "@mui/material"
+import { array, arrayOf, bool, func, string } from "prop-types"
+import { useState } from "react"
+
+function FilterCheckbox({ label, filter, setFilter }) {
+    return (
+        <FormControlLabel control={<Checkbox checked={filter} onChange={() => setFilter(!filter)} />} label={label} />
+    )
+}
+FilterCheckbox.propTypes = {
+    label: string,
+    filter: bool,
+    setFilter: func,
+}
+
+function Filters({
+    itemType,
+    allowHidingUnsupportedItems,
+    showUnsupportedItems,
+    setShowUnsupportedItems,
+    allowHidingUsedItems,
+    hideUsedItems,
+    setHideUsedItems,
+    hideUsedItemsScope,
+    setHideUsedItemsScope,
+}) {
+    if (!allowHidingUnsupportedItems && !allowHidingUsedItems) {
+        return null
+    }
+    return (
+        <FormGroup row sx={{ ml: "10px" }}>
+            {allowHidingUnsupportedItems && (
+                <FilterCheckbox
+                    label={`Select from all ${itemType} types`}
+                    filter={showUnsupportedItems}
+                    setFilter={setShowUnsupportedItems}
+                />
+            )}
+            {allowHidingUsedItems && (
+                <>
+                    <FilterCheckbox
+                        label={`Hide ${itemType} types already used in this:`}
+                        filter={hideUsedItems}
+                        setFilter={setHideUsedItems}
+                    />
+                    <RadioGroup
+                        row
+                        value={hideUsedItemsScope}
+                        onChange={(event) => setHideUsedItemsScope(event.target.value)}
+                    >
+                        <FormControlLabel name="report" value="report" control={<Radio />} label="report" />
+                        <FormControlLabel name="subject" value="subject" control={<Radio />} label="subject" />
+                    </RadioGroup>
+                </>
+            )}
+        </FormGroup>
+    )
+}
+Filters.propTypes = {
+    itemType: string,
+    allowHidingUnsupportedItems: bool,
+    showUnsupportedItems: bool,
+    setShowUnsupportedItems: func,
+    allowHidingUsedItems: bool,
+    hideUsedItems: bool,
+    setHideUsedItems: func,
+    hideUsedItemsScope: string,
+    setHideUsedItemsScope: func,
+}
+
+export function ItemSelector({
+    renderAnchor,
+    tooltip,
+    itemSubtypes,
+    itemType,
+    onClick,
+    allItemSubtypes,
+    usedItemSubtypeKeysInReport,
+    usedItemSubtypeKeysInSubject,
+    sort,
+}) {
+    const [anchorEl, setAnchorEl] = useState()
+    const handleMenu = (event) => setAnchorEl(event.currentTarget)
+    const onClickMenuItem = (value) => {
+        onClick(value)
+        setAnchorEl(null)
+    }
+    const [query, setQuery] = useState("") // Search query to filter item subtypes
+    const [showUnsupportedItems, setShowUnsupportedItems] = useState(false) // Show only supported itemSubTypes or also unsupported itemSubTypes?
+    const [hideUsedItems, setHideUsedItems] = useState(false) // Hide itemSubTypes already used?
+    const [hideUsedItemsScope, setHideUsedItemsScope] = useState("report") // Hide itemSubTypes already used in report or subject?
+    let items = showUnsupportedItems ? allItemSubtypes : itemSubtypes
+    let usedItemKeys = hideUsedItemsScope === "report" ? usedItemSubtypeKeysInReport : usedItemSubtypeKeysInSubject
+    if (hideUsedItems) {
+        items = items.filter((item) => !usedItemKeys.includes(item.key))
+    }
+    const options = items.filter((itemSubtype) => itemSubtype.text.toLowerCase().includes(query.toLowerCase()))
+    // Unless specified not to, sort the options:
+    if (sort !== false) {
+        options.sort((a, b) => a.text.localeCompare(b.text))
+    }
+    return (
+        <>
+            <Tooltip title={tooltip} placement="top">
+                {renderAnchor(handleMenu)}
+            </Tooltip>
+            <Popover id="dropdown-menu" anchorEl={anchorEl} onClose={() => setAnchorEl(null)} open={Boolean(anchorEl)}>
+                <TextField
+                    autoFocus
+                    fullWidth
+                    label={`Filter ${itemType} types`}
+                    onChange={(event) => setQuery(event.target.value)}
+                    value={query}
+                    variant="outlined"
+                    sx={{ ml: "10px", mt: "10px", pr: "20px" }}
+                    type="search"
+                />
+                <Filters
+                    itemType={itemType}
+                    allowHidingUnsupportedItems={allItemSubtypes?.length > 0}
+                    showUnsupportedItems={showUnsupportedItems}
+                    setShowUnsupportedItems={setShowUnsupportedItems}
+                    allowHidingUsedItems={usedItemKeys?.length > 0}
+                    hideUsedItems={hideUsedItems}
+                    setHideUsedItems={setHideUsedItems}
+                    hideUsedItemsScope={hideUsedItemsScope}
+                    setHideUsedItemsScope={setHideUsedItemsScope}
+                />
+                <MenuList sx={{ height: "30vh", width: "50vw" }}>
+                    <MenuItem disabled divider>
+                        <Typography variant="button">{`Available ${itemType} types`}</Typography>
+                    </MenuItem>
+                    {options.map((option) => (
+                        <MenuItem
+                            key={option.key}
+                            onClick={() => onClickMenuItem(option.value)}
+                            sx={{ whiteSpace: "wrap" }}
+                        >
+                            {option.content}
+                        </MenuItem>
+                    ))}
+                </MenuList>
+            </Popover>
+        </>
+    )
+}
+ItemSelector.propTypes = {
+    allItemSubtypes: array,
+    itemSubtypes: array,
+    itemType: string,
+    onClick: func,
+    renderAnchor: func,
+    sort: bool,
+    tooltip: string,
+    usedItemSubtypeKeysInReport: arrayOf(string),
+    usedItemSubtypeKeysInSubject: arrayOf(string),
+}

--- a/components/frontend/src/widgets/ItemSelector.test.jsx
+++ b/components/frontend/src/widgets/ItemSelector.test.jsx
@@ -1,0 +1,166 @@
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { vi } from "vitest"
+
+import { asyncClickRole, asyncClickText, expectNoText, expectText } from "../testUtils"
+import { ItemSelector } from "./ItemSelector"
+
+function renderItemSelector({
+    nrItems = 2,
+    totalItems = 10,
+    usedItemKeysInReport = [],
+    usedItemKeysInSubject = [],
+    sort = true,
+} = {}) {
+    const mockCallback = vi.fn()
+    const itemSubtypes = []
+    let allItemSubtypes
+    if (nrItems < totalItems) {
+        allItemSubtypes = []
+        for (const index of Array(totalItems).keys()) {
+            const text = `Sub ${index + 1}`
+            const key = text.toLowerCase()
+            const option = { key: key, text: text, value: key, content: text }
+            allItemSubtypes.push(option)
+            if (index < nrItems) {
+                itemSubtypes.push(option)
+            }
+        }
+    }
+    render(
+        <ItemSelector
+            allItemSubtypes={allItemSubtypes}
+            itemType="foo"
+            itemSubtypes={itemSubtypes.toReversed()} // Pass items in reversed order to test they are sorted correctly
+            onClick={mockCallback}
+            renderAnchor={(handleMenu) => (
+                <button type="button" onClick={handleMenu}>
+                    Add foo
+                </button>
+            )}
+            tooltip="Add a new foo here"
+            usedItemSubtypeKeysInReport={usedItemKeysInReport}
+            usedItemSubtypeKeysInSubject={usedItemKeysInSubject}
+            sort={sort}
+        />,
+    )
+    return mockCallback
+}
+
+test("ItemSelector renders the child anchor", async () => {
+    renderItemSelector()
+    expectText(/Add foo/)
+    expectNoText(/Available/) // Menu is closed until the anchor is clicked
+})
+
+test("ItemSelector mouse navigation", async () => {
+    const mockCallback = renderItemSelector()
+    await asyncClickText(/Add foo/)
+    expect(screen.getByLabelText(/Filter/)).toHaveFocus()
+    await asyncClickText(/Sub 2/)
+    expect(mockCallback).toHaveBeenCalledWith("sub 2")
+})
+
+test("ItemSelector keyboard navigation", async () => {
+    const mockCallback = renderItemSelector()
+    await asyncClickText(/Add foo/)
+    expect(screen.getByLabelText(/Filter/)).toHaveFocus()
+    await act(async () => {
+        fireEvent.keyDown(screen.getByText(/Available/), { key: "ArrowDown" })
+    })
+    await act(async () => {
+        fireEvent.keyDown(screen.getByText(/Available/), { key: "ArrowUp" })
+    })
+    await act(async () => {
+        fireEvent.keyDown(screen.getByText(/Available/), { key: "ArrowDown" })
+    })
+    await act(async () => {
+        fireEvent.keyDown(screen.getByText(/Sub 2/), { key: "Enter" })
+    })
+    expect(mockCallback).toHaveBeenCalledWith("sub 2")
+})
+
+test("ItemSelector is sorted", async () => {
+    renderItemSelector()
+    await asyncClickText(/Add foo/)
+    expect(screen.getAllByText(/Sub/).map((item) => item.innerHTML)).toStrictEqual(["Sub 1", "Sub 2"])
+})
+
+test("ItemSelector is not sorted", async () => {
+    renderItemSelector({ sort: false })
+    await asyncClickText(/Add foo/)
+    expect(screen.getAllByText(/Sub/).map((item) => item.innerHTML)).toStrictEqual(["Sub 2", "Sub 1"])
+})
+
+test("ItemSelector filter one item", async () => {
+    renderItemSelector({ nrItems: 6 })
+    await asyncClickText(/Add foo/)
+    await userEvent.type(screen.getByRole("searchbox"), "Sub 3")
+    expect(screen.getAllByText(/Sub/).map((item) => item.innerHTML)).toStrictEqual(["Sub 3"])
+})
+
+test("ItemSelector filter zero items", async () => {
+    renderItemSelector({ nrItems: 6 })
+    await asyncClickText(/Add foo/)
+    await userEvent.type(screen.getByRole("searchbox"), "FOO{Enter}")
+    expectNoText(/Sub/)
+})
+
+test("ItemSelector select from all items", async () => {
+    const mockCallback = renderItemSelector()
+    await asyncClickText(/Add foo/)
+    await asyncClickRole("checkbox")
+    await asyncClickText(/Sub 3/)
+    expect(mockCallback).toHaveBeenCalledWith("sub 3")
+})
+
+test("ItemSelector hide used items in report", async () => {
+    renderItemSelector({
+        nrItems: 2,
+        totalItems: 3,
+        usedItemKeysInReport: ["sub 1"],
+    })
+    await asyncClickText(/Add foo/)
+    expectText(/Sub 1/)
+    expectText(/Sub 2/)
+    expectNoText(/Sub 3/) // Hidden because it's not supported by the subject type
+    await asyncClickRole("checkbox", "Hide foo types already used in this:")
+    await asyncClickRole("radio", "report")
+    expectNoText(/Sub 1/) // Now hidden because it's already used in the report
+    expectText(/Sub 2/)
+    expectNoText(/Sub 3/) // Still hidden because it's not supported by the subject type
+})
+
+test("ItemSelector hide used items in subject", async () => {
+    renderItemSelector({
+        nrItems: 2,
+        totalItems: 3,
+        usedItemKeysInReport: ["sub 1", "sub 2"],
+        usedItemKeysInSubject: ["sub 2"],
+    })
+    await asyncClickText(/Add foo/)
+    expectText(/Sub 1/)
+    expectText(/Sub 2/)
+    expectNoText(/Sub 3/) // Hidden because it's not supported by the subject type
+    await asyncClickRole("checkbox", "Hide foo types already used in this:")
+    await asyncClickRole("radio", "subject")
+    expectText(/Sub 1/)
+    expectNoText(/Sub 2/) // Now hidden because it's already used in the subject
+    expectNoText(/Sub 3/) // Still hidden because it's not supported by the subject type
+})
+
+test("ItemSelector add all items by keyboard", async () => {
+    const mockCallback = renderItemSelector()
+    await asyncClickText(/Add foo/)
+    await userEvent.type(screen.getByRole("checkbox"), "{Enter}")
+    await asyncClickText(/Sub 3/)
+    expect(mockCallback).toHaveBeenCalledWith("sub 3")
+})
+
+test("ItemSelector menu can be closed without selecting an item", async () => {
+    const mockCallback = renderItemSelector()
+    await asyncClickText(/Add foo/)
+    await userEvent.keyboard("{Escape}")
+    expectNoText(/Sub/)
+    expect(mockCallback).not.toHaveBeenCalled()
+})

--- a/components/frontend/src/widgets/buttons/AddDropdownButton.jsx
+++ b/components/frontend/src/widgets/buttons/AddDropdownButton.jsx
@@ -1,88 +1,9 @@
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown"
-import {
-    Button,
-    Checkbox,
-    FormControlLabel,
-    FormGroup,
-    MenuItem,
-    MenuList,
-    Popover,
-    Radio,
-    RadioGroup,
-    TextField,
-    Tooltip,
-    Typography,
-} from "@mui/material"
+import { Button } from "@mui/material"
 import { array, arrayOf, bool, func, string } from "prop-types"
-import { useState } from "react"
 
 import { AddItemIcon } from "../icons"
-
-function FilterCheckbox({ label, filter, setFilter }) {
-    return (
-        <FormControlLabel control={<Checkbox checked={filter} onChange={() => setFilter(!filter)} />} label={label} />
-    )
-}
-FilterCheckbox.propTypes = {
-    label: string,
-    filter: bool,
-    setFilter: func,
-}
-
-function Filters({
-    itemType,
-    allowHidingUnsupportedItems,
-    showUnsupportedItems,
-    setShowUnsupportedItems,
-    allowHidingUsedItems,
-    hideUsedItems,
-    setHideUsedItems,
-    hideUsedItemsScope,
-    setHideUsedItemsScope,
-}) {
-    if (!allowHidingUnsupportedItems && !allowHidingUsedItems) {
-        return null
-    }
-    return (
-        <FormGroup row sx={{ ml: "10px" }}>
-            {allowHidingUnsupportedItems && (
-                <FilterCheckbox
-                    label={`Select from all ${itemType} types`}
-                    filter={showUnsupportedItems}
-                    setFilter={setShowUnsupportedItems}
-                />
-            )}
-            {allowHidingUsedItems && (
-                <>
-                    <FilterCheckbox
-                        label={`Hide ${itemType} types already used in this:`}
-                        filter={hideUsedItems}
-                        setFilter={setHideUsedItems}
-                    />
-                    <RadioGroup
-                        row
-                        value={hideUsedItemsScope}
-                        onChange={(event) => setHideUsedItemsScope(event.target.value)}
-                    >
-                        <FormControlLabel name="report" value="report" control={<Radio />} label="report" />
-                        <FormControlLabel name="subject" value="subject" control={<Radio />} label="subject" />
-                    </RadioGroup>
-                </>
-            )}
-        </FormGroup>
-    )
-}
-Filters.propTypes = {
-    itemType: string,
-    allowHidingUnsupportedItems: bool,
-    showUnsupportedItems: bool,
-    setShowUnsupportedItems: func,
-    allowHidingUsedItems: bool,
-    hideUsedItems: bool,
-    setHideUsedItems: func,
-    hideUsedItemsScope: string,
-    setHideUsedItemsScope: func,
-}
+import { ItemSelector } from "../ItemSelector"
 
 export function AddDropdownButton({
     itemSubtypes,
@@ -93,71 +14,22 @@ export function AddDropdownButton({
     usedItemSubtypeKeysInSubject,
     sort,
 }) {
-    const [anchorEl, setAnchorEl] = useState()
-    const handleMenu = (event) => setAnchorEl(event.currentTarget)
-    const onClickMenuItem = (value) => {
-        onClick(value)
-        setAnchorEl(null)
-    }
-    const [query, setQuery] = useState("") // Search query to filter item subtypes
-    const [showUnsupportedItems, setShowUnsupportedItems] = useState(false) // Show only supported itemSubTypes or also unsupported itemSubTypes?
-    const [hideUsedItems, setHideUsedItems] = useState(false) // Hide itemSubTypes already used?
-    const [hideUsedItemsScope, setHideUsedItemsScope] = useState("report") // Hide itemSubTypes already used in report or subject?
-    let items = showUnsupportedItems ? allItemSubtypes : itemSubtypes
-    let usedItemKeys = hideUsedItemsScope === "report" ? usedItemSubtypeKeysInReport : usedItemSubtypeKeysInSubject
-    if (hideUsedItems) {
-        items = items.filter((item) => !usedItemKeys.includes(item.key))
-    }
-    const options = items.filter((itemSubtype) => itemSubtype.text.toLowerCase().includes(query.toLowerCase()))
-    // Unless specified not to, sort the options:
-    if (sort !== false) {
-        options.sort((a, b) => a.text.localeCompare(b.text))
-    }
     return (
-        <>
-            <Tooltip title={`Add a new ${itemType} here`} placement="top">
+        <ItemSelector
+            allItemSubtypes={allItemSubtypes}
+            itemSubtypes={itemSubtypes}
+            itemType={itemType}
+            onClick={onClick}
+            renderAnchor={(handleMenu) => (
                 <Button aria-describedby="dropdown-menu" onClick={handleMenu} variant="outlined">
                     <AddItemIcon /> {`Add ${itemType} `} <ArrowDropDownIcon />
                 </Button>
-            </Tooltip>
-            <Popover id="dropdown-menu" anchorEl={anchorEl} onClose={() => setAnchorEl(null)} open={Boolean(anchorEl)}>
-                <TextField
-                    autoFocus
-                    fullWidth
-                    label={`Filter ${itemType} types`}
-                    onChange={(event) => setQuery(event.target.value)}
-                    value={query}
-                    variant="outlined"
-                    sx={{ ml: "10px", mt: "10px", pr: "20px" }}
-                    type="search"
-                />
-                <Filters
-                    itemType={itemType}
-                    allowHidingUnsupportedItems={allItemSubtypes?.length > 0}
-                    showUnsupportedItems={showUnsupportedItems}
-                    setShowUnsupportedItems={setShowUnsupportedItems}
-                    allowHidingUsedItems={usedItemKeys?.length > 0}
-                    hideUsedItems={hideUsedItems}
-                    setHideUsedItems={setHideUsedItems}
-                    hideUsedItemsScope={hideUsedItemsScope}
-                    setHideUsedItemsScope={setHideUsedItemsScope}
-                />
-                <MenuList sx={{ height: "30vh", width: "50vw" }}>
-                    <MenuItem disabled divider>
-                        <Typography variant="button">{`Available ${itemType} types`}</Typography>
-                    </MenuItem>
-                    {options.map((option) => (
-                        <MenuItem
-                            key={option.key}
-                            onClick={() => onClickMenuItem(option.value)}
-                            sx={{ whiteSpace: "wrap" }}
-                        >
-                            {option.content}
-                        </MenuItem>
-                    ))}
-                </MenuList>
-            </Popover>
-        </>
+            )}
+            sort={sort}
+            tooltip={`Add a new ${itemType} here`}
+            usedItemSubtypeKeysInReport={usedItemSubtypeKeysInReport}
+            usedItemSubtypeKeysInSubject={usedItemSubtypeKeysInSubject}
+        />
     )
 }
 AddDropdownButton.propTypes = {

--- a/components/frontend/src/widgets/buttons/AddDropdownButton.test.jsx
+++ b/components/frontend/src/widgets/buttons/AddDropdownButton.test.jsx
@@ -1,154 +1,28 @@
-import { act, fireEvent, render, screen } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
+import { render, screen } from "@testing-library/react"
 import { vi } from "vitest"
 
-import { asyncClickRole, asyncClickText, expectNoText, expectText } from "../../testUtils"
+import { asyncClickText, expectText } from "../../testUtils"
 import { AddDropdownButton } from "./AddDropdownButton"
 
-function renderAddDropdownButton({
-    nrItems = 2,
-    totalItems = 10,
-    usedItemKeysInReport = [],
-    usedItemKeysInSubject = [],
-    sort = true,
-} = {}) {
+function renderAddDropdownButton() {
     const mockCallback = vi.fn()
-    const itemSubtypes = []
-    let allItemSubtypes
-    if (nrItems < totalItems) {
-        allItemSubtypes = []
-        for (const index of Array(totalItems).keys()) {
-            const text = `Sub ${index + 1}`
-            const key = text.toLowerCase()
-            const option = { key: key, text: text, value: key, content: text }
-            allItemSubtypes.push(option)
-            if (index < nrItems) {
-                itemSubtypes.push(option)
-            }
-        }
-    }
-    render(
-        <AddDropdownButton
-            allItemSubtypes={allItemSubtypes}
-            itemType="foo"
-            itemSubtypes={itemSubtypes.toReversed()} // Pass items in reversed order to test they are sorted correctly
-            onClick={mockCallback}
-            usedItemSubtypeKeysInReport={usedItemKeysInReport}
-            usedItemSubtypeKeysInSubject={usedItemKeysInSubject}
-            sort={sort}
-        />,
-    )
+    const itemSubtypes = [
+        { key: "sub 1", text: "Sub 1", value: "sub 1", content: "Sub 1" },
+        { key: "sub 2", text: "Sub 2", value: "sub 2", content: "Sub 2" },
+    ]
+    render(<AddDropdownButton itemType="foo" itemSubtypes={itemSubtypes} onClick={mockCallback} />)
     return mockCallback
 }
 
-test("AddDropdownButton mouse navigation", async () => {
+test("AddDropdownButton shows the add button", () => {
+    renderAddDropdownButton()
+    expectText(/Add foo/)
+})
+
+test("AddDropdownButton opens the menu and selects an item", async () => {
     const mockCallback = renderAddDropdownButton()
     await asyncClickText(/Add foo/)
     expect(screen.getByLabelText(/Filter/)).toHaveFocus()
     await asyncClickText(/Sub 2/)
     expect(mockCallback).toHaveBeenCalledWith("sub 2")
-})
-
-test("AddDropdownButton keyboard navigation", async () => {
-    const mockCallback = renderAddDropdownButton()
-    await asyncClickText(/Add foo/)
-    expect(screen.getByLabelText(/Filter/)).toHaveFocus()
-    await act(async () => {
-        fireEvent.keyDown(screen.getByText(/Available/), { key: "ArrowDown" })
-    })
-    await act(async () => {
-        fireEvent.keyDown(screen.getByText(/Available/), { key: "ArrowUp" })
-    })
-    await act(async () => {
-        fireEvent.keyDown(screen.getByText(/Available/), { key: "ArrowDown" })
-    })
-    await act(async () => {
-        fireEvent.keyDown(screen.getByText(/Sub 2/), { key: "Enter" })
-    })
-    expect(mockCallback).toHaveBeenCalledWith("sub 2")
-})
-
-test("AddDropdownButton is sorted", async () => {
-    renderAddDropdownButton()
-    await asyncClickText(/Add foo/)
-    expect(screen.getAllByText(/Sub/).map((item) => item.innerHTML)).toStrictEqual(["Sub 1", "Sub 2"])
-})
-
-test("AddDropdownButton is not sorted", async () => {
-    renderAddDropdownButton({ sort: false })
-    await asyncClickText(/Add foo/)
-    expect(screen.getAllByText(/Sub/).map((item) => item.innerHTML)).toStrictEqual(["Sub 2", "Sub 1"])
-})
-
-test("AddDropdownButton filter one item", async () => {
-    renderAddDropdownButton({ nrItems: 6 })
-    await asyncClickText(/Add foo/)
-    await userEvent.type(screen.getByRole("searchbox"), "Sub 3")
-    expect(screen.getAllByText(/Sub/).map((item) => item.innerHTML)).toStrictEqual(["Sub 3"])
-})
-
-test("AddDropdownButton filter zero items", async () => {
-    renderAddDropdownButton({ nrItems: 6 })
-    await asyncClickText(/Add foo/)
-    await userEvent.type(screen.getByRole("searchbox"), "FOO{Enter}")
-    expectNoText(/Sub/)
-})
-
-test("AddDropdownButton select from all items", async () => {
-    const mockCallback = renderAddDropdownButton()
-    await asyncClickText(/Add foo/)
-    await asyncClickRole("checkbox")
-    await asyncClickText(/Sub 3/)
-    expect(mockCallback).toHaveBeenCalledWith("sub 3")
-})
-
-test("AddDropdownButton hide used items in report", async () => {
-    renderAddDropdownButton({
-        nrItems: 2,
-        totalItems: 3,
-        usedItemKeysInReport: ["sub 1"],
-    })
-    await asyncClickText(/Add foo/)
-    expectText(/Sub 1/)
-    expectText(/Sub 2/)
-    expectNoText(/Sub 3/) // Hidden because it's not supported by the subject type
-    await asyncClickRole("checkbox", "Hide foo types already used in this:")
-    await asyncClickRole("radio", "report")
-    expectNoText(/Sub 1/) // Now hidden because it's already used in the report
-    expectText(/Sub 2/)
-    expectNoText(/Sub 3/) // Still hidden because it's not supported by the subject type
-})
-
-test("AddDropdownButton hide used items in subject", async () => {
-    renderAddDropdownButton({
-        nrItems: 2,
-        totalItems: 3,
-        usedItemKeysInReport: ["sub 1", "sub 2"],
-        usedItemKeysInSubject: ["sub 2"],
-    })
-    await asyncClickText(/Add foo/)
-    expectText(/Sub 1/)
-    expectText(/Sub 2/)
-    expectNoText(/Sub 3/) // Hidden because it's not supported by the subject type
-    await asyncClickRole("checkbox", "Hide foo types already used in this:")
-    await asyncClickRole("radio", "subject")
-    expectText(/Sub 1/)
-    expectNoText(/Sub 2/) // Now hidden because it's already used in the subject
-    expectNoText(/Sub 3/) // Still hidden because it's not supported by the subject type
-})
-
-test("AddDropdownButton add all items by keyboard", async () => {
-    const mockCallback = renderAddDropdownButton()
-    await asyncClickText(/Add foo/)
-    await userEvent.type(screen.getByRole("checkbox"), "{Enter}")
-    await asyncClickText(/Sub 3/)
-    expect(mockCallback).toHaveBeenCalledWith("sub 3")
-})
-
-test("AddDropdownButton menu can be closed without selecting an item", async () => {
-    const mockCallback = renderAddDropdownButton()
-    await asyncClickText(/Add foo/)
-    await userEvent.keyboard("{Escape}")
-    expectNoText(/Sub/)
-    expect(mockCallback).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
Extract a generic ItemSelector from AddDropdownButton. ItemSelector holds the dropdown/filter/sort logic but no longer hardcodes the anchor: callers pass a render-prop child that receives the menu handler and returns their own anchor element, and the tooltip label is now a required prop. AddDropdownButton becomes a thin wrapper that supplies its button anchor and tooltip.

Prepares for #10688.

Closes #13653.