### PR TITLE
Drop support for SonarQube security hotspots

### DIFF
--- a/components/api_server/src/initialization/migrations.py
+++ b/components/api_server/src/initialization/migrations.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING
 
-from shared.model.iterators import metrics, subjects
+from shared.model.iterators import metrics, sources, subjects
 
 from utils.log import get_logger
 
@@ -24,6 +24,7 @@ def perform_migrations(database: Database) -> None:
                 remove_checkmarx(report),
                 remove_pyupio_safety_and_trello(report),
                 remove_subject_description(report),
+                remove_sonarqube_hotspot_parameters(report),
             )
             if change
         ]
@@ -85,6 +86,19 @@ def remove_subject_description(report) -> str:
         if "description" in subject:
             change_description = "remove the description field from subjects"
             del subject["description"]
+    return change_description
+
+
+def remove_sonarqube_hotspot_parameters(report) -> str:
+    """Remove the hotspot parameters from SonarQube sources."""
+    # Added after Quality-time v5.57.0, see https://github.com/ICTU/quality-time/issues/12911
+    change_description = ""
+    for source in sources(report):
+        if source["type"] == "sonarqube" and "parameters" in source:
+            for obsolete_parameter in ("hotspot_statuses", "review_priorities", "security_types"):
+                if obsolete_parameter in source["parameters"]:
+                    del source["parameters"][obsolete_parameter]
+                    change_description = "remove hotspot parameters from SonarQube sources"
     return change_description
 
 

--- a/components/api_server/tests/initialization/test_migrations.py
+++ b/components/api_server/tests/initialization/test_migrations.py
@@ -193,3 +193,59 @@ class RemoveSubjectDescriptionTest(MigrationTestCase):
         inserted_report = self.inserted_report()
         del inserted_report["subjects"][SUBJECT_ID]["description"]
         self.check_inserted_report(inserted_report)
+
+
+class RemoveSonarQubeHotspotParametersTest(MigrationTestCase):
+    """Init tests for the migration to remove the hotspot parameters from SonarQube sources."""
+
+    HOTSPOT_PARAMETERS = ("hotspot_statuses", "review_priorities", "security_types")
+
+    def existing_report(self, **kwargs):
+        """Extend to add a SonarQube source."""
+        report = super().existing_report(**kwargs)
+        metrics = report["subjects"][SUBJECT_ID]["metrics"]
+        metrics[METRIC_ID2] = {
+            "type": "security_warnings",
+            "sources": {
+                SOURCE_ID: {
+                    "type": "sonarqube",
+                    "parameters": {
+                        "url": "https://sonarqube",
+                        "hotspot_statuses": ["to review"],
+                        "review_priorities": ["high"],
+                        "security_types": [],
+                    },
+                },
+            },
+        }
+        return report
+
+    @classmethod
+    def remove_hotspot_parameters(cls, report) -> None:
+        """Remove the hotspot parameters from the SonarQube source in the report."""
+        parameters = report["subjects"][SUBJECT_ID]["metrics"][METRIC_ID2]["sources"][SOURCE_ID]["parameters"]
+        for parameter in cls.HOTSPOT_PARAMETERS:
+            del parameters[parameter]
+
+    def test_report_without_hotspot_parameters(self):
+        """Test that the migration succeeds with reports whose SonarQube sources have no hotspot parameters."""
+        report = self.existing_report()
+        self.remove_hotspot_parameters(report)
+        self.database.reports.find.return_value = [report]
+        perform_migrations(self.database)
+        self.database.reports.replace_one.assert_not_called()
+
+    def test_remove_hotspot_parameters(self):
+        """Test that the migration removes the hotspot parameters."""
+        self.database.reports.find.return_value = [self.existing_report()]
+        perform_migrations(self.database)
+        inserted_report = self.inserted_report()
+        self.remove_hotspot_parameters(inserted_report)
+        self.check_inserted_report(inserted_report)
+
+    def test_remove_hotspot_parameters_idempotency(self):
+        """Test that the migration does not change the report again when it is run twice."""
+        self.database.reports.find.return_value = [self.existing_report()]
+        perform_migrations(self.database)
+        perform_migrations(self.database)
+        self.database.reports.replace_one.assert_called_once()

--- a/components/collector/src/model/entity.py
+++ b/components/collector/src/model/entity.py
@@ -39,10 +39,6 @@ class Entities(list[Entity]):
         self.__keys: set[str] = set()  # Keep track of the keys in a set to make adding entities faster
         self.extend(entities)
 
