### PR TITLE
Use item type selector for changing item type

### DIFF
--- a/components/frontend/src/measurement/Overrun.test.jsx
+++ b/components/frontend/src/measurement/Overrun.test.jsx
@@ -1,7 +1,7 @@
-import { render, screen } from "@testing-library/react"
+import { render } from "@testing-library/react"
 
 import { DataModelContext } from "../context/DataModel"
-import { expectNoAccessibilityViolations, expectText } from "../testUtils"
+import { expectNoAccessibilityViolations, expectNoDisplayValue, expectText } from "../testUtils"
 import { Overrun } from "./Overrun"
 
 const dates = [new Date("2020-01-01"), new Date("2020-12-31")]
@@ -32,7 +32,7 @@ it("has no accessibility violations", async () => {
 
 it("renders nothing if there is no overrun", async () => {
     renderOverrun()
-    expect(screen.queryAllByDisplayValue(/days/).length).toBe(0)
+    expectNoDisplayValue(/days/)
 })
 
 it("renders the days overrun if the metric has overrun its deadline", async () => {

--- a/components/frontend/src/metric/MetricConfigurationParameters.jsx
+++ b/components/frontend/src/metric/MetricConfigurationParameters.jsx
@@ -18,7 +18,7 @@ import {
     getMetricUnit,
     getReportTags,
 } from "../utils"
-import { MetricType } from "./MetricType"
+import { MetricTypeSelector } from "./MetricTypeSelector"
 import { Target } from "./Target"
 import { TargetVisualiser } from "./TargetVisualiser"
 
@@ -253,7 +253,13 @@ export function MetricConfigurationParameters({ metric, metricUuid, reload, repo
     return (
         <Grid container spacing={{ xs: 1, sm: 2, md: 3 }} columns={{ xs: 1, sm: 3, md: 3 }}>
             <Grid size={1}>
-                <MetricType metric={metric} metricUuid={metricUuid} reload={reload} subjectType={subject.type} />
+                <MetricTypeSelector
+                    metric={metric}
+                    metricUuid={metricUuid}
+                    reload={reload}
+                    report={report}
+                    subject={subject}
+                />
             </Grid>
             <Grid size={1}>
                 <Stack spacing={{ xs: 1, sm: 1, md: 1 }}>

--- a/components/frontend/src/metric/MetricConfigurationParameters.test.jsx
+++ b/components/frontend/src/metric/MetricConfigurationParameters.test.jsx
@@ -47,7 +47,7 @@ async function renderMetricParameters(scale = "count") {
             <PermissionsContext value={[EDIT_REPORT_PERMISSION]}>
                 <DataModelContext value={dataModel}>
                     <MetricConfigurationParameters
-                        subject={{ type: "subject_type" }}
+                        subject={{ type: "subject_type", metrics: {} }}
                         metric={{
                             type: "violations",
                             scale: scale,
@@ -139,7 +139,7 @@ it("skips the metric unit fields for metrics with the version number scale", asy
         <DataModelContext value={dataModel}>
             <MetricConfigurationParameters
                 report={{ subjects: {} }}
-                subject={{ type: "subject_type" }}
+                subject={{ type: "subject_type", metrics: {} }}
                 metric={{ type: "source_version" }}
                 metricUuid="metric_uuid"
             />

--- a/components/frontend/src/metric/MetricDetails.test.jsx
+++ b/components/frontend/src/metric/MetricDetails.test.jsx
@@ -49,7 +49,7 @@ const report = {
                         },
                     },
                 },
-                metric_uuid2: { name: "Metric 2", sources: {} },
+                metric_uuid2: { name: "Metric 2", sources: {}, type: "violations" },
             },
         },
     },
@@ -73,6 +73,7 @@ function createDataModel({ deprecateSonarQube = false, mandatoryURL = false } = 
         },
         metrics: {
             violations: {
+                name: "Violations",
                 direction: "<",
                 tags: [],
                 sources: ["sonarqube"],

--- a/components/frontend/src/metric/MetricTypeSelector.jsx
+++ b/components/frontend/src/metric/MetricTypeSelector.jsx
@@ -1,13 +1,14 @@
-import { MenuItem, Stack, Typography } from "@mui/material"
+import { Stack, Typography } from "@mui/material"
 import { func, string } from "prop-types"
 import { useContext } from "react"
 
 import { setMetricAttribute } from "../api/metric"
 import { DataModelContext } from "../context/DataModel"
 import { accessGranted, EDIT_REPORT_PERMISSION, PermissionsContext } from "../context/Permissions"
-import { TextField } from "../fields/TextField"
-import { metricPropType } from "../sharedPropTypes"
+import { metricPropType, reportPropType, subjectPropType } from "../sharedPropTypes"
 import { getMetricTypeName, getSubjectTypeMetrics, referenceDocumentationURL } from "../utils"
+import { ItemTypeSelector } from "../widgets/ItemTypeSelector"
+import { ItemTypeSelectorTextField } from "../widgets/ItemTypeSelectorTextField"
 import { ReadTheDocsLink } from "../widgets/ReadTheDocsLink"
 
 export function metricTypeOption(key, metricType) {
@@ -55,43 +56,42 @@ export function usedMetricTypesInReport(report) {
     return Array.from(metricTypes)
 }
 
-export function MetricType({ metric, metricUuid, reload, subjectType }) {
+export function MetricTypeSelector({ metric, metricUuid, reload, report, subject }) {
     const dataModel = useContext(DataModelContext)
     const permissions = useContext(PermissionsContext)
     const disabled = !accessGranted(permissions, [EDIT_REPORT_PERMISSION])
-    const options = metricTypeOptions(dataModel, subjectType)
     const metricType = metric.type
-    const metricTypes = options.map((option) => option.key)
-    if (!metricTypes.includes(metricType)) {
-        options.push(metricTypeOption(metricType, dataModel.metrics[metricType]))
-    }
     const hasExtraDocs = dataModel.metrics[metricType].documentation
     const howToConfigure = ` for ${hasExtraDocs ? "additional " : ""}information on how to configure this metric type.`
     return (
-        <TextField
-            disabled={disabled}
-            helperText={
-                <>
-                    <ReadTheDocsLink url={referenceDocumentationURL(getMetricTypeName(metric, dataModel))} />
-                    {howToConfigure}
-                </>
-            }
-            label="Metric type"
-            onChange={(value) => setMetricAttribute(metricUuid, "type", value, reload)}
-            select
-            value={metricType}
-        >
-            {options.map((option) => (
-                <MenuItem key={option.key} value={option.value}>
-                    {option.content}
-                </MenuItem>
-            ))}
-        </TextField>
+        <ItemTypeSelector
+            allItemSubtypes={allMetricTypeOptions(dataModel)}
+            itemSubtypes={metricTypeOptions(dataModel, subject.type)}
+            itemType="metric"
+            onClick={(value) => setMetricAttribute(metricUuid, "type", value, reload)}
+            renderAnchor={(handleMenu) => (
+                <ItemTypeSelectorTextField
+                    disabled={disabled}
+                    handleMenu={handleMenu}
+                    helperText={
+                        <>
+                            <ReadTheDocsLink url={referenceDocumentationURL(getMetricTypeName(metric, dataModel))} />
+                            {howToConfigure}
+                        </>
+                    }
+                    label="Metric type"
+                    value={getMetricTypeName(metric, dataModel)}
+                />
+            )}
+            usedItemSubtypeKeysInReport={usedMetricTypesInReport(report)}
+            usedItemSubtypeKeysInSubject={usedMetricTypesInSubject(subject)}
+        />
     )
 }
-MetricType.propTypes = {
+MetricTypeSelector.propTypes = {
     metric: metricPropType,
     metricUuid: string,
     reload: func,
-    subjectType: string,
+    report: reportPropType,
+    subject: subjectPropType,
 }

--- a/components/frontend/src/metric/MetricTypeSelector.test.jsx
+++ b/components/frontend/src/metric/MetricTypeSelector.test.jsx
@@ -1,12 +1,11 @@
-import { render, screen } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
+import { fireEvent, render, screen } from "@testing-library/react"
 import { vi } from "vitest"
 
 import * as fetchServerApi from "../api/fetch_server_api"
 import { DataModelContext } from "../context/DataModel"
 import { EDIT_REPORT_PERMISSION, PermissionsContext } from "../context/Permissions"
-import { expectFetch, expectNoAccessibilityViolations, expectText } from "../testUtils"
-import { MetricType } from "./MetricType"
+import { asyncClickText, expectFetch, expectNoAccessibilityViolations, expectText } from "../testUtils"
+import { MetricTypeSelector } from "./MetricTypeSelector"
 
 const dataModel = {
     subjects: {
@@ -40,15 +39,16 @@ const dataModel = {
     },
 }
 
-function renderMetricType(metricType) {
+function renderMetricTypeSelector({ metricType = "violations", permissions = [EDIT_REPORT_PERMISSION] } = {}) {
     return render(
-        <PermissionsContext value={[EDIT_REPORT_PERMISSION]}>
+        <PermissionsContext value={permissions}>
             <DataModelContext value={dataModel}>
-                <MetricType
-                    subjectType="subject_type"
+                <MetricTypeSelector
+                    subject={{ type: "subject_type", metrics: {} }}
                     metric={{ type: metricType }}
                     metricUuid="metric_uuid"
                     reload={vi.fn()}
+                    report={{ subjects: {} }}
                 />
             </DataModelContext>
         </PermissionsContext>,
@@ -56,34 +56,30 @@ function renderMetricType(metricType) {
 }
 
 it("has no accessibility violations", async () => {
-    const { container } = renderMetricType("violations")
+    const { container } = renderMetricTypeSelector()
     await expectNoAccessibilityViolations(container)
 })
 
 it("sets the metric type", async () => {
     vi.spyOn(fetchServerApi, "fetchServerApi").mockResolvedValue({ ok: true })
-    renderMetricType("violations")
-    await userEvent.type(screen.getByRole("combobox"), "Source version{Enter}")
+    renderMetricTypeSelector()
+    fireEvent.click(screen.getByDisplayValue("Violations"))
+    await asyncClickText("Source version")
     expectFetch("post", "metric/metric_uuid/attribute/type", { type: "source_version" })
 })
 
-it("shows the metric type even when not supported by the subject type", async () => {
-    renderMetricType("unsupported")
-    expectText(/Unsupported/)
-})
-
 it("shows the metric type read the docs URL", async () => {
-    renderMetricType("violations")
+    renderMetricTypeSelector()
     expectText(/Read the Docs/)
 })
 
 it("shows the metric type has extra documentation", async () => {
-    renderMetricType("source_version")
+    renderMetricTypeSelector({ metricType: "source_version" })
     expectText(/for additional information on how to configure this metric type/)
 })
 
 it("uses the name of the metric type for the documentation link", async () => {
-    renderMetricType("failed_jobs")
+    renderMetricTypeSelector({ metricType: "failed_jobs" })
     const readTheDocsLink = screen.getByRole("link", { name: "Read the Docs" })
     expect(readTheDocsLink).toHaveAttribute("href", expect.stringContaining("#failed-ci-jobs"))
 })

--- a/components/frontend/src/report/IssueTracker.jsx
+++ b/components/frontend/src/report/IssueTracker.jsx
@@ -10,7 +10,7 @@ import { SnackbarContext } from "../context/Snackbar"
 import { MultipleChoiceField } from "../fields/MultipleChoiceField"
 import { TextField } from "../fields/TextField"
 import { reportPropType } from "../sharedPropTypes"
-import { sourceTypeOption } from "../source/SourceType"
+import { sourceTypeOption } from "../source/SourceTypeSelector"
 import { HyperLink } from "../widgets/HyperLink"
 import { WarningMessage } from "../widgets/WarningMessage"
 

--- a/components/frontend/src/report/LocationParameters.jsx
+++ b/components/frontend/src/report/LocationParameters.jsx
@@ -7,7 +7,7 @@ import { EDIT_REPORT_PERMISSION } from "../context/Permissions"
 import { SnackbarContext } from "../context/Snackbar"
 import { reportPropType, sourcePropType } from "../sharedPropTypes"
 import { SourceParameter } from "../source/SourceParameter"
-import { SourceTypeRichDescription } from "../source/SourceType"
+import { SourceTypeRichDescription } from "../source/SourceTypeSelector"
 import { pluralize } from "../utils"
 import { InfoMessage } from "../widgets/WarningMessage"
 

--- a/components/frontend/src/source/Source.jsx
+++ b/components/frontend/src/source/Source.jsx
@@ -25,7 +25,7 @@ import { HyperLink } from "../widgets/HyperLink"
 import { Tabs } from "../widgets/Tabs"
 import { InfoMessage, WarningMessage } from "../widgets/WarningMessage"
 import { SourceParameters } from "./SourceParameters"
-import { SourceType } from "./SourceType"
+import { SourceTypeSelector } from "./SourceTypeSelector"
 
 function SourceButtonRow({ firstSource, lastSource, reload, sourceUuid }) {
     const deleteButton = <DeleteButton itemType="source" onClick={() => deleteSource(sourceUuid, reload)} />
@@ -100,7 +100,7 @@ function Parameters({
                 </Grid>
             )}
             <Grid size={{ xs: 1, sm: 1, md: 1 }}>
-                <SourceType
+                <SourceTypeSelector
                     metricType={metric.type}
                     setSourceAttribute={(a, v) => setSourceAttribute(sourceUuid, a, v, reload)}
                     sourceUuid={sourceUuid}

--- a/components/frontend/src/source/Source.test.jsx
+++ b/components/frontend/src/source/Source.test.jsx
@@ -59,7 +59,7 @@ it("invokes the callback on clicking delete", async () => {
 
 it("changes the source type", async () => {
     renderSource(metric)
-    fireEvent.mouseDown(screen.getByLabelText(/Source type/))
+    fireEvent.click(screen.getByLabelText(/Source type/))
     clickText(/Source type 2/)
     expectFetch("post", "source/source_uuid/attribute/type", { type: "source_type2" })
 })

--- a/components/frontend/src/source/SourceEntityDetails.test.jsx
+++ b/components/frontend/src/source/SourceEntityDetails.test.jsx
@@ -7,7 +7,7 @@ import { vi } from "vitest"
 
 import * as sourceApi from "../api/source"
 import { EDIT_ENTITY_PERMISSION, PermissionsContext } from "../context/Permissions"
-import { clickText, expectNoAccessibilityViolations, expectText } from "../testUtils"
+import { clickText, expectDisplayValue, expectNoAccessibilityViolations, expectText } from "../testUtils"
 import { SourceEntityDetails } from "./SourceEntityDetails"
 
 const reload = vi.fn
@@ -100,7 +100,7 @@ it("changes the entity status", async () => {
 
 it("shows the entity status end date", async () => {
     renderSourceEntityDetails({ statusEndDate: "20250112" })
-    expect(screen.queryAllByDisplayValue("01/12/2025").length).toBe(1)
+    expectDisplayValue("01/12/2025")
 })
 
 it("changes the entity status end date", async () => {

--- a/components/frontend/src/source/SourceParameter.test.jsx
+++ b/components/frontend/src/source/SourceParameter.test.jsx
@@ -10,7 +10,9 @@ import { EDIT_REPORT_PERMISSION, PermissionsContext } from "../context/Permissio
 import {
     clickButton,
     clickLabeledElement,
+    expectDisplayValue,
     expectFetch,
+    expectLabelText,
     expectNoAccessibilityViolations,
     expectNoFetch,
     expectNoText,
@@ -94,20 +96,20 @@ it("has no accessibility violations", async () => {
 
 it("renders an URL parameter", async () => {
     renderSourceParameter({})
-    expect(screen.queryAllByLabelText(/URL/).length).toBe(1)
+    expectLabelText(/URL/)
     expect(screen.getByDisplayValue(/https:\/\/test/)).toBeValid()
 })
 
 it("renders an URL parameter with warning", async () => {
     renderSourceParameter({ warning: true })
-    expect(screen.queryAllByLabelText(/URL/).length).toBe(1)
+    expectLabelText(/URL/)
     expect(screen.getByDisplayValue(/https:\/\/test/)).not.toBeValid()
 })
 
 it("renders a string parameter", async () => {
     renderSourceParameter({ parameter: { name: "String", type: "string" } })
-    expect(screen.queryAllByLabelText(/String/).length).toBe(1)
-    expect(screen.queryAllByDisplayValue(/https/).length).toBe(1)
+    expectLabelText(/String/)
+    expectDisplayValue(/https/)
 })
 
 it("renders a password parameter", async () => {
@@ -121,7 +123,7 @@ it("renders a date parameter", async () => {
         parameterValue: "2021-10-10",
     })
     expect(screen.queryAllByLabelText(/Date/, { selector: "input" }).length).toBe(1)
-    expect(screen.queryAllByDisplayValue("10/10/2021").length).toBe(1)
+    expectDisplayValue("10/10/2021")
 })
 
 it("renders a date parameter without date", async () => {
@@ -224,7 +226,7 @@ it("renders an integer parameter", async () => {
         parameter: { name: "Integer", type: "integer" },
         parameterValue: "0",
     })
-    expect(screen.queryAllByLabelText(/Integer/).length).toBe(1)
+    expectLabelText(/Integer/)
     expect(screen.getByLabelText(/Integer/)).toBeValid()
 })
 
@@ -233,7 +235,7 @@ it("does not accept floats as number", async () => {
         parameter: { name: "Integer", type: "integer" },
         parameterValue: "0.1",
     })
-    expect(screen.queryAllByLabelText(/Integer/).length).toBe(1)
+    expectLabelText(/Integer/)
     expect(screen.getByLabelText(/Integer/)).not.toBeValid()
 })
 
@@ -242,7 +244,7 @@ it("does not accept negative integers as number", async () => {
         parameter: { name: "Integer", type: "integer" },
         parameterValue: "-1",
     })
-    expect(screen.queryAllByLabelText(/Integer/).length).toBe(1)
+    expectLabelText(/Integer/)
     expect(screen.getByLabelText(/Integer/)).not.toBeValid()
 })
 
@@ -260,7 +262,7 @@ it("renders a single choice parameter", async () => {
         parameter: { name: "Single choice", type: "single_choice", values: ["option 1", "option 2"] },
         parameterValue: "option 1",
     })
-    expect(screen.queryAllByLabelText(/Single choice/).length).toBe(1)
+    expectLabelText(/Single choice/)
     expectText(/option 1/)
 })
 
@@ -274,7 +276,7 @@ it("renders a multiple choice parameter with default", async () => {
         },
         parameterValue: null,
     })
-    expect(screen.queryAllByLabelText(/Multiple choice/).length).toBe(1)
+    expectLabelText(/Multiple choice/)
     expectText(/option 1/)
     expectNoText(/option 2/)
 })
@@ -288,7 +290,7 @@ it("renders a multiple choice parameter without defaults", async () => {
         },
         parameterValue: [],
     })
-    expect(screen.queryAllByLabelText(/Multiple choice/).length).toBe(1)
+    expectLabelText(/Multiple choice/)
     expectNoText(/option 1/)
     expectNoText(/option 2/)
 })

--- a/components/frontend/src/source/SourceParameters.test.jsx
+++ b/components/frontend/src/source/SourceParameters.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react"
 
 import { DataModelContext } from "../context/DataModel"
-import { expectNoAccessibilityViolations, expectText } from "../testUtils"
+import { expectDisplayValue, expectLabelText, expectNoAccessibilityViolations, expectText } from "../testUtils"
 import { SourceParameters } from "./SourceParameters"
 
 function renderSourceParameters({
@@ -70,7 +70,7 @@ it("has no accessibility violations", async () => {
 
 it("renders a string parameter", async () => {
     renderSourceParameters({})
-    expect(screen.queryAllByLabelText(/Parameter/).length).toBe(1)
+    expectLabelText(/Parameter/)
 })
 
 it("renders a string parameter with placeholder", async () => {
@@ -80,12 +80,12 @@ it("renders a string parameter with placeholder", async () => {
 
 it("renders a default value if the source parameter has no value", async () => {
     renderSourceParameters({})
-    expect(screen.queryAllByDisplayValue(/Default value/).length).toBe(1)
+    expectDisplayValue(/Default value/)
 })
 
 it("renders the source parameter value", async () => {
     renderSourceParameters({ sourceParameterValue: "Value" })
-    expect(screen.queryAllByDisplayValue(/Value/).length).toBe(1)
+    expectDisplayValue(/Value/)
 })
 
 it("does not render a warning if a mandatory parameter has a value", async () => {
@@ -122,5 +122,5 @@ it("renders parameter groups", async () => {
 
 it("renders ungrouped parameters in the group without explicitly listed parameters", async () => {
     renderSourceParameters({})
-    expect(screen.queryAllByLabelText(/Other parameter/).length).toBe(1)
+    expectLabelText(/Other parameter/)
 })

--- a/components/frontend/src/source/SourceTypeSelector.jsx
+++ b/components/frontend/src/source/SourceTypeSelector.jsx
@@ -1,12 +1,13 @@
-import { Chip, MenuItem, Stack, Typography } from "@mui/material"
+import { Chip, InputAdornment, Stack, Typography } from "@mui/material"
 import { func, string } from "prop-types"
 import { useContext } from "react"
 
 import { DataModelContext } from "../context/DataModel"
 import { accessGranted, EDIT_REPORT_PERMISSION, PermissionsContext } from "../context/Permissions"
-import { TextField } from "../fields/TextField"
 import { dataModelPropType, sourceTypePropType } from "../sharedPropTypes"
 import { referenceDocumentationURL } from "../utils"
+import { ItemTypeSelector } from "../widgets/ItemTypeSelector"
+import { ItemTypeSelectorTextField } from "../widgets/ItemTypeSelectorTextField"
 import { ReadTheDocsLink } from "../widgets/ReadTheDocsLink"
 import { Logo } from "./Logo"
 
@@ -67,7 +68,7 @@ sourceTypeOptions.propTypes = {
     metricType: string,
 }
 
-export function SourceType({ metricType, setSourceAttribute, sourceType }) {
+export function SourceTypeSelector({ metricType, setSourceAttribute, sourceType }) {
     const dataModel = useContext(DataModelContext)
     const permissions = useContext(PermissionsContext)
     const disabled = !accessGranted(permissions, [EDIT_REPORT_PERMISSION])
@@ -79,29 +80,39 @@ export function SourceType({ metricType, setSourceAttribute, sourceType }) {
     const sourceTypeDocumentation = dataModel.sources[sourceType]?.documentation
     const hasExtraDocs = sourceTypeDocumentation?.generic || sourceTypeDocumentation?.[metricType]
     const howToConfigure = ` for ${hasExtraDocs ? "additional " : ""}information on how to configure this source type.`
+    const sourceTypeName = dataModel.sources[sourceType].name
+    const sourceTypeDeprecated = dataModel.sources[sourceType].deprecated
     return (
-        <TextField
-            disabled={disabled}
-            helperText={
-                <>
-                    <ReadTheDocsLink url={referenceDocumentationURL(dataModel.sources[sourceType].name)} />
-                    {howToConfigure}
-                </>
-            }
-            label="Source type"
-            onChange={(value) => setSourceAttribute("type", value)}
-            select
-            value={sourceType}
-        >
-            {options.map((option) => (
-                <MenuItem key={option.key} sx={{ width: "50vw" }} value={option.value}>
-                    {option.content}
-                </MenuItem>
-            ))}
-        </TextField>
+        <ItemTypeSelector
+            itemSubtypes={options}
+            itemType="source"
+            onClick={(value) => setSourceAttribute("type", value)}
+            renderAnchor={(handleMenu) => (
+                <ItemTypeSelectorTextField
+                    disabled={disabled}
+                    handleMenu={handleMenu}
+                    helperText={
+                        <>
+                            <ReadTheDocsLink url={referenceDocumentationURL(sourceTypeName)} />
+                            {howToConfigure}
+                        </>
+                    }
+                    label="Source type"
+                    startAdornment={
+                        <InputAdornment position="start">
+                            {sourceTypeDeprecated && (
+                                <Chip color="warning" label="Deprecated" size="small" sx={{ marginRight: "10px" }} />
+                            )}
+                            <Logo logo={sourceType} alt={sourceTypeName} width="1em" height="1em" />
+                        </InputAdornment>
+                    }
+                    value={sourceTypeName}
+                />
+            )}
+        />
     )
 }
-SourceType.propTypes = {
+SourceTypeSelector.propTypes = {
     metricType: string,
     setSourceAttribute: func,
     sourceType: string,

--- a/components/frontend/src/source/SourceTypeSelector.test.jsx
+++ b/components/frontend/src/source/SourceTypeSelector.test.jsx
@@ -1,12 +1,11 @@
 import { act, fireEvent, render, screen } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
 import { vi } from "vitest"
 
 import * as fetchServerApi from "../api/fetch_server_api"
 import { DataModelContext } from "../context/DataModel"
 import { EDIT_REPORT_PERMISSION, PermissionsContext } from "../context/Permissions"
-import { expectNoAccessibilityViolations, expectText } from "../testUtils"
-import { SourceType } from "./SourceType"
+import { asyncClickText, expectDisplayValue, expectNoAccessibilityViolations, expectText } from "../testUtils"
+import { SourceTypeSelector } from "./SourceTypeSelector"
 
 beforeEach(() => {
     vi.spyOn(fetchServerApi, "fetchServerApi")
@@ -48,7 +47,7 @@ async function renderSourceType(metricType, sourceType, mockSetSourceAttribute) 
         result = render(
             <PermissionsContext value={[EDIT_REPORT_PERMISSION]}>
                 <DataModelContext value={dataModel}>
-                    <SourceType
+                    <SourceTypeSelector
                         metricType={metricType}
                         sourceType={sourceType}
                         setSourceAttribute={mockSetSourceAttribute}
@@ -68,23 +67,24 @@ it("has no accessibility violations", async () => {
 it("sets the source type", async () => {
     const mockSetSourceAttribute = vi.fn()
     await renderSourceType("violations", "sonarqube", mockSetSourceAttribute)
-    await userEvent.type(screen.getByRole("combobox"), "GitLab{Enter}")
+    fireEvent.click(screen.getByDisplayValue("SonarQube"))
+    await asyncClickText("GitLab")
     expect(mockSetSourceAttribute).toHaveBeenLastCalledWith("type", "gitlab")
 })
 
-it("shows the metric type even when not supported by the subject type", async () => {
+it("shows the source type even when not supported by the metric type", async () => {
     await renderSourceType("violations", "unsupported")
-    expectText(/Unsupported/)
+    expectDisplayValue(/Unsupported/)
 })
 
-it("shows the supported source versions", async () => {
+it("shows the supported source versions in the menu", async () => {
     await renderSourceType("violations", "sonarqube")
+    fireEvent.click(screen.getByDisplayValue("SonarQube"))
     expectText(/Supported SonarQube versions: >=8.2/)
 })
 
 it("shows sources as deprecated if they are deprecated", async () => {
-    await renderSourceType("violations", "sonarqube")
-    fireEvent.mouseDown(screen.getByLabelText(/Source type/))
+    await renderSourceType("violations", "gitlab")
     expectText(/Deprecated/)
 })
 

--- a/components/frontend/src/source/Sources.jsx
+++ b/components/frontend/src/source/Sources.jsx
@@ -21,7 +21,7 @@ import { MoveButton } from "../widgets/buttons/MoveButton"
 import { sourceOptions } from "../widgets/menu_options"
 import { InfoMessage } from "../widgets/WarningMessage"
 import { Source } from "./Source"
-import { sourceTypeOptions } from "./SourceType"
+import { sourceTypeOptions } from "./SourceTypeSelector"
 
 function ButtonSegment({ metric, metricUuid, reload, reports }) {
     const dataModel = useContext(DataModelContext)

--- a/components/frontend/src/source/Sources.test.jsx
+++ b/components/frontend/src/source/Sources.test.jsx
@@ -9,8 +9,10 @@ import { EDIT_REPORT_PERMISSION, PermissionsContext } from "../context/Permissio
 import {
     asyncClickButton,
     asyncClickText,
+    expectDisplayValue,
     expectFetch,
     expectNoAccessibilityViolations,
+    expectNoDisplayValue,
     expectText,
 } from "../testUtils"
 import { SnackbarAlerts } from "../widgets/SnackbarAlerts"
@@ -127,8 +129,8 @@ it("shows a message if there are no sources", async () => {
 
 it("doesn't show sources not in the data model", async () => {
     renderSources()
-    expect(screen.queryAllByDisplayValue(/Source 1/).length).toBe(1)
-    expect(screen.queryAllByDisplayValue(/Source with non-existing source type/).length).toBe(0)
+    expectDisplayValue(/Source 1/)
+    expectNoDisplayValue(/Source with non-existing source type/)
 })
 
 it("shows errored sources", async () => {
@@ -174,7 +176,7 @@ it("updates a parameter of a source", async () => {
     await act(async () => {
         fireEvent.click(screen.getByDisplayValue("Source 1"))
     })
-    expect(screen.getAllByDisplayValue("https://other").length).toBe(1)
+    expectDisplayValue("https://other")
     expectFetch("post", "source/source_uuid/parameter/url", { edit_scope: "source", url: "https://other" })
     expect(showMessage).toHaveBeenCalledTimes(0)
 })

--- a/components/frontend/src/subject/SubjectParameters.jsx
+++ b/components/frontend/src/subject/SubjectParameters.jsx
@@ -9,7 +9,7 @@ import { CommentField } from "../fields/CommentField"
 import { TextField } from "../fields/TextField"
 import { subjectPropType } from "../sharedPropTypes"
 import { getSubjectName, getSubjectTypeName } from "../utils"
-import { SubjectType } from "./SubjectType"
+import { SubjectTypeSelector } from "./SubjectTypeSelector"
 
 export function SubjectParameters({ subject, subjectUuid, reload }) {
     const dataModel = useContext(DataModelContext)
@@ -18,7 +18,7 @@ export function SubjectParameters({ subject, subjectUuid, reload }) {
     return (
         <Grid container spacing={{ xs: 1, sm: 1, md: 2 }} columns={{ xs: 1, sm: 1, md: 3 }}>
             <Grid size={{ xs: 1, sm: 1, md: 1 }}>
-                <SubjectType
+                <SubjectTypeSelector
                     id={`${subjectUuid}-type`}
                     setValue={(value) => setSubjectAttribute(subjectUuid, "type", value, reload)}
                     subjectType={subject.type}

--- a/components/frontend/src/subject/SubjectTableFooter.jsx
+++ b/components/frontend/src/subject/SubjectTableFooter.jsx
@@ -10,7 +10,7 @@ import {
     metricTypeOptions,
     usedMetricTypesInReport,
     usedMetricTypesInSubject,
-} from "../metric/MetricType"
+} from "../metric/MetricTypeSelector"
 import { reportPropType, reportsPropType, subjectPropType } from "../sharedPropTypes"
 import { ButtonRow } from "../widgets/ButtonRow"
 import { AddDropdownButton } from "../widgets/buttons/AddDropdownButton"

--- a/components/frontend/src/subject/SubjectTitle.test.jsx
+++ b/components/frontend/src/subject/SubjectTitle.test.jsx
@@ -78,6 +78,7 @@ it("has no accessibility violations", async () => {
 
 it("changes the subject type", async () => {
     await renderSubjectTitle()
+    fireEvent.click(screen.getAllByDisplayValue("Default subject type")[0])
     fireEvent.mouseDown(screen.getByLabelText(/Subject type/))
     clickText(/Other subject type/)
     expectFetch("post", "subject/subject_uuid/attribute/type", { type: "subject_type2" })
@@ -85,6 +86,7 @@ it("changes the subject type", async () => {
 
 it("changes the subject type to a nested type", async () => {
     await renderSubjectTitle()
+    fireEvent.click(screen.getAllByDisplayValue("Default subject type")[0])
     fireEvent.mouseDown(screen.getByLabelText(/Subject type/))
     clickText(/Nested subject type/)
     expectFetch("post", "subject/subject_uuid/attribute/type", { type: "nested_subject_type" })
@@ -92,6 +94,7 @@ it("changes the subject type to a nested type", async () => {
 
 it("changes the subject type from a nested type", async () => {
     await renderSubjectTitle("nested_subject_type")
+    fireEvent.click(screen.getAllByDisplayValue("Nested subject type")[0])
     fireEvent.mouseDown(screen.getByLabelText(/Subject type/))
     clickText(/Other subject type/)
     expectFetch("post", "subject/subject_uuid/attribute/type", { type: "subject_type2" })

--- a/components/frontend/src/subject/SubjectTypeSelector.jsx
+++ b/components/frontend/src/subject/SubjectTypeSelector.jsx
@@ -1,13 +1,14 @@
 import CircleIcon from "@mui/icons-material/Circle"
-import { MenuItem, Stack, Typography } from "@mui/material"
+import { Stack, Typography } from "@mui/material"
 import { func, number, objectOf, string } from "prop-types"
 import { useContext } from "react"
 
 import { DataModelContext } from "../context/DataModel"
 import { accessGranted, EDIT_REPORT_PERMISSION, PermissionsContext } from "../context/Permissions"
-import { TextField } from "../fields/TextField"
 import { subjectPropType } from "../sharedPropTypes"
 import { getSubjectType, referenceDocumentationURL } from "../utils"
+import { ItemTypeSelector } from "../widgets/ItemTypeSelector"
+import { ItemTypeSelectorTextField } from "../widgets/ItemTypeSelectorTextField"
 import { ReadTheDocsLink } from "../widgets/ReadTheDocsLink"
 
 export function subjectTypes(subjectTypesMapping, level = 0) {
@@ -50,29 +51,30 @@ subjectTypes.propTypes = {
     level: number,
 }
 
-export function SubjectType({ subjectType, setValue }) {
+export function SubjectTypeSelector({ subjectType, setValue }) {
     const dataModel = useContext(DataModelContext)
     const permissions = useContext(PermissionsContext)
     const disabled = !accessGranted(permissions, [EDIT_REPORT_PERMISSION])
     const subjectTypeName = getSubjectType(subjectType, dataModel.subjects).name
     return (
-        <TextField
-            disabled={disabled}
-            helperText={<ReadTheDocsLink url={referenceDocumentationURL(subjectTypeName)} />}
-            label="Subject type"
-            onChange={(value) => setValue(value)}
-            select
-            value={subjectType}
-        >
-            {subjectTypes(dataModel.subjects).map((subjectType) => (
-                <MenuItem key={subjectType.key} value={subjectType.value}>
-                    {subjectType.content}
-                </MenuItem>
-            ))}
-        </TextField>
+        <ItemTypeSelector
+            itemSubtypes={subjectTypes(dataModel.subjects)}
+            itemType="subject"
+            onClick={(value) => setValue(value)}
+            renderAnchor={(handleMenu) => (
+                <ItemTypeSelectorTextField
+                    disabled={disabled}
+                    handleMenu={handleMenu}
+                    helperText={<ReadTheDocsLink url={referenceDocumentationURL(subjectTypeName)} />}
+                    label="Subject type"
+                    value={subjectTypeName}
+                />
+            )}
+            sort={false}
+        />
     )
 }
-SubjectType.propTypes = {
+SubjectTypeSelector.propTypes = {
     subjectType: string,
     setValue: func,
 }

--- a/components/frontend/src/subject/SubjectTypeSelector.test.jsx
+++ b/components/frontend/src/subject/SubjectTypeSelector.test.jsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { vi } from "vitest"
+
+import { DataModelContext } from "../context/DataModel"
+import { EDIT_REPORT_PERMISSION, PermissionsContext } from "../context/Permissions"
+import { asyncClickText, expectDisplayValue, expectNoAccessibilityViolations, expectText } from "../testUtils"
+import { SubjectTypeSelector } from "./SubjectTypeSelector"
+
+const dataModel = {
+    subjects: {
+        software: {
+            name: "Software",
+            description: "A software subject type.",
+            subjects: {
+                application: {
+                    name: "Application",
+                    description: "An application subject type.",
+                },
+            },
+        },
+        process: {
+            name: "Process",
+            description: "A process subject type.",
+        },
+        ci: {
+            name: "CI-pipeline",
+            description: "A continuous integration subject type.",
+        },
+    },
+}
+
+function renderSubjectTypeSelector({
+    subjectType = "software",
+    permissions = [EDIT_REPORT_PERMISSION],
+    setValue = vi.fn(),
+} = {}) {
+    return render(
+        <PermissionsContext value={permissions}>
+            <DataModelContext value={dataModel}>
+                <SubjectTypeSelector subjectType={subjectType} setValue={setValue} />
+            </DataModelContext>
+        </PermissionsContext>,
+    )
+}
+
+it("has no accessibility violations", async () => {
+    const { container } = renderSubjectTypeSelector()
+    await expectNoAccessibilityViolations(container)
+})
+
+it("sets the subject type", async () => {
+    const setValue = vi.fn()
+    renderSubjectTypeSelector({ setValue })
+    fireEvent.click(screen.getByDisplayValue("Software"))
+    await asyncClickText("Process")
+    expect(setValue).toHaveBeenLastCalledWith("process")
+})
+
+it("shows nested subject types in the menu", () => {
+    renderSubjectTypeSelector()
+    fireEvent.click(screen.getByDisplayValue("Software"))
+    expectText(/Application/)
+})
+
+it("shows a fallback name for an unknown subject type", () => {
+    renderSubjectTypeSelector({ subjectType: "unknown" })
+    expectDisplayValue("Unknown subject type")
+})
+
+it("shows the subject type read the docs URL", () => {
+    renderSubjectTypeSelector()
+    expectText(/Read the Docs/)
+})
+
+it("uses the name of the subject type for the documentation link", () => {
+    renderSubjectTypeSelector({ subjectType: "ci" })
+    const readTheDocsLink = screen.getByRole("link", { name: "Read the Docs" })
+    expect(readTheDocsLink).toHaveAttribute("href", expect.stringContaining("#ci-pipeline"))
+})

--- a/components/frontend/src/subject/SubjectsButtonRow.jsx
+++ b/components/frontend/src/subject/SubjectsButtonRow.jsx
@@ -10,7 +10,7 @@ import { AddDropdownButton } from "../widgets/buttons/AddDropdownButton"
 import { CopyButton } from "../widgets/buttons/CopyButton"
 import { MoveButton } from "../widgets/buttons/MoveButton"
 import { subjectOptions } from "../widgets/menu_options"
-import { subjectTypes } from "./SubjectType"
+import { subjectTypes } from "./SubjectTypeSelector"
 
 export function SubjectsButtonRow({ reload, report, reports, settings }) {
     const dataModel = useContext(DataModelContext)

--- a/components/frontend/src/testUtils.js
+++ b/components/frontend/src/testUtils.js
@@ -24,7 +24,7 @@ export function expectSearch(query) {
 }
 
 export function expectText(text, count = 1) {
-    expect(screen.getAllByText(text).length).toBe(count)
+    expect(screen.getAllByText(text)).toHaveLength(count)
 }
 
 export async function expectTextAfterWait(text) {
@@ -33,7 +33,7 @@ export async function expectTextAfterWait(text) {
     })
 }
 export function expectNoText(text) {
-    expect(screen.queryAllByText(text).length).toBe(0)
+    expect(screen.queryAllByText(text)).toHaveLength(0)
 }
 
 export async function expectNoTextAfterWait(text) {
@@ -43,19 +43,27 @@ export async function expectNoTextAfterWait(text) {
 }
 
 export function expectLabelText(text, count = 1) {
-    expect(screen.getAllByLabelText(text).length).toBe(count)
+    expect(screen.getAllByLabelText(text)).toHaveLength(count)
 }
 
 export function expectNoLabelText(text) {
-    expect(screen.queryAllByLabelText(text).length).toBe(0)
+    expect(screen.queryAllByLabelText(text)).toHaveLength(0)
 }
 
 export function expectAltText(text, count = 1) {
-    expect(screen.getAllByAltText(text).length).toBe(count)
+    expect(screen.getAllByAltText(text)).toHaveLength(count)
 }
 
 export function expectNoAltText(text) {
-    expect(screen.queryAllByAltText(text).length).toBe(0)
+    expect(screen.queryAllByAltText(text)).toHaveLength(0)
+}
+
+export function expectDisplayValue(text, count = 1) {
+    expect(screen.getAllByDisplayValue(text)).toHaveLength(count)
+}
+
+export function expectNoDisplayValue(text) {
+    expect(screen.queryAllByDisplayValue(text)).toHaveLength(0)
 }
 
 export function clickText(text, index) {

--- a/components/frontend/src/widgets/ItemTypeSelector.jsx
+++ b/components/frontend/src/widgets/ItemTypeSelector.jsx
@@ -80,7 +80,7 @@ Filters.propTypes = {
     setHideUsedItemsScope: func,
 }
 
-export function ItemSelector({
+export function ItemTypeSelector({
     renderAnchor,
     tooltip,
     itemSubtypes,
@@ -116,7 +116,13 @@ export function ItemSelector({
             <Tooltip title={tooltip} placement="top">
                 {renderAnchor(handleMenu)}
             </Tooltip>
-            <Popover id="dropdown-menu" anchorEl={anchorEl} onClose={() => setAnchorEl(null)} open={Boolean(anchorEl)}>
+            <Popover
+                id="dropdown-menu"
+                anchorEl={anchorEl}
+                anchorOrigin={{ vertical: "bottom" }}
+                onClose={() => setAnchorEl(null)}
+                open={Boolean(anchorEl)}
+            >
                 <TextField
                     autoFocus
                     fullWidth
@@ -156,7 +162,7 @@ export function ItemSelector({
         </>
     )
 }
-ItemSelector.propTypes = {
+ItemTypeSelector.propTypes = {
     allItemSubtypes: array,
     itemSubtypes: array,
     itemType: string,

--- a/components/frontend/src/widgets/ItemTypeSelector.test.jsx
+++ b/components/frontend/src/widgets/ItemTypeSelector.test.jsx
@@ -3,9 +3,9 @@ import userEvent from "@testing-library/user-event"
 import { vi } from "vitest"
 
 import { asyncClickRole, asyncClickText, expectNoText, expectText } from "../testUtils"
-import { ItemSelector } from "./ItemSelector"
+import { ItemTypeSelector } from "./ItemTypeSelector"
 
-function renderItemSelector({
+function renderItemTypeSelector({
     nrItems = 2,
     totalItems = 10,
     usedItemKeysInReport = [],
@@ -28,7 +28,7 @@ function renderItemSelector({
         }
     }
     render(
-        <ItemSelector
+        <ItemTypeSelector
             allItemSubtypes={allItemSubtypes}
             itemType="foo"
             itemSubtypes={itemSubtypes.toReversed()} // Pass items in reversed order to test they are sorted correctly
@@ -47,22 +47,22 @@ function renderItemSelector({
     return mockCallback
 }
 
-test("ItemSelector renders the child anchor", async () => {
-    renderItemSelector()
+test("ItemTypeSelector renders the child anchor", async () => {
+    renderItemTypeSelector()
     expectText(/Add foo/)
     expectNoText(/Available/) // Menu is closed until the anchor is clicked
 })
 
-test("ItemSelector mouse navigation", async () => {
-    const mockCallback = renderItemSelector()
+test("ItemTypeSelector mouse navigation", async () => {
+    const mockCallback = renderItemTypeSelector()
     await asyncClickText(/Add foo/)
     expect(screen.getByLabelText(/Filter/)).toHaveFocus()
     await asyncClickText(/Sub 2/)
     expect(mockCallback).toHaveBeenCalledWith("sub 2")
 })
 
-test("ItemSelector keyboard navigation", async () => {
-    const mockCallback = renderItemSelector()
+test("ItemTypeSelector keyboard navigation", async () => {
+    const mockCallback = renderItemTypeSelector()
     await asyncClickText(/Add foo/)
     expect(screen.getByLabelText(/Filter/)).toHaveFocus()
     await act(async () => {
@@ -80,42 +80,42 @@ test("ItemSelector keyboard navigation", async () => {
     expect(mockCallback).toHaveBeenCalledWith("sub 2")
 })
 
-test("ItemSelector is sorted", async () => {
-    renderItemSelector()
+test("ItemTypeSelector is sorted", async () => {
+    renderItemTypeSelector()
     await asyncClickText(/Add foo/)
     expect(screen.getAllByText(/Sub/).map((item) => item.innerHTML)).toStrictEqual(["Sub 1", "Sub 2"])
 })
 
-test("ItemSelector is not sorted", async () => {
-    renderItemSelector({ sort: false })
+test("ItemTypeSelector is not sorted", async () => {
+    renderItemTypeSelector({ sort: false })
     await asyncClickText(/Add foo/)
     expect(screen.getAllByText(/Sub/).map((item) => item.innerHTML)).toStrictEqual(["Sub 2", "Sub 1"])
 })
 
-test("ItemSelector filter one item", async () => {
-    renderItemSelector({ nrItems: 6 })
+test("ItemTypeSelector filter one item", async () => {
+    renderItemTypeSelector({ nrItems: 6 })
     await asyncClickText(/Add foo/)
     await userEvent.type(screen.getByRole("searchbox"), "Sub 3")
     expect(screen.getAllByText(/Sub/).map((item) => item.innerHTML)).toStrictEqual(["Sub 3"])
 })
 
-test("ItemSelector filter zero items", async () => {
-    renderItemSelector({ nrItems: 6 })
+test("ItemTypeSelector filter zero items", async () => {
+    renderItemTypeSelector({ nrItems: 6 })
     await asyncClickText(/Add foo/)
     await userEvent.type(screen.getByRole("searchbox"), "FOO{Enter}")
     expectNoText(/Sub/)
 })
 
-test("ItemSelector select from all items", async () => {
-    const mockCallback = renderItemSelector()
+test("ItemTypeSelector select from all items", async () => {
+    const mockCallback = renderItemTypeSelector()
     await asyncClickText(/Add foo/)
     await asyncClickRole("checkbox")
     await asyncClickText(/Sub 3/)
     expect(mockCallback).toHaveBeenCalledWith("sub 3")
 })
 
-test("ItemSelector hide used items in report", async () => {
-    renderItemSelector({
+test("ItemTypeSelector hide used items in report", async () => {
+    renderItemTypeSelector({
         nrItems: 2,
         totalItems: 3,
         usedItemKeysInReport: ["sub 1"],
@@ -131,8 +131,8 @@ test("ItemSelector hide used items in report", async () => {
     expectNoText(/Sub 3/) // Still hidden because it's not supported by the subject type
 })
 
-test("ItemSelector hide used items in subject", async () => {
-    renderItemSelector({
+test("ItemTypeSelector hide used items in subject", async () => {
+    renderItemTypeSelector({
         nrItems: 2,
         totalItems: 3,
         usedItemKeysInReport: ["sub 1", "sub 2"],
@@ -149,16 +149,16 @@ test("ItemSelector hide used items in subject", async () => {
     expectNoText(/Sub 3/) // Still hidden because it's not supported by the subject type
 })
 
-test("ItemSelector add all items by keyboard", async () => {
-    const mockCallback = renderItemSelector()
+test("ItemTypeSelector add all items by keyboard", async () => {
+    const mockCallback = renderItemTypeSelector()
     await asyncClickText(/Add foo/)
     await userEvent.type(screen.getByRole("checkbox"), "{Enter}")
     await asyncClickText(/Sub 3/)
     expect(mockCallback).toHaveBeenCalledWith("sub 3")
 })
 
-test("ItemSelector menu can be closed without selecting an item", async () => {
-    const mockCallback = renderItemSelector()
+test("ItemTypeSelector menu can be closed without selecting an item", async () => {
+    const mockCallback = renderItemTypeSelector()
     await asyncClickText(/Add foo/)
     await userEvent.keyboard("{Escape}")
     expectNoText(/Sub/)

--- a/components/frontend/src/widgets/ItemTypeSelectorTextField.jsx
+++ b/components/frontend/src/widgets/ItemTypeSelectorTextField.jsx
@@ -1,0 +1,47 @@
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown"
+import { InputAdornment, TextField } from "@mui/material"
+import { bool, func, node, string } from "prop-types"
+
+export function ItemTypeSelectorTextField({ handleMenu, disabled, label, helperText, value, startAdornment }) {
+    return (
+        <TextField
+            disabled={disabled}
+            fullWidth
+            helperText={helperText}
+            label={label}
+            onClick={disabled ? undefined : handleMenu}
+            onKeyDown={
+                disabled
+                    ? undefined
+                    : (event) => {
+                          // The input is read-only, so open the popover on the keys a select responds to
+                          if (["Enter", " ", "ArrowDown", "ArrowUp"].includes(event.key)) {
+                              event.preventDefault()
+                              handleMenu(event)
+                          }
+                      }
+            }
+            slotProps={{
+                input: {
+                    readOnly: true,
+                    sx: { cursor: disabled ? "default" : "pointer" },
+                    startAdornment: startAdornment,
+                    endAdornment: (
+                        <InputAdornment position="end">
+                            <ArrowDropDownIcon />
+                        </InputAdornment>
+                    ),
+                },
+            }}
+            value={value}
+        />
+    )
+}
+ItemTypeSelectorTextField.propTypes = {
+    handleMenu: func,
+    disabled: bool,
+    label: string,
+    helperText: node,
+    value: string,
+    startAdornment: node,
+}

--- a/components/frontend/src/widgets/ItemTypeSelectorTextField.test.jsx
+++ b/components/frontend/src/widgets/ItemTypeSelectorTextField.test.jsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { vi } from "vitest"
+
+import { expectNoAccessibilityViolations, expectText } from "../testUtils"
+import { ItemTypeSelectorTextField } from "./ItemTypeSelectorTextField"
+
+function renderItemTypeSelectorTextField({ disabled = false, handleMenu = vi.fn(), startAdornment = null } = {}) {
+    return render(
+        <ItemTypeSelectorTextField
+            disabled={disabled}
+            handleMenu={handleMenu}
+            helperText="Help text"
+            label="Item type"
+            startAdornment={startAdornment}
+            value="Item value"
+        />,
+    )
+}
+
+it("has no accessibility violations", async () => {
+    const { container } = renderItemTypeSelectorTextField()
+    await expectNoAccessibilityViolations(container)
+})
+
+it("shows the label, value, and helper text", () => {
+    renderItemTypeSelectorTextField()
+    expect(screen.getByLabelText("Item type")).toHaveValue("Item value")
+    expectText("Help text")
+})
+
+it("is read-only", () => {
+    renderItemTypeSelectorTextField()
+    expect(screen.getByDisplayValue("Item value")).toHaveAttribute("readonly")
+})
+
+it("shows the dropdown arrow", () => {
+    renderItemTypeSelectorTextField()
+    expect(screen.getByTestId("ArrowDropDownIcon")).toBeInTheDocument()
+})
+
+it("shows the start adornment when given", () => {
+    renderItemTypeSelectorTextField({ startAdornment: <span>Start</span> })
+    expectText("Start")
+})
+
+it("opens the menu when clicked", () => {
+    const handleMenu = vi.fn()
+    renderItemTypeSelectorTextField({ handleMenu })
+    fireEvent.click(screen.getByDisplayValue("Item value"))
+    expect(handleMenu).toHaveBeenCalled()
+})
+
+it("does not open the menu when clicked while disabled", () => {
+    const handleMenu = vi.fn()
+    renderItemTypeSelectorTextField({ disabled: true, handleMenu })
+    fireEvent.click(screen.getByDisplayValue("Item value"))
+    expect(handleMenu).not.toHaveBeenCalled()
+})
+
+for (const key of ["Enter", " ", "ArrowDown", "ArrowUp"]) {
+    it(`opens the menu when pressing "${key}"`, () => {
+        const handleMenu = vi.fn()
+        renderItemTypeSelectorTextField({ handleMenu })
+        const defaultNotPrevented = fireEvent.keyDown(screen.getByDisplayValue("Item value"), { key: key })
+        expect(handleMenu).toHaveBeenCalled()
+        expect(defaultNotPrevented).toBe(false) // The handler calls preventDefault
+    })
+}
+
+it("does not open the menu when pressing another key", () => {
+    const handleMenu = vi.fn()
+    renderItemTypeSelectorTextField({ handleMenu })
+    fireEvent.keyDown(screen.getByDisplayValue("Item value"), { key: "a" })
+    expect(handleMenu).not.toHaveBeenCalled()
+})
+
+it("does not open the menu when pressing a key while disabled", () => {
+    const handleMenu = vi.fn()
+    renderItemTypeSelectorTextField({ disabled: true, handleMenu })
+    fireEvent.keyDown(screen.getByDisplayValue("Item value"), { key: "Enter" })
+    expect(handleMenu).not.toHaveBeenCalled()
+})

--- a/components/frontend/src/widgets/buttons/AddDropdownButton.jsx
+++ b/components/frontend/src/widgets/buttons/AddDropdownButton.jsx
@@ -3,7 +3,7 @@ import { Button } from "@mui/material"
 import { array, arrayOf, bool, func, string } from "prop-types"
 
 import { AddItemIcon } from "../icons"
-import { ItemSelector } from "../ItemSelector"
+import { ItemTypeSelector } from "../ItemTypeSelector"
 
 export function AddDropdownButton({
     itemSubtypes,
@@ -15,7 +15,7 @@ export function AddDropdownButton({
     sort,
 }) {
     return (
-        <ItemSelector
+        <ItemTypeSelector
             allItemSubtypes={allItemSubtypes}
             itemSubtypes={itemSubtypes}
             itemType={itemType}


### PR DESCRIPTION
Use the same item type selector for changing a domain object's type as for adding a domain object.

Closes #10688.