### PR TITLE
Fix several bugs in the dashboards

### DIFF
--- a/components/frontend/src/dashboard/CardDashboard.jsx
+++ b/components/frontend/src/dashboard/CardDashboard.jsx
@@ -1,8 +1,13 @@
 import { array, arrayOf, bool, element, func } from "prop-types"
 import { useEffect, useState } from "react"
-import ReactGridLayout, { noCompactor, useContainerWidth } from "react-grid-layout"
+import ReactGridLayout, { getCompactor, useContainerWidth } from "react-grid-layout"
+import { absoluteStrategy } from "react-grid-layout/core"
 
 import { accessGranted, EDIT_REPORT_PERMISSION, PermissionsContext } from "../context/Permissions"
+
+// Don't compact the layout, so cards can be placed anywhere, but do prevent cards from overlapping. Note that
+// react-grid-layout reads preventCollision from the compactor; passing it as a prop has no effect.
+const compactor = getCompactor(null, false, true)
 
 function cardDivs(cards, isDragging) {
     return cards.map((card) => (
@@ -30,7 +35,7 @@ export function CardDashboard({ cards, initialLayout, saveLayout }) {
     const cols = 32
     const cardWidth = 4
     const cardHeight = 6
-    const { width, containerRef, mounted } = useContainerWidth()
+    const { width, containerRef, mounted } = useContainerWidth({ measureBeforeMount: true })
     const [mousePos, setMousePos] = useState([0, 0, 0])
     const [dragging, setDragging] = useState(false)
     useEffect(() => {
@@ -45,6 +50,9 @@ export function CardDashboard({ cards, initialLayout, saveLayout }) {
     }
     const cardKeys = new Set(cards.map((card) => card.key))
     const layout = (initialLayout ?? []).filter((layoutItem) => cardKeys.has(layoutItem.i))
+    // Keep the layout of cards that are currently hidden, for example because the user hid their tags, so their
+    // position is not lost when the user drags a card and the layout is saved
+    const hiddenLayout = (initialLayout ?? []).filter((layoutItem) => !cardKeys.has(layoutItem.i))
     const layoutItemIds = new Set(layout.map((layoutItem) => layoutItem.i))
     const newCards = cards.filter((card) => !layoutItemIds.has(card.key))
     const maxY = layout.length === 0 ? 0 : Math.max(...layout.map((card) => card.y)) + cardHeight
@@ -68,7 +76,7 @@ export function CardDashboard({ cards, initialLayout, saveLayout }) {
 
     function onDragStop(newLayout, _oldItem, _newItem, _placeholder, event) {
         if (isDragging(event) && newLayout !== layout) {
-            saveLayout(newLayout)
+            saveLayout(newLayout.concat(hiddenLayout))
         }
         setTimeout(() => setDragging(false), 200) // User was dragging, prevent click event propagation
     }
@@ -93,15 +101,13 @@ export function CardDashboard({ cards, initialLayout, saveLayout }) {
                 <div ref={containerRef}>
                     {mounted && (
                         <ReactGridLayout
-                            compactor={noCompactor}
-                            isDraggable={accessGranted(permissions, [EDIT_REPORT_PERMISSION])}
+                            compactor={compactor}
+                            dragConfig={{ enabled: accessGranted(permissions, [EDIT_REPORT_PERMISSION]) }}
                             gridConfig={{ cols: cols, rowHeight: 24 }}
                             layout={layout}
-                            measureBeforeMount={true}
                             onDragStart={onDragStart}
                             onDragStop={onDragStop}
-                            preventCollision={true}
-                            useCSSTransforms={false} // Don't fly-in the cards from the top left
+                            positionStrategy={absoluteStrategy} // Don't fly-in the cards from the top left
                             width={width}
                         >
                             {cardDivs(cards, isDragging)}

--- a/components/frontend/src/dashboard/CardDashboard.test.jsx
+++ b/components/frontend/src/dashboard/CardDashboard.test.jsx
@@ -23,10 +23,15 @@ function metricSummaryCard(key = "card") {
     )
 }
 
-function renderCardDashboard({ cards = [], initialLayout = [], saveLayout = vi.fn } = {}) {
+function renderCardDashboard({
+    cards = [],
+    initialLayout = [],
+    saveLayout = vi.fn,
+    permissions = [EDIT_REPORT_PERMISSION],
+} = {}) {
     return render(
         <ThemeProvider theme={theme}>
-            <PermissionsContext value={[EDIT_REPORT_PERMISSION]}>
+            <PermissionsContext value={permissions}>
                 <div id="dashboard">
                     <CardDashboard cards={cards} initialLayout={initialLayout} saveLayout={saveLayout} />
                 </div>
@@ -65,8 +70,19 @@ it("reuses initial layout entries for matching cards", async () => {
         saveLayout: saveLayout,
     })
     // y=12 with rowHeight 24 + default margin 10 → pixel y = 12*24 + 12*10 + 10 = 418px.
-    // If the initial entry were ignored, the card would be placed fresh at y=0.
+    // If the initial entry were ignored, the card would be placed fresh at y=0. Cards are positioned with top/left
+    // instead of CSS transforms so that they don't fly in from the top left.
     const gridItem = container.querySelector(".react-grid-item")
-    expect(gridItem.style.transform).toContain("418px")
+    expect(gridItem.style.top).toBe("418px")
     expect(saveLayout).not.toHaveBeenCalled()
+})
+
+it("allows for dragging cards with the edit report permission", async () => {
+    const { container } = renderCardDashboard({ cards: [metricSummaryCard()] })
+    expect(container.querySelector(".react-grid-item")).toHaveClass("react-draggable")
+})
+
+it("does not allow for dragging cards without the edit report permission", async () => {
+    const { container } = renderCardDashboard({ cards: [metricSummaryCard()], permissions: [] })
+    expect(container.querySelector(".react-grid-item")).not.toHaveClass("react-draggable")
 })

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -27,6 +27,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 ### Fixed
 
 - When clicking the 'Reset settings' button while not time traveling, a spinner would appear and never disappear. This bug was introduced in v5.55.0. Fixes [#14553](https://github.com/ICTU/quality-time/issues/14553).
+- Fix several bugs in the dashboards: when dragging a card, other cards would be moved around and could end up hidden behind each other (this bug was introduced in v5.48.2), cards could be dragged by users without the 'edit report' permission (this bug was introduced in v5.48.0), and dragging a card while other cards were hidden, for example because their tags were hidden, would make the dashboard forget the position of the hidden cards. Fixes [#14557](https://github.com/ICTU/quality-time/issues/14557).
 
 ## v5.58.0 - 2026-08-21
 


### PR DESCRIPTION
- When dragging a card, other cards would be moved around and could end up hidden behind each other (this bug was introduced in v5.48.2).
- Cards could be dragged by users without the 'edit report' permission (this bug was introduced in v5.48.0).
- Dragging a card while other cards were hidden, for example because their tags were hidden, would make the dashboard forget the position of the hidden cards.

Fixes #14557.