-    def __add__(self, other):
-        """Return the concatenation of the entities."""
-        return self.__class__(super().__add__(other))
-
     def __getitem__(self, item):
         """Override to return an Entities slice or an Entity."""
         return self.__class__(super().__getitem__(item)) if isinstance(item, slice) else super().__getitem__(item)

--- a/components/collector/src/source_collectors/sonarqube/security_warnings.py
+++ b/components/collector/src/source_collectors/sonarqube/security_warnings.py
@@ -1,49 +1,10 @@
 """SonarQube security warnings collector."""
 
-from base_collectors import SourceCollector
-from collector_utilities.type import URL
-from model import Entity, SourceMeasurement, SourceResponses
-
-from .base import SonarQubeCollector
 from .violations import SonarQubeViolations
 
 
 class SonarQubeSecurityWarnings(SonarQubeViolations):
-    """SonarQube security warnings, which are a combination of issues with security impact and security hotspots."""
-
-    async def _landing_url(self, responses: SourceResponses) -> URL:
-        """Extend to return the correct landing url depending on the selected security types."""
-        base_landing_url = await SourceCollector._landing_url(self, responses)  # noqa: SLF001
-        component = self._parameter("component")
-        branch = self._parameter("branch")
-        common_url_parameters, extra_url_parameters = f"?id={component}&branch={branch}", ""
-        if self.__issues_with_security_impact_selected() and self.__security_hotspots_selected():
-            landing_path = "dashboard"
-        elif self.__issues_with_security_impact_selected():
-            landing_path = "project/issues"
-            extra_url_parameters = f"&resolved=false{self._url_parameters()}"
-        else:
-            landing_path = "security_hotspots"
-        return URL(f"{base_landing_url}/{landing_path}{common_url_parameters}{extra_url_parameters}")
-
-    async def _get_source_responses(self, *urls: URL) -> SourceResponses:
-        """Extend to add urls for the selected security types."""
-        api_urls = []
-        component = self._parameter("component")
-        branch = self._parameter("branch")
-        if self.__issues_with_security_impact_selected():
-            api_urls.append(await super()._api_url())
-        if self.__security_hotspots_selected():
-            base_url = await SonarQubeCollector._api_url(self)  # noqa: SLF001
-            # Note we pass both the project and the deprecated projectKey parameter because Sonarcloud.io doesn't
-            # accept the project parameter. Tested October 8, 2025.
-            api_urls.append(
-                URL(
-                    f"{base_url}/api/hotspots/search?project={component}&projectKey={component}&branch={branch}&"
-                    f"ps={self.PAGE_SIZE}"
-                )
-            )
-        return await super()._get_source_responses(*api_urls)
+    """SonarQube security warnings, which basically are issues with security impact."""
 
     def _url_parameters(self) -> str:
         """Override to return parameters needed for issues with security impact, common to API URL and landing URL."""
@@ -52,77 +13,3 @@ class SonarQubeSecurityWarnings(SonarQubeViolations):
             + "&impactSoftwareQualities=SECURITY"
             + self._query_parameter("tags")
         )
