### PR TITLE
Uninstall gzip from database image

### DIFF
--- a/components/database/Dockerfile
+++ b/components/database/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Quality-time team <quality-time@ictu.nl>"
 LABEL description="Quality-time database"
 
 # Harden the base MongoDB image: remove unused tooling that ships known vulnerabilities (MongoDB database tools, gosu,
-# js-yaml, ncurses-bin), upgrade libraries to the latest Ubuntu security fixes ahead of the base image, and make the
+# js-yaml, ncurses-bin, gzip), upgrade libraries to the latest Ubuntu security fixes ahead of the base image, and make the
 # data directories group-writable so the container can run as a non-root/arbitrary UID. Each step is guarded to fail
 # the build once the base image makes it redundant. See README.md ("Container hardening") for the full rationale, CVE
 # references, and when each workaround can be removed. The DL3008/SC2086 ignores are explained there too.
@@ -34,7 +34,7 @@ RUN PACKAGE_VERSIONS="\
     done && \
     apt-get update && \
     apt-get purge --yes mongodb-database-tools mongodb-org-database-tools-extra && \
-    apt-get purge --yes --allow-remove-essential ncurses-bin && \
+    apt-get purge --yes --allow-remove-essential ncurses-bin gzip && \
     apt-get install --only-upgrade --yes --no-install-recommends $packages && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/components/database/README.md
+++ b/components/database/README.md
@@ -34,6 +34,13 @@ that fails the build once the base image makes the workaround redundant, signall
   source — `ncurses-base` (terminfo data) and the shared libraries `libtinfo6` and `libncursesw6` (needed by `bash`,
   `procps`, and `util-linux`) — cannot all be removed and do not contain the flawed `infocmp` code, so they are
   *upgraded* rather than removed for the same CVE; see "Library upgrades".
+- **`gzip`.** Ships the `gzip`, `gunzip`, `zcat`, and `gzexe` command-line tools. Not used by `mongod` (which links its
+  own compression libraries), by `mongosh`, or by the entrypoint (verified), and nothing installed depends on it. It
+  carries [CVE-2026-41991](https://www.cve.org/CVERecord?id=CVE-2026-41991) (arbitrary file overwrite via insecure
+  temporary files in `gzexe`) and [CVE-2026-41992](https://www.cve.org/CVERecord?id=CVE-2026-41992) (buffer overflow in
+  the LZH decoder), both in the `gzip` binaries themselves, so removing the package deletes the vulnerable code rather
+  than merely upgrading it. `--allow-remove-essential` is required because `gzip` is marked essential; that is safe here
+  because the container never installs packages at runtime.
 
 ### Library upgrades
 


### PR DESCRIPTION
Uninstall gzip from database image to close CVE-2026-41991 and CVE-2026-41992.