### PR TITLE
Refactor ItemTypeSelector

### DIFF
--- a/components/frontend/src/source/Sources.jsx
+++ b/components/frontend/src/source/Sources.jsx
@@ -15,7 +15,7 @@ import {
     settingsPropType,
 } from "../sharedPropTypes"
 import { ButtonRow } from "../widgets/ButtonRow"
-import { AddDropdownButton } from "../widgets/buttons/AddDropdownButton"
+import { AddItemByTypeButton } from "../widgets/buttons/AddItemByTypeButton"
 import { CopyButton } from "../widgets/buttons/CopyButton"
 import { MoveButton } from "../widgets/buttons/MoveButton"
 import { sourceOptions } from "../widgets/menu_options"
@@ -30,7 +30,7 @@ function ButtonSegment({ metric, metricUuid, reload, reports }) {
             requiredPermissions={[EDIT_REPORT_PERMISSION]}
             editableComponent={
                 <ButtonRow paddingLeft={0} paddingRight={0} paddingTop={2}>
-                    <AddDropdownButton
+                    <AddItemByTypeButton
                         itemType="source"
                         itemSubtypes={sourceTypeOptions(dataModel, metric.type)}
                         onClick={(subtype) => addSource(metricUuid, subtype, reload)}

--- a/components/frontend/src/subject/SubjectTableFooter.jsx
+++ b/components/frontend/src/subject/SubjectTableFooter.jsx
@@ -13,7 +13,7 @@ import {
 } from "../metric/MetricTypeSelector"
 import { reportPropType, reportsPropType, subjectPropType } from "../sharedPropTypes"
 import { ButtonRow } from "../widgets/ButtonRow"
-import { AddDropdownButton } from "../widgets/buttons/AddDropdownButton"
+import { AddItemByTypeButton } from "../widgets/buttons/AddItemByTypeButton"
 import { CopyButton } from "../widgets/buttons/CopyButton"
 import { MoveButton } from "../widgets/buttons/MoveButton"
 import { metricOptions } from "../widgets/menu_options"
@@ -24,7 +24,7 @@ function SubjectTableFooterButtonRow({ subject, subjectUuid, reload, report, rep
         <TableRow>
             <TableCell colSpan="99">
                 <ButtonRow paddingLeft={0} paddingRight={0}>
-                    <AddDropdownButton
+                    <AddItemByTypeButton
                         allItemSubtypes={allMetricTypeOptions(dataModel)}
                         itemType="metric"
                         itemSubtypes={metricTypeOptions(dataModel, subject.type)}

--- a/components/frontend/src/subject/SubjectsButtonRow.jsx
+++ b/components/frontend/src/subject/SubjectsButtonRow.jsx
@@ -6,7 +6,7 @@ import { DataModelContext } from "../context/DataModel"
 import { EDIT_REPORT_PERMISSION, ReadOnlyOrEditable } from "../context/Permissions"
 import { reportPropType, reportsPropType, settingsPropType } from "../sharedPropTypes"
 import { ButtonRow } from "../widgets/ButtonRow"
-import { AddDropdownButton } from "../widgets/buttons/AddDropdownButton"
+import { AddItemByTypeButton } from "../widgets/buttons/AddItemByTypeButton"
 import { CopyButton } from "../widgets/buttons/CopyButton"
 import { MoveButton } from "../widgets/buttons/MoveButton"
 import { subjectOptions } from "../widgets/menu_options"
@@ -23,7 +23,7 @@ export function SubjectsButtonRow({ reload, report, reports, settings }) {
             requiredPermissions={[EDIT_REPORT_PERMISSION]}
             editableComponent={
                 <ButtonRow paddingLeft={0} paddingTop={7}>
-                    <AddDropdownButton
+                    <AddItemByTypeButton
                         itemType="subject"
                         itemSubtypes={subjectTypes(dataModel.subjects)}
                         onClick={(subtype) => {

--- a/components/frontend/src/widgets/ItemTypeSelector.jsx
+++ b/components/frontend/src/widgets/ItemTypeSelector.jsx
@@ -8,7 +8,6 @@ import {
     Radio,
     RadioGroup,
     TextField,
-    Tooltip,
     Typography,
 } from "@mui/material"
 import { array, arrayOf, bool, func, string } from "prop-types"
@@ -82,7 +81,6 @@ Filters.propTypes = {
 
 export function ItemTypeSelector({
     renderAnchor,
-    tooltip,
     itemSubtypes,
     itemType,
     onClick,
@@ -113,9 +111,7 @@ export function ItemTypeSelector({
     }
     return (
         <>
-            <Tooltip title={tooltip} placement="top">
-                {renderAnchor(handleMenu)}
-            </Tooltip>
+            {renderAnchor(handleMenu)}
             <Popover
                 id="dropdown-menu"
                 anchorEl={anchorEl}
@@ -169,7 +165,6 @@ ItemTypeSelector.propTypes = {
     onClick: func,
     renderAnchor: func,
     sort: bool,
-    tooltip: string,
     usedItemSubtypeKeysInReport: arrayOf(string),
     usedItemSubtypeKeysInSubject: arrayOf(string),
 }

--- a/components/frontend/src/widgets/ItemTypeSelector.test.jsx
+++ b/components/frontend/src/widgets/ItemTypeSelector.test.jsx
@@ -38,7 +38,6 @@ function renderItemTypeSelector({
                     Add foo
                 </button>
             )}
-            tooltip="Add a new foo here"
             usedItemSubtypeKeysInReport={usedItemKeysInReport}
             usedItemSubtypeKeysInSubject={usedItemKeysInSubject}
             sort={sort}

--- a/components/frontend/src/widgets/buttons/AddItemByTypeButton.jsx
+++ b/components/frontend/src/widgets/buttons/AddItemByTypeButton.jsx
@@ -1,11 +1,11 @@
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown"
-import { Button } from "@mui/material"
+import { Button, Tooltip } from "@mui/material"
 import { array, arrayOf, bool, func, string } from "prop-types"
 
 import { AddItemIcon } from "../icons"
 import { ItemTypeSelector } from "../ItemTypeSelector"
 
-export function AddDropdownButton({
+export function AddItemByTypeButton({
     itemSubtypes,
     itemType,
     onClick,
@@ -21,18 +21,19 @@ export function AddDropdownButton({
             itemType={itemType}
             onClick={onClick}
             renderAnchor={(handleMenu) => (
-                <Button aria-describedby="dropdown-menu" onClick={handleMenu} variant="outlined">
-                    <AddItemIcon /> {`Add ${itemType} `} <ArrowDropDownIcon />
-                </Button>
+                <Tooltip title={`Add a new ${itemType} here`} placement="top">
+                    <Button aria-describedby="dropdown-menu" onClick={handleMenu} variant="outlined">
+                        <AddItemIcon /> {`Add ${itemType} `} <ArrowDropDownIcon />
+                    </Button>
+                </Tooltip>
             )}
             sort={sort}
-            tooltip={`Add a new ${itemType} here`}
             usedItemSubtypeKeysInReport={usedItemSubtypeKeysInReport}
             usedItemSubtypeKeysInSubject={usedItemSubtypeKeysInSubject}
         />
     )
 }
-AddDropdownButton.propTypes = {
+AddItemByTypeButton.propTypes = {
     allItemSubtypes: array,
     itemSubtypes: array,
     itemType: string,

--- a/components/frontend/src/widgets/buttons/AddItemByTypeButton.test.jsx
+++ b/components/frontend/src/widgets/buttons/AddItemByTypeButton.test.jsx
@@ -2,25 +2,25 @@ import { render, screen } from "@testing-library/react"
 import { vi } from "vitest"
 
 import { asyncClickText, expectText } from "../../testUtils"
-import { AddDropdownButton } from "./AddDropdownButton"
+import { AddItemByTypeButton } from "./AddItemByTypeButton"
 
-function renderAddDropdownButton() {
+function renderAddItemByTypeButton() {
     const mockCallback = vi.fn()
     const itemSubtypes = [
         { key: "sub 1", text: "Sub 1", value: "sub 1", content: "Sub 1" },
         { key: "sub 2", text: "Sub 2", value: "sub 2", content: "Sub 2" },
     ]
-    render(<AddDropdownButton itemType="foo" itemSubtypes={itemSubtypes} onClick={mockCallback} />)
+    render(<AddItemByTypeButton itemType="foo" itemSubtypes={itemSubtypes} onClick={mockCallback} />)
     return mockCallback
 }
 
-test("AddDropdownButton shows the add button", () => {
-    renderAddDropdownButton()
+it("shows the button", () => {
+    renderAddItemByTypeButton()
     expectText(/Add foo/)
 })
 
-test("AddDropdownButton opens the menu and selects an item", async () => {
-    const mockCallback = renderAddDropdownButton()
+it("opens the menu and selects an item", async () => {
+    const mockCallback = renderAddItemByTypeButton()
     await asyncClickText(/Add foo/)
     expect(screen.getByLabelText(/Filter/)).toHaveFocus()
     await asyncClickText(/Sub 2/)


### PR DESCRIPTION
- Not all ItemTypeSelectors clients need a tooltip, move it to the one client that does
- Rename AddDropdownButton to AddItemByTyprButton