-
-    async def _entity(self, issue) -> Entity:
-        """Extend to set the entity security type."""
-        entity = await super()._entity(issue)
-        entity["security_type"] = "issue with security impact"
-        return entity
-
-    async def _parse_source_responses(self, responses: SourceResponses) -> SourceMeasurement:
-        """Override to parse the selected security types."""
-        vulnerabilities = (
-            await super()._parse_source_responses(SourceResponses(responses=[responses[0]]))
-            if self.__issues_with_security_impact_selected()
-            else SourceMeasurement()
-        )
-        if self.__security_hotspots_selected():
-            json = await responses[-1].json()
-            hotspots = [
-                await self.__hotspot_entity(hotspot)
-                for hotspot in json.get("hotspots", [])
-                if self.__include_hotspot(hotspot)
-            ]
-        else:
-            hotspots = []
-        return SourceMeasurement(
-            value=str(int(vulnerabilities.value or 0) + len(hotspots)),
-            entities=vulnerabilities.get_entities() + hotspots,
-        )
-
-    def __include_hotspot(self, hotspot: dict[str, str]) -> bool:
-        """Return whether to include the hotspot."""
-        review_priorities = self._parameter("review_priorities")
-        review_priority = hotspot["vulnerabilityProbability"].lower()
-        statuses = self._parameter("hotspot_statuses")
-        status = self.__hotspot_status(hotspot)
-        return review_priority in review_priorities and status in statuses
-
-    async def __hotspot_entity(self, hotspot: dict[str, str]) -> Entity:
-        """Create the security warning entity for the hotspot."""
-        return Entity(
-            key=hotspot["key"],
-            component=hotspot["component"],
-            message=hotspot["message"],
-            security_type="security hotspot",
-            url=await self.__hotspot_landing_url(hotspot["key"]),
-            review_priority=hotspot["vulnerabilityProbability"].lower(),
-            creation_date=hotspot["creationDate"],
-            update_date=hotspot["updateDate"],
-            hotspot_status=self.__hotspot_status(hotspot),
-        )
-
-    @staticmethod
-    def __hotspot_status(hotspot: dict[str, str]) -> str:
-        """Return the hotspot status."""
-        # The SonarQube documentation describes the hotspot lifecycle as having four statuses (see
-        # https://docs.sonarqube.org/latest/user-guide/security-hotspots/#lifecycle): 'to review', 'acknowledged',
-        # 'fixed', and 'safe'. However, in the API the status is either 'to review' or 'reviewed' and the other
-        # statuses ('acknowledged', 'fixed', and 'safe') are called resolutions. So to determine the status as defined
-        # by the docs, check both the hotspot status and the hotspot resolution:
-        return "to review" if hotspot["status"] == "TO_REVIEW" else hotspot["resolution"].lower()
-
-    async def __hotspot_landing_url(self, hotspot_key: str) -> URL:
-        """Generate a landing url for the hotspot."""
-        url = await SonarQubeCollector._landing_url(self, SourceResponses())  # noqa: SLF001
-        component = self._parameter("component")
-        branch = self._parameter("branch")
-        return URL(f"{url}/security_hotspots?id={component}&branch={branch}&hotspots={hotspot_key}")
-
-    def __issues_with_security_impact_selected(self) -> bool:
-        """Return whether the user selected issues with security impact."""
-        return "issue with security impact" in self._parameter("security_types")
-
-    def __security_hotspots_selected(self) -> bool:
-        """Return whether the user selected security hotspots."""
-        return "security hotspot" in self._parameter("security_types")

--- a/components/collector/tests/source_collectors/sonarqube/base.py
+++ b/components/collector/tests/source_collectors/sonarqube/base.py
@@ -24,48 +24,31 @@ class SonarQubeTestCase(SourceCollectorTestCase):
         key: str,
         component: str,
         message: str,
-        security_type: str | None = None,
-        impacts: str | None = None,
-        clean_code_attribute_category: str | None = None,
+        impacts: str,
+        clean_code_attribute_category: str,
+        tags: str,
         issue_status: str | None = None,
         rationale: str | None = None,
-        review_priority: str | None = None,
         creation_date: str | None = None,
         update_date: str | None = None,
-        hotspot_status: str | None = None,
-        tags: str | None = None,
         hostname: str = "sonarqube",
     ) -> Entity:
         """Create an entity."""
-        url = (
-            f"https://{hostname}/security_hotspots?id=id&branch=main&hotspots={key}"
-            if security_type == "security hotspot"
-            else f"https://{hostname}/project/issues?id=id&branch=main&issues={key}&open={key}"
-        )
         entity = Entity(
             key=key,
             component=component,
             message=message,
-            url=url,
+            impacts=impacts,
+            clean_code_attribute_category=clean_code_attribute_category,
             creation_date=creation_date,
             update_date=update_date,
+            tags=tags,
+            url=f"https://{hostname}/project/issues?id=id&branch=main&issues={key}&open={key}",
         )
-        if security_type is not None:
-            entity["security_type"] = security_type
-        if impacts is not None:
-            entity["impacts"] = impacts
-        if clean_code_attribute_category is not None:
-            entity["clean_code_attribute_category"] = clean_code_attribute_category
         if issue_status is not None:
             entity["issue_status"] = issue_status
         if rationale is not None:
             entity["rationale"] = rationale
-        if review_priority is not None:
-            entity["review_priority"] = review_priority
-        if hotspot_status is not None:
-            entity["hotspot_status"] = hotspot_status
-        if tags is not None:
-            entity["tags"] = tags
         return entity
 
     @staticmethod

--- a/components/collector/tests/source_collectors/sonarqube/test_security_warnings.py
+++ b/components/collector/tests/source_collectors/sonarqube/test_security_warnings.py
@@ -10,9 +10,6 @@ class SonarQubeSecurityWarningsTest(SonarQubeTestCase):
     SONARQUBE_URL = "https://sonarqube"
     API_URL = f"{SONARQUBE_URL}/api"
     BRANCH = "&branch=main"
