### PR TITLE
Fix GitLab pipeline duration without idle time

### DIFF
--- a/components/collector/src/source_collectors/gitlab/base.py
+++ b/components/collector/src/source_collectors/gitlab/base.py
@@ -158,6 +158,15 @@ class GitLabPipelineBase(GitLabProjectBase):
         matches_trigger = entity["trigger"] in self._parameter("pipeline_triggers_to_include")
         return matches_branches and matches_schedule_description and matches_status and matches_trigger
 
+    async def _pipeline_details(self, pipeline_ids: list[str]) -> list[Pipeline]:
+        """Get the details, such as the duration, of the pipelines with the specified ids, in the same order."""
+        if not pipeline_ids:
+            return []
+        urls = [await self._gitlab_api_url(f"pipelines/{pipeline_id}") for pipeline_id in pipeline_ids]
+        # Skip GitLabPipelineBase._get_source_responses() because the pipeline schedules have already been retrieved
+        responses = await super()._get_source_responses(*urls)
+        return [Pipeline.from_json(**await response.json()) for response in responses]
+
     async def _pipelines(self, responses: SourceResponses) -> list[Pipeline]:
         """Get the pipelines from the responses."""
         pipelines = []

--- a/components/collector/src/source_collectors/gitlab/json_types.py
+++ b/components/collector/src/source_collectors/gitlab/json_types.py
@@ -26,8 +26,13 @@ class GitLabJSON:
 class Pipeline(GitLabJSON):
     """GitLab pipeline JSON. See https://docs.gitlab.com/ee/api/pipelines.html.
 
-    We don't use the pipeline details to determine the pipeline duration, but simply subtract the update_at and
-    created_at timestamps. Reason is that GitLab itself is pretty unclear about what exactly the pipeline duration is.
+    To determine the bruto duration of a pipeline, we don't get the duration reported by GitLab, but simply subtract
+    the updated_at and created_at timestamps. Reason is that the API to list pipelines of a project does not return
+    the duration.Getting the duration requires  a call to the API to get one pipelines for each pipeline.
+
+    Note that GitLab does not report a duration for pipelines that have not finished.
+
+    Also note that GitLab itself is pretty unclear about what exactly the pipeline duration is.
     See https://gitlab.com/gitlab-org/gitlab/-/issues/19594.
     """
 
@@ -39,7 +44,7 @@ class Pipeline(GitLabJSON):
     source: str
     created_at: str
     web_url: str
-    duration: int = 0
+    duration: int | None = None
     updated_at: str = ""
     schedule_description: str = ""  # Pipeline schedule description for scheduled pipelines
 
@@ -58,11 +63,7 @@ class Pipeline(GitLabJSON):
     @property
     def netto_duration(self) -> timedelta:
         """Return the netto duration of the pipeline, meaning the duration excluding idle time."""
-        return timedelta(minutes=self.duration)
-
-    def pipeline_duration(self, exclude_idle_time: bool) -> timedelta:
-        """Return the duration of the pipeline."""
-        return self.netto_duration if exclude_idle_time else self.bruto_duration
+        return timedelta(seconds=self.duration or 0)
 
 
 @dataclass

--- a/components/collector/src/source_collectors/gitlab/pipeline_duration.py
+++ b/components/collector/src/source_collectors/gitlab/pipeline_duration.py
@@ -20,9 +20,26 @@ class GitLabPipelineDuration(GitLabPipelineBase):
     def _create_entity(self, pipeline: Pipeline) -> Entity:
         """Extend to also add the duration to the entity created from a GitLab pipeline."""
         entity = super()._create_entity(pipeline)
-        exclude_idle_time = self._parameter("exclude_idle_time_from_pipeline_duration") == "yes"
-        entity["duration"] = str(minutes(pipeline.pipeline_duration(exclude_idle_time)))
+        entity["duration"] = str(minutes(pipeline.bruto_duration))
         return entity
+
+    async def _parse_entities(self, responses: SourceResponses) -> Entities:
+        """Extend to replace the bruto durations with the netto durations, if idle time is to be excluded."""
+        entities = await super()._parse_entities(responses)
+        if self._parameter("exclude_idle_time_from_pipeline_duration") == "yes":
+            await self._replace_bruto_with_netto_duration(entities)
+        return entities
+
+    async def _replace_bruto_with_netto_duration(self, entities: Entities) -> None:
+        """Replace the duration of the entities that pass the filters with the netto duration of their pipeline.
+
+        Only the GitLab API to get one pipeline returns the duration of a pipeline, so the details of each pipeline
+        that passes the filters have to be retrieved separately. The key of the entities is the pipeline id.
+        """
+        included_entities = [entity for entity in entities if self._include_entity(entity)]
+        pipelines = await self._pipeline_details([entity["key"] for entity in included_entities])
+        for entity, pipeline in zip(included_entities, pipelines, strict=True):
+            entity["duration"] = str(minutes(pipeline.netto_duration))
 
     async def _parse_value(self, responses: SourceResponses, included_entities: Entities) -> Value:
         """Parse the value from the responses."""

