### PR TITLE
Fix spinner not disappearing

### DIFF
--- a/components/frontend/src/App.jsx
+++ b/components/frontend/src/App.jsx
@@ -203,6 +203,9 @@ export default function App() {
             date = null
         }
         history.replace({ search: toSearchString(parsed) })
+        if (date?.getTime() === reportDate?.getTime()) {
+            return // The report date did not change; don't show the spinner because no reports will be fetched
+        }
         setReportDate(date)
         setLoading(true)
     }

--- a/components/frontend/src/App.test.jsx
+++ b/components/frontend/src/App.test.jsx
@@ -176,6 +176,16 @@ it("handles a date reset", async () => {
     expect(reportDateButton().textContent).toMatch(/today/)
 })
 
+it("hides the spinner after resetting the settings when the report date is today", async () => {
+    // Regression test for https://github.com/ICTU/quality-time/issues/14553
+    history.push("?expanded=subject_uuid:0")
+    mockSuccessfulFetches()
+    render(<App />)
+    await waitFor(() => expectNoLabelText(/Loading/))
+    clickText("Reset settings")
+    expectNoLabelText(/Loading/)
+})
+
 it("navigates to a report when its card is clicked", async () => {
     mockSuccessfulFetches({ reports: [{ report_uuid: "report_uuid", title: "Report title", subjects: {} }] })
     render(<App />)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -20,6 +20,10 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 - The compose file that comes with *Quality-time* passes the password of the LDAP lookup user to the API-server as a secret, read from `docker/ldap_lookup_user_password.txt`, instead of as an environment variable. If you use the `LDAP_LOOKUP_USER_PASSWORD` environment variable to configure the compose file, put the password in the secret file instead, or point the secret to a file of your own. See the [deployment instructions](deployment.md#ldap).
 
+### Fixed
+
+- When clicking the 'Reset settings' button while not time traveling, a spinner would appear and never disappear. This bug was introduced in v5.55.0. Fixes [#14553](https://github.com/ICTU/quality-time/issues/14553).
+
 ## v5.58.0 - 2026-08-21
 
 ### Added


### PR DESCRIPTION
When clicking the 'Reset settings' button while not time traveling, a spinner would appear and never disappear. This bug was introduced in v5.55.0.

Fixes #14553.