-    DASHBOARD_URL = f"{SONARQUBE_URL}/dashboard?id=id{BRANCH}"
-    HOTSPOTS_API = f"{API_URL}/hotspots/search?project=id&projectKey=id{BRANCH}&ps=500"
-    HOTSPOTS_LANDING_URL = f"{SONARQUBE_URL}/security_hotspots?id=id{BRANCH}"
     ISSUES_API = (
         f"{API_URL}/issues/search?projects=id&branch=main&resolved=false&ps=500&impactSoftwareQualities=SECURITY"
     )
@@ -22,7 +19,7 @@ class SonarQubeSecurityWarningsTest(SonarQubeTestCase):
         """Extend to set up SonarQube security warnings."""
         super().setUp()
         self.issues_json = {
-            "total": "2",
+            "total": "3",
             "issues": [
                 {
                     "key": "issue1",
@@ -42,61 +39,24 @@ class SonarQubeSecurityWarningsTest(SonarQubeTestCase):
                     "cleanCodeAttributeCategory": "CONSISTENT",
                     "creationDate": "2019-08-30T22:48:52+0200",
                     "updateDate": "2019-09-30T22:48:52+0200",
-                    "tags": ["bug", "other tag"],
+                    "tags": ["bug", "injection"],
+                },
+                {
+                    "key": "issue3",
+                    "message": "message3",
+                    "component": "component3",
+                    "impacts": [{"severity": "high", "softwareQuality": "security"}],
+                    "cleanCodeAttributeCategory": "CONSISTENT",
+                    "creationDate": "2019-08-30T22:48:52+0200",
+                    "updateDate": "2019-09-30T22:48:52+0200",
+                    "tags": [],
                 },
             ],
         }