--- a/components/collector/tests/source_collectors/gitlab/test_pipeline_duration.py
+++ b/components/collector/tests/source_collectors/gitlab/test_pipeline_duration.py
@@ -26,14 +26,19 @@ class GitLabPipelineDurationTest(GitLabTestCase):
         self.pipeline_schedules_json = [{"id": "pipeline schedule id", "description": "pipeline description"}]
         self.scheduled_pipelines_json = [{"id": "pipeline 1"}]
         self.pipeline_json = [self.create_pipeline_run()]
+        self.pipeline_details_json = [self.create_pipeline_details()]
 
     def create_pipeline_run(
         self,
         pipeline_id: str = "1",
         created_at: str = "2022-09-21T01:05:14.197Z",
         updated_at: str = "2022-09-21T01:15:14.175Z",
+        status: str = "success",
     ):
-        """Create a pipeline run."""
+        """Create a pipeline run, as returned by the GitLab API to list the pipelines of a project.
+
+        Note that this API does not return the duration of the pipelines; only the API to get one pipeline does.
+        """
         return {
             "id": f"pipeline {pipeline_id}",
             "project_id": "project id",
@@ -41,21 +46,40 @@ class GitLabPipelineDurationTest(GitLabTestCase):
             "created_at": created_at,
             "updated_at": updated_at,
             "ref": "branch",
-            "status": "success",
+            "status": status,
             "source": "push",
             "web_url": self.landing_url,
-            "duration": 7,
         }
 
-    async def collect_measurement(self) -> MetricMeasurement:
+    def create_pipeline_details(self, pipeline_id: str = "1", duration: int | None = 420, **kwargs):
+        """Create the details of a pipeline run, as returned by the GitLab API to get one pipeline.
+
+        The duration is the number of seconds the pipeline ran, excluding the time it spent queued. GitLab does not
+        report a duration for pipelines that have not finished, so the duration can be null.
+        """
+        return self.create_pipeline_run(pipeline_id=pipeline_id, **kwargs) | {
+            "started_at": "2022-09-21T01:05:20.000Z",
+            "finished_at": "2022-09-21T01:12:20.000Z" if duration else None,
+            "duration": duration,
+            "queued_duration": 6,
+        }
+
+    async def collect(self, **kwargs) -> MetricMeasurement | tuple[MetricMeasurement | None, Mock, Mock] | None:
         """Override to pass the GitLab pipeline JSON responses."""
-        return await super().collect_measurement(
-            get_request_side_effect=[
-                FakeResponse(self.pipeline_schedules_json),  # To fetch all pipeline schedules
-                FakeResponse(self.scheduled_pipelines_json),  # To fetch all pipelines for the pipeline schedule
-                FakeResponse(self.pipeline_json),  # To fetch all pipelines
-            ]
-        )
+        responses = [
+            FakeResponse(self.pipeline_schedules_json),  # To fetch all pipeline schedules
+            FakeResponse(self.scheduled_pipelines_json),  # To fetch all pipelines for the pipeline schedule
+            FakeResponse(self.pipeline_json),  # To fetch all pipelines
+        ]
+        if self.exclude_idle_time():
+            # To fetch the details of each pipeline that passes the filters, because only the API to get one pipeline
+            # returns the duration of the pipeline
+            responses.extend(FakeResponse(details) for details in self.pipeline_details_json)
+        return await super().collect(get_request_side_effect=responses, **kwargs)
+
+    def exclude_idle_time(self) -> bool:
+        """Return whether idle time is excluded from the pipeline duration."""
+        return str(self.sources["source_id"]["parameters"].get("exclude_idle_time_from_pipeline_duration")) == "yes"
 
     async def test_report_slowest_duration(self):
         """Test that the duration of the slowest pipeline is returned."""
@@ -106,7 +130,53 @@ class GitLabPipelineDurationTest(GitLabTestCase):
         self.assert_measurement(measurement, value="10", landing_url=self.landing_url)
 
     async def test_exclude_idle_time(self):
