### PR TITLE
Fix/workaround CodeQL issues

### DIFF
--- a/components/api_server/src/model/transformations.py
+++ b/components/api_server/src/model/transformations.py
@@ -76,16 +76,16 @@ def decrypt_credential(private_key: str, credential: str | tuple[str, str]) -> s
         return decrypted_credential
 
 
-def replace_report_uuids(*reports) -> None:
-    """Change all uuids in this report."""
-    for report in reports:
-        report["report_uuid"] = uuid()
-        for subject_uuid in report.get("subjects", {}).copy():
-            subject = report["subjects"][uuid()] = report["subjects"].pop(subject_uuid)
-            for metric_uuid in subject.get("metrics", {}).copy():
-                metric = subject["metrics"][uuid()] = subject["metrics"].pop(metric_uuid)
-                for source_uuid in metric.get("sources").copy():
-                    metric["sources"][uuid()] = metric["sources"].pop(source_uuid)
+def replace_report_uuids(report: dict) -> ReportId:
+    """Change all uuids in this report and return the report's new uuid."""
+    report["report_uuid"] = report_uuid = cast("ReportId", uuid())
+    for subject_uuid in report.get("subjects", {}).copy():
+        subject = report["subjects"][uuid()] = report["subjects"].pop(subject_uuid)
+        for metric_uuid in subject.get("metrics", {}).copy():
+            metric = subject["metrics"][uuid()] = subject["metrics"].pop(metric_uuid)
+            for source_uuid in metric.get("sources").copy():
+                metric["sources"][uuid()] = metric["sources"].pop(source_uuid)
+    return report_uuid
 
 
 def change_source_parameter(

--- a/components/api_server/src/routes/measurement.py
+++ b/components/api_server/src/routes/measurement.py
@@ -13,7 +13,7 @@ from shared.utils.type import MetricId, SourceId
 from database import sessions
 from database.measurements import count_measurements, all_metric_measurements, measurements_in_period
 from database.reports import latest_report_for_uuids, latest_reports
-from utils.functions import report_date_time
+from utils.functions import report_date_time, sanitize_html
 from utils.log import get_logger
 
 from .plugins.auth_plugin import EDIT_ENTITY_PERMISSION
@@ -44,6 +44,8 @@ def set_entity_attribute(
     entity_description = "/".join([str(entity[key]) for key in entity if key not in ("key", "url")])
     old_value = source.get("entity_user_data", {}).get(entity_key, {}).get(attribute) or ""
     new_value = cast(dict, bottle.request.json)[attribute]
+    if attribute == "rationale" and new_value:
+        new_value = sanitize_html(new_value)
     user = sessions.find_user(database)
     description = f"{user.name()} changed the {attribute} of '{entity_description}' from '{old_value}' to '{new_value}'"
     entity_user_data = source.setdefault("entity_user_data", {}).setdefault(entity_key, {})

--- a/components/api_server/src/routes/report.py
+++ b/components/api_server/src/routes/report.py
@@ -90,7 +90,6 @@ def get_report_metric_status_summary(database: Database, report: Report, report_
 def post_report_import(database: Database):
     """Import a preconfigured report into the database."""
     report = cast(dict, bottle.request.json)
-    report["delta"] = {"uuids": [report["report_uuid"]]}
 
     secret = database.secrets.find_one({"name": EXPORT_FIELDS_KEYS_NAME}, {"private_key": True, "_id": False})
     if not secret:  # pragma: no feature-test-cover
@@ -98,9 +97,9 @@ def post_report_import(database: Database):
         return {"ok": False, "error": "Cannot find the private key of this Quality-time instance."}
 
     decryption_successful = decrypt_credentials(secret["private_key"], report)
-    replace_report_uuids(report)
-    result = insert_new_report(database, "{user} imported a new report", [report["report_uuid"]], report)
-    result["new_report_uuid"] = report["report_uuid"]
+    new_report_uuid = replace_report_uuids(report)
+    result = insert_new_report(database, "{user} imported a new report", [new_report_uuid], report)
+    result["new_report_uuid"] = new_report_uuid
     if not decryption_successful:
         result["warning"] = (
             "Credentials could not be decrypted, most likely because they were not encrypted with the public key of "

--- a/components/api_server/src/utils/functions.py
+++ b/components/api_server/src/utils/functions.py
@@ -48,10 +48,11 @@ def check_url_availability(
         response = requests.get(url, auth=credentials, headers=headers, timeout=10)
         status_code, exception_reason = response.status_code, response.reason
     except Exception as exception_instance:  # noqa: BLE001
-        exception_reason = str(exception_instance) or exception_instance.__class__.__name__
-        # If the reason contains an errno, only return the errno and accompanying text, and leave out the traceback
-        # that led to the error:
-        exception_reason = re.sub(r".*(\[errno \-?\d+\] [^\)^']+).*", r"\1", exception_reason, flags=re.IGNORECASE)
+        # If the exception message contains an errno, only return the errno and accompanying text, and leave out the
+        # traceback that led to the error. Return the exception class name if the exception message has no errno,
+        # because the rest of the message may expose internals, such as the HTTP libraries and hosts used:
+        errno = re.search(r"""\[errno \-?\d+\] [^\)^'"]+""", str(exception_instance), flags=re.IGNORECASE)
+        exception_reason = errno.group() if errno else exception_instance.__class__.__name__
         status_code = -1
     return {"status_code": status_code, "reason": exception_reason}
 

--- a/components/api_server/tests/routes/test_measurement.py
+++ b/components/api_server/tests/routes/test_measurement.py
@@ -146,6 +146,12 @@ class SetEntityAttributeTest(DatabaseTestCase):
             measurement["delta"],
         )
 
+    def test_set_rationale_sanitizes_html(self):
+        """Test that dangerous HTML is removed from the rationale, because the frontend renders it as HTML."""
+        measurement = self.set_entity_attribute("rationale", '<img src="x" onerror="alert(1)">Why not')
+        entity = measurement["sources"][0]["entity_user_data"]["entity_key"]
+        self.assertEqual({"rationale": '<img src="x">Why not'}, entity)
+
     def test_set_status_also_sets_status_end_date_if_status_has_a_desired_response_time(self):
         """Test that setting the status also sets the end date when the desired status resolution has been set."""
         deadline = (now() + timedelta(days=10)).date()

--- a/components/api_server/tests/routes/test_source.py
+++ b/components/api_server/tests/routes/test_source.py
@@ -227,6 +227,21 @@ class PostSourceParameterTest(SourceTestCase):
         )
 
     @patch.object(requests, "get")
+    def test_url_error_without_errno(self, mock_get, request):
+        """Test that the exception message is not reported if it has no errno, as it may expose internals."""
+        mock_get.side_effect = requests.exceptions.SSLError(
+            "HTTPSConnectionPool(host='internal.example.org', port=443): Max retries exceeded"
+        )
+        request.json = {"url": self.url}
+        response = post_source_parameter(SOURCE_ID, "url", self.database)
+        self.assert_url_check(response, -1, "SSLError")
+        self.assert_delta(
+            "url of source 'Source' of metric 'Metric' of subject 'Subject' in report 'Report' "
+            f"from '' to '{self.url}'",
+            report=self.inserted_report(),
+        )
+
+    @patch.object(requests, "get")
     def test_url_socket_error(self, mock_get, request):
         """Test that the error is reported if a request exception occurs, while checking connection of a url."""
         mock_get.side_effect = socket.gaierror("This is some text that should be ignored ([Errno 1234] Error message)")

--- a/tests/feature_tests/src/features/measurement_entities.feature
+++ b/tests/feature_tests/src/features/measurement_entities.feature
@@ -60,6 +60,18 @@ Feature: measurement entities
     And the client sets the status_end_date of entity 1 to "2022-02-02"
     Then the metric status is "target_met"
 
+  Scenario: the rationale for the status of an entity is sanitized
+    Given an existing metric with type "user_story_points"
+    And an existing source with type "azure_devops"
+    When the collector measures "120"
+      | key | story_points |
+      | 1   | 100          |
+    And the client sets the rationale of entity 1 to "<b>Fixed</b> in the next release<script>alert('XSS')</script>"
+    Then the source changelog reads
+      """
+      Jane Doe changed the rationale of '100' from '' to '<b>Fixed</b> in the next release'.
+      """
+
   Scenario: mark an entity to a different status with the same desired response time
     Given an existing metric with type "user_story_points"
     And an existing source with type "azure_devops"

--- a/tests/feature_tests/test.sh
+++ b/tests/feature_tests/test.sh
@@ -55,8 +55,11 @@ wait "$api_server_pid" 2>/dev/null || true
 if [[ "$result" -eq "0" ]]
 then
   tests/feature_tests/.venv/bin/coverage combine . components/api_server
+  # Write the text and HTML reports first and don't let them fail, so that the HTML report is always available as
+  # CI-artefact to see what is uncovered. The XML report is written last because it fails when the coverage is too
+  # low, and 'set -e' would prevent the other reports from being written if it failed first.
+  tests/feature_tests/.venv/bin/coverage report --fail-under=0
+  tests/feature_tests/.venv/bin/coverage html --fail-under=0
   tests/feature_tests/.venv/bin/coverage xml
-  tests/feature_tests/.venv/bin/coverage html
-  tests/feature_tests/.venv/bin/coverage report
 fi
 exit $result


### PR DESCRIPTION
The rationale of a measurement entity's status is rendered as HTML in the frontend, through DivWithHtml/dangerouslySetInnerHTML in SourceEntity.jsx, but the API server stored it verbatim. A user with the edit-entity permission could store markup that ran in the browser of everyone viewing the source's measurement entities. Sanitize the rationale with sanitize_html on save, as already happens for the comment fields of reports, subjects, metrics, and sources, which are the other fields rendered as HTML. Fixes CodeQL alert 23853 (py/reflective-xss).

Don't expose exception messages in the URL availability check: check_url_availability() returned str(exception) as the availability reason, which is sent to the client by post_report_issue_tracker_attribute() and post_source_parameter(). The regex that narrows the message to its errno was already there, but re.sub() returns the subject unchanged when it does not match, so any exception without an errno leaked its full message, including urllib3 connection pool internals and object reprs. Use re.search() instead and fall back to the exception class name when there is no errno, so the reason fails closed. The errno cases, which are the common ones, are unchanged. Addresses CodeQL alerts 23855 and 23856 (py/stack-trace-exposure).

CodeQL alert 23854 (py/reflective-xss) traced the JSON request body in post_report_import() through report["report_uuid"] into the response. The value was already a freshly generated UUID, since replace_report_uuids() overwrites it, but CodeQL cannot see that the dict entry has been sanitized. Have replace_report_uuids() return the report's new UUID and use that for both the delta UUIDs and new_report_uuid, so the value no longer comes from a read-back of the request body. Narrow its *reports varargs to a single report, as it only has one caller.