-        self.hotspots_json = {
-            "paging": {"total": "2"},
-            "hotspots": [
-                {
-                    "key": "hotspot1",
-                    "message": "message1",
-                    "component": "component1",
-                    "vulnerabilityProbability": "MEDIUM",
-                    "creationDate": "2010-12-13T10:37:07+0000",
-                    "updateDate": "2019-08-26T09:02:49+0000",
-                    "status": "TO_REVIEW",
-                },
-                {
-                    "key": "hotspot2",
-                    "message": "message2",
-                    "component": "component2",
-                    "vulnerabilityProbability": "LOW",
-                    "creationDate": "2011-10-26T13:34:12+0000",
-                    "updateDate": "2020-08-31T08:19:00+0000",
-                    "status": "REVIEWED",
-                    "resolution": "FIXED",
-                },
-            ],
-        }
-        self.hotspot_entities = [
-            self.entity(
-                key="hotspot1",
-                component="component1",
-                security_type="security hotspot",
-                message="message1",
-                review_priority="medium",
-                creation_date="2010-12-13T10:37:07+0000",
-                update_date="2019-08-26T09:02:49+0000",
-                hotspot_status="to review",
-            ),
-            self.entity(
-                key="hotspot2",
-                component="component2",
-                security_type="security hotspot",
-                message="message2",
-                review_priority="low",
-                creation_date="2011-10-26T13:34:12+0000",
-                update_date="2020-08-31T08:19:00+0000",
-                hotspot_status="fixed",
-            ),
-        ]
         self.issue_entities = [
             self.entity(
                 key="issue1",
                 component="component1",
-                security_type="issue with security impact",
                 message="message1",
                 impacts="low impact on security",
                 clean_code_attribute_category="responsible",
@@ -107,51 +67,27 @@ class SonarQubeSecurityWarningsTest(SonarQubeTestCase):
             self.entity(
                 key="issue2",
                 component="component2",
-                security_type="issue with security impact",
                 impacts="medium impact on security",
                 clean_code_attribute_category="consistent",
                 creation_date="2019-08-30T22:48:52+0200",
                 update_date="2019-09-30T22:48:52+0200",
                 message="message2",
-                tags="bug, other tag",
+                tags="bug, injection",
+            ),
+            self.entity(
+                key="issue3",
+                component="component3",
+                impacts="high impact on security",
+                clean_code_attribute_category="consistent",
+                creation_date="2019-08-30T22:48:52+0200",
+                update_date="2019-09-30T22:48:52+0200",
+                message="message3",
+                tags="",
             ),
         ]
 
-    async def test_all_security_warnings(self):
-        """Test that all security warnings are returned."""
-        self.set_source_parameter("security_types", ["issue with security impact", "security hotspot"])
-        show_component_json = {}
-        measurement, get, post = await self.collect_measurement_and_mocks(
-            get_request_json_side_effect=[show_component_json, self.issues_json, self.hotspots_json],
-        )
-        get.assert_called_with(self.HOTSPOTS_API, allow_redirects=True, headers={}, auth=None)
-        post.assert_not_called()
-        self.assert_measurement(
-            measurement,
-            value="3",
-            total="100",
-            entities=self.issue_entities + self.hotspot_entities[:1],
-            landing_url=self.DASHBOARD_URL,
-        )
-
-    async def test_security_warnings_hotspots_only(self):
-        """Test that only the security hotspots are returned."""
-        self.set_source_parameter("security_types", ["security hotspot"])
-        measurement, get, post = await self.collect_measurement_and_mocks(
-            get_request_json_return_value=self.hotspots_json
-        )
-        get.assert_called_with(self.HOTSPOTS_API, allow_redirects=True, headers={}, auth=None)
-        post.assert_not_called()
-        self.assert_measurement(
-            measurement,
-            value="1",
-            total="100",
-            entities=self.hotspot_entities[:1],
-            landing_url=self.HOTSPOTS_LANDING_URL,
-        )
-
     async def test_security_warnings_vulnerabilities_only(self):
-        """Test that by default only issues with security impact are returned."""
+        """Test that issues with security impact are returned."""
         measurement, get, post = await self.collect_measurement_and_mocks(
             get_request_json_return_value=self.issues_json
         )
@@ -159,41 +95,24 @@ class SonarQubeSecurityWarningsTest(SonarQubeTestCase):
         post.assert_not_called()
         self.assert_measurement(
             measurement,
-            value="2",
+            value="3",
             total="100",
             entities=self.issue_entities,
             landing_url=self.ISSUES_LANDING_URL,
         )
 
-    async def test_filter_security_warnings_hotspots_by_status(self):
-        """Test that the security hotspots can be filtered by status."""
-        self.set_source_parameter("security_types", ["security hotspot"])
-        self.set_source_parameter("hotspot_statuses", ["to review", "fixed"])
-        measurement, get, post = await self.collect_measurement_and_mocks(
-            get_request_json_return_value=self.hotspots_json
-        )
-        get.assert_called_with(self.HOTSPOTS_API, allow_redirects=True, headers={}, auth=None)
-        post.assert_not_called()
-        self.assert_measurement(
-            measurement,
-            value="2",
-            total="100",
-            entities=self.hotspot_entities,
-            landing_url=self.HOTSPOTS_LANDING_URL,
-        )
-
     async def test_filter_security_warning_issues_by_tag(self):
         """Test that the security warning issues can be filtered by tag."""
-        self.set_source_parameter("tags", ["cwe"])
+        self.set_source_parameter("tags", ["injection"])
         measurement, get, post = await self.collect_measurement_and_mocks(
             get_request_json_return_value=self.issues_json
         )
-        get.assert_called_with(self.ISSUES_API + "&tags=cwe", allow_redirects=True, headers={}, auth=None)
+        get.assert_called_with(self.ISSUES_API + "&tags=injection", allow_redirects=True, headers={}, auth=None)
         post.assert_not_called()
         self.assert_measurement(
             measurement,
-            value="2",
+            value="3",  # SonarQube does the filtering, so here we just get the three entities in self.issues_json
             total="100",
             entities=self.issue_entities,
-            landing_url=self.ISSUES_LANDING_URL + "&tags=cwe",
+            landing_url=self.ISSUES_LANDING_URL + "&tags=injection",
         )

--- a/components/shared_code/src/shared_data_model/sources/sonarqube.py
+++ b/components/shared_code/src/shared_data_model/sources/sonarqube.py
@@ -26,10 +26,7 @@ class Lines(StrEnum):
     CODE = "lines with code"
 
 
-def violation_entity_attributes(
-    include_security_warning_attributes=False,
-    include_suppressed_violation_attributes=False,
-) -> list[EntityAttribute]:
+def violation_entity_attributes(*, include_suppressed_violation_attributes: bool = False) -> list[EntityAttribute]:
     """Return the violation entity attributes."""
     attributes = [
         EntityAttribute(name="Message"),
@@ -50,12 +47,6 @@ def violation_entity_attributes(
         ),
         EntityAttribute(name="Clean code attribute", key="clean_code_attribute_category"),
     ]
-    if include_security_warning_attributes:
-        attributes.append(EntityAttribute(name="Warning type", key="security_type"))
-        attributes.append(EntityAttribute(name="Hotspot status"))
-        attributes.append(
-            EntityAttribute(name="Review priority", color={"high": Color.NEGATIVE, "medium": Color.WARNING}),
-        )
     if include_suppressed_violation_attributes:
         attributes.append(EntityAttribute(name="Issue status"))
         attributes.append(EntityAttribute(name="Rationale"))
@@ -103,8 +94,6 @@ ALL_SONARQUBE_METRICS = sorted(
 )
 
 VIOLATION_ENTITY = Entity(name="violation", attributes=violation_entity_attributes())
-
-ISSUE_SECURITY_TYPE = "issue with security impact"
 
 SONARQUBE = Source(
     name="SonarQube",
@@ -371,8 +360,7 @@ SONARQUBE = Source(
         "version_number_pattern": VersionNumberPattern(),
         "directories_to_include": MultipleChoiceWithAdditionParameter(
             name="Directories to include",
-            help="Only report issues for the listed directories. Note that SonarQube does not support filtering "
-            "security hotspots by directory.",
+            help="Only report issues for the listed directories.",
             placeholder="all directories",
             metrics=PROJECT_ISSUES_METRICS,
         ),
@@ -417,21 +405,6 @@ SONARQUBE = Source(
             values=["adaptable", "consistent", "intentional", "responsible"],
             metrics=["suppressed_violations", "violations"],
         ),
-        "hotspot_statuses": MultipleChoiceWithDefaultsParameter(
-            name="Security hotspot statuses",
-            help_url=HttpUrl("https://docs.sonarsource.com/sonarqube-server/latest/user-guide/security-hotspots/"),
-            placeholder="acknowledged, to review",
-            values=["to review", "acknowledged", "safe", "fixed"],
-            default_value=["to review", "acknowledged"],
-            metrics=["security_warnings"],
-        ),
-        "review_priorities": MultipleChoiceWithDefaultsParameter(
-            name="Security hotspot review priorities",
-            help_url=HttpUrl("https://docs.sonarsource.com/sonarqube-server/latest/user-guide/security-hotspots/"),
-            placeholder="all review priorities",
-            values=["low", "medium", "high"],
-            metrics=["security_warnings"],
-        ),
         "effort_types": MultipleChoiceWithDefaultsParameter(
             name="Types of effort",
             placeholder="all effort types",
@@ -449,14 +422,6 @@ SONARQUBE = Source(
                 "effort to fix all vulnerabilities": "security_remediation_effort",
             },
             metrics=["remediation_effort"],
-        ),
-        "security_types": MultipleChoiceWithDefaultsParameter(
-            name="Security issue types",
-            placeholder=ISSUE_SECURITY_TYPE,
-            help_url=HttpUrl("https://docs.sonarsource.com/sonarqube-server/latest/user-guide/rules/overview/"),
-            default_value=[ISSUE_SECURITY_TYPE],
-            values=["security hotspot", ISSUE_SECURITY_TYPE],
-            metrics=["security_warnings"],
         ),
         "tags": MultipleChoiceWithAdditionParameter(
             name="Tags to include",
@@ -493,7 +458,7 @@ SONARQUBE = Source(
         ),
         "security_warnings": Entity(
             name="security warning",
-            attributes=violation_entity_attributes(include_security_warning_attributes=True),
+            attributes=violation_entity_attributes(),
         ),
         "suppressed_violations": Entity(
             name="violation",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -16,6 +16,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - Drop support for the Cobertura Jenkins plugin as source for metrics. Closes [#12817](https://github.com/ICTU/quality-time/issues/12817).
 - Drop support for Trello as source for metrics. Closes [#12818](https://github.com/ICTU/quality-time/issues/12818).
+- Drop support for SonarQube security hotspots as source for security warnings. Note that security warning metrics with SonarQube as source that were configured to only measure security hotspots will now measure issues with security impact (as the parameter to choose between issues with security impact and security hotspots has been removed). Closes [#12911](https://github.com/ICTU/quality-time/issues/12911).
 - Drop support for Pyupio Safety as source for metrics. Closes [#13079](https://github.com/ICTU/quality-time/issues/13079).
 
 ## v5.57.0 - 2026-06-25


### PR DESCRIPTION
Drop support for SonarQube security hotspots as source for security warnings.

Closes #12911.