-        """Test that idle time can be excluded from pipeline duration."""
+        """Test that idle time can be excluded from pipeline duration.
+
+        GitLab reports the duration of a pipeline in seconds, so the 420 seconds of the pipeline are reported as
+        seven minutes.
+        """
         self.set_source_parameter("exclude_idle_time_from_pipeline_duration", "yes")
         measurement = await self.collect_measurement()
         self.assert_measurement(measurement, value="7", landing_url=self.landing_url)
+
+    async def test_exclude_idle_time_when_pipeline_has_not_finished(self):
+        """Test that pipelines for which GitLab reports no duration are counted as taking zero minutes."""
+        self.set_source_parameter("exclude_idle_time_from_pipeline_duration", "yes")
+        unfinished = {"pipeline_id": "2", "status": "running"}
+        self.pipeline_json.append(self.create_pipeline_run(**unfinished))
+        self.pipeline_details_json.append(self.create_pipeline_details(duration=None, **unfinished))
+        measurement = await self.collect_measurement()
+        self.assert_measurement(measurement, value="7", landing_url=self.landing_url)
+
+    async def test_exclude_idle_time_when_no_match(self):
+        """Test that no pipeline details are fetched when no pipelines pass the filters."""
+        self.set_source_parameter("exclude_idle_time_from_pipeline_duration", "yes")
+        self.set_source_parameter("branches", ["missing"])
+        measurement, get, _post = await self.collect_measurement_and_mocks()
+        self.assert_measurement(measurement, parse_error="No pipelines found with given filter(s)")
+        self.assertEqual([], self.pipeline_detail_urls(get))
+
+    async def test_pipeline_details_fetched_when_excluding_idle_time(self):
+        """Test that the details of the pipelines that pass the filters are fetched, to get their duration."""
+        self.set_source_parameter("exclude_idle_time_from_pipeline_duration", "yes")
+        _measurement, get, _post = await self.collect_measurement_and_mocks()
+        expected_url = "https://gitlab/api/v4/projects/namespace%2Fproject/pipelines/pipeline 1?per_page=100"
+        self.assertEqual([expected_url], self.pipeline_detail_urls(get))
+
+    async def test_pipeline_details_not_fetched_when_including_idle_time(self):
+        """Test that the pipeline details are not fetched when idle time is included in the pipeline duration."""
+        measurement, get, _post = await self.collect_measurement_and_mocks()
+        self.assert_measurement(measurement, value="10", landing_url=self.landing_url)
+        # Only the pipeline schedules, the scheduled pipelines, and the pipelines are fetched
+        self.assertEqual(3, len(self.request_urls(get)))
+        self.assertEqual([], self.pipeline_detail_urls(get))
+
+    @staticmethod
+    def request_urls(get: Mock) -> list[str]:
+        """Return the URLs of the get requests."""
+        return [str(call.args[0]) for call in get.call_args_list]
+
+    @classmethod
+    def pipeline_detail_urls(cls, get: Mock) -> list[str]:
+        """Return the URLs of the get requests for the details of individual pipelines."""
+        return [url for url in cls.request_urls(get) if "/pipelines/" in url]

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,6 +19,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 - Drop support for SonarQube security hotspots as source for security warnings. Note that security warning metrics with SonarQube as source that were configured to only measure security hotspots will now measure issues with security impact (as the parameter to choose between issues with security impact and security hotspots has been removed). Closes [#12911](https://github.com/ICTU/quality-time/issues/12911).
 - Drop support for Pyupio Safety as source for metrics. Closes [#13079](https://github.com/ICTU/quality-time/issues/13079).
 
+### Fixed
+
+- When using GitLab as source for the 'CI-pipeline duration' metric with the parameter 'exclude idle time from pipeline duration' set to 'yes', the duration of each pipeline would be zero minutes. The reason is that GitLab does not report the duration of pipelines when listing the pipelines of a project. Get the details of each pipeline that passes the filters to retrieve its duration. Fixes [#13944](https://github.com/ICTU/quality-time/issues/13944).
+
 ## v5.57.0 - 2026-06-25
 
 ### Changed


### PR DESCRIPTION
When using GitLab as source for the 'CI-pipeline duration' metric with the parameter 'exclude idle time from pipeline duration' set to 'yes', the duration of each pipeline would be zero minutes. The reason is that GitLab does not report the duration of pipelines when listing the pipelines of a project. Get the details of each pipeline that passes the filters to retrieve its duration.

Fixes #13944.