### PR TITLE
Count a job as failed after X failures

### DIFF
--- a/components/collector/src/source_collectors/gitlab/base.py
+++ b/components/collector/src/source_collectors/gitlab/base.py
@@ -1,7 +1,9 @@
 """GitLab collector base classes."""
 
 from abc import ABC
+from collections import defaultdict
 from datetime import datetime, timedelta
+from operator import itemgetter
 from typing import cast
 
 from shared.utils.date_time import now
@@ -64,36 +66,35 @@ class GitLabJobsBase(GitLabProjectBase):
 
     async def _parse_entities(self, responses: SourceResponses) -> Entities:
         """Override to parse the jobs from the responses."""
-        return Entities(
-            [
-                Entity(
-                    branch=job["ref"],
-                    build_date=str(self._build_datetime(job).date()),
-                    build_datetime=self._build_datetime(job),
-                    build_result=job["status"],
-                    key=job["id"],
-                    name=job["name"],
-                    stage=job["stage"],
-                    url=job["web_url"],
-                )
-                for job in await self._jobs(responses)
-            ],
+        return Entities([self._create_entity(job) for job in await self._jobs(responses)])
+
+    def _create_entity(self, job: Job) -> Entity:
+        """Create an entity from a job."""
+        return Entity(
+            branch=job["ref"],
+            build_date=str(self._build_datetime(job).date()),
+            build_datetime=self._build_datetime(job),
+            build_result=job["status"],
+            key=job["id"],
+            name=job["name"],
+            stage=job["stage"],
+            url=job["web_url"],
         )
 
+    async def _jobs(self, responses: SourceResponses) -> list[Job]:
+        """Return the jobs to count, that is, the most recent run of each job."""
+        return [runs[0] for runs in (await self._job_runs(responses)).values()]
+
     @staticmethod
-    async def _jobs(responses: SourceResponses) -> list[Job]:
-        """Return the jobs to count."""
-
-        def newer(job1: Job, job2: Job) -> Job:
-            """Return the newer of the two jobs."""
-            return job1 if job1["created_at"] > job2["created_at"] else job2
-
-        jobs: dict[tuple[str, str, str], Job] = {}
+    async def _job_runs(responses: SourceResponses) -> dict[tuple[str, str, str], list[Job]]:
+        """Return the runs of each job, most recent run first. Jobs are identified by name, stage, and ref."""
+        job_runs: dict[tuple[str, str, str], list[Job]] = defaultdict(list)
         for response in responses:
             for job in await response.json():
-                key = job["name"], job["stage"], job["ref"]
-                jobs[key] = newer(job, jobs.get(key, job))
-        return list(jobs.values())
+                job_runs[(job["name"], job["stage"], job["ref"])].append(job)
+        for runs in job_runs.values():
+            runs.sort(key=itemgetter("created_at"), reverse=True)
+        return job_runs
 
     def _include_entity(self, entity: Entity) -> bool:
         """Return whether to count the job."""

--- a/components/collector/src/source_collectors/gitlab/failed_jobs.py
+++ b/components/collector/src/source_collectors/gitlab/failed_jobs.py
@@ -1,17 +1,47 @@
 """GitLab failed jobs collector."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from .base import GitLabJobsBase
 
 if TYPE_CHECKING:
-    from model import Entity
+    from model import Entity, SourceResponses
+
+    from .json_types import Job
+
+FAILURE_COUNT = "failure_count"  # Key used to add the number of consecutive failures to the job JSON
 
 
 class GitLabFailedJobs(GitLabJobsBase):
     """Collector class to get failed job counts from GitLab."""
 
-    def _include_entity(self, entity: Entity) -> bool:
-        """Return whether the job has failed."""
+    async def _jobs(self, responses: SourceResponses) -> list[Job]:
+        """Extend to add the number of consecutive failures to each job."""
+        jobs = []
+        for runs in (await self._job_runs(responses)).values():
+            job = runs[0]
+            job[FAILURE_COUNT] = self._consecutive_failures(runs)
+            jobs.append(job)
+        return jobs
+
+    def _create_entity(self, job: Job) -> Entity:
+        """Extend to add the number of consecutive failures to the entity."""
+        entity = super()._create_entity(job)
+        entity[FAILURE_COUNT] = str(job[FAILURE_COUNT])
+        return entity
+
+    def _consecutive_failures(self, runs: list[Job]) -> int:
+        """Return the number of most recent runs of the job that failed in a row, within the look-back period."""
         failure_types = list(self._parameter("failure_type"))
-        return super()._include_entity(entity) and entity["build_result"] in failure_types
+        lookback_datetime = self._lookback_datetime()
+        consecutive_failures = 0
+        for run in runs:
+            if run["status"] not in failure_types or self._build_datetime(run) < lookback_datetime:
+                break
+            consecutive_failures += 1
+        return consecutive_failures
+
+    def _include_entity(self, entity: Entity) -> bool:
+        """Return whether the job has failed often enough."""
+        minimum_number_of_failures = int(cast(str, self._parameter("minimum_number_of_failures")))
+        return super()._include_entity(entity) and int(entity[FAILURE_COUNT]) >= minimum_number_of_failures

--- a/components/collector/src/source_collectors/gitlab/job_runs_within_time_period.py
+++ b/components/collector/src/source_collectors/gitlab/job_runs_within_time_period.py
@@ -15,9 +15,8 @@ if TYPE_CHECKING:
 class GitLabJobRunsWithinTimePeriod(GitLabJobsBase):
     """Collector class to measure the number of GitLab CI builds run within a specified time period."""
 
-    @staticmethod
-    async def _jobs(responses: SourceResponses) -> list[Job]:
-        """Return the jobs to count, not deduplicated to latest branch or tag run."""
+    async def _jobs(self, responses: SourceResponses) -> list[Job]:
+        """Override to return the jobs to count, not deduplicated to latest branch or tag run."""
         jobs: list[Job] = []
         for response in responses:
             jobs.extend(list(await response.json()))

--- a/components/collector/tests/source_collectors/gitlab/test_failed_jobs.py
+++ b/components/collector/tests/source_collectors/gitlab/test_failed_jobs.py
@@ -8,6 +8,25 @@ class GitLabFailedJobsTest(CommonGitLabJobsTestsMixin, GitLabJobsTestCase):
 
     METRIC_TYPE = "failed_jobs"
 
+    def setUp(self):
+        """Extend to add the number of consecutive failures to the expected entities."""
+        super().setUp()
+        for entity in self.expected_entities:
+            entity["failure_count"] = "1"
+
+    @staticmethod
+    def failed_job2_run(job_id: str, created_at: str, status: str = "failed") -> dict[str, str]:
+        """Return a previous run of the second job."""
+        return {
+            "id": job_id,
+            "status": status,
+            "name": "job2",
+            "stage": "stage",
+            "created_at": created_at,
+            "web_url": f"https://gitlab/jobs/{job_id}",
+            "ref": "develop",
+        }
+
     async def test_nr_of_failed_jobs(self):
         """Test that the number of failed jobs is returned."""
         measurement = await self.collect_measurement(get_request_json_return_value=self.gitlab_jobs_json)
@@ -54,6 +73,41 @@ class GitLabFailedJobsTest(CommonGitLabJobsTestsMixin, GitLabJobsTestCase):
         self.assert_measurement(
             measurement, value="1", entities=self.expected_entities[-1:], landing_url=self.LANDING_URL
         )
+
+    async def test_minimum_number_of_failures(self):
+        """Test that jobs that failed fewer times in a row than the minimum are not counted."""
+        self.set_source_parameter("minimum_number_of_failures", "2")
+        measurement = await self.collect_measurement(get_request_json_return_value=self.gitlab_jobs_json)
+        self.assert_measurement(measurement, value="0", entities=[], landing_url=self.LANDING_URL)
+
+    async def test_consecutive_failures(self):
+        """Test that jobs that failed at least the minimum number of times in a row are counted."""
+        self.set_source_parameter("minimum_number_of_failures", "2")
+        self.gitlab_jobs_json.append(self.failed_job2_run("5", "2019-03-31T19:39:39.927Z"))
+        expected_entities = self.expected_entities[-1:]
+        expected_entities[0]["failure_count"] = "2"
+        measurement = await self.collect_measurement(get_request_json_return_value=self.gitlab_jobs_json)
+        self.assert_measurement(measurement, value="1", entities=expected_entities, landing_url=self.LANDING_URL)
+
+    async def test_successful_run_ends_the_sequence_of_failures(self):
+        """Test that a successful run before the failed runs ends the sequence of failures."""
+        self.set_source_parameter("minimum_number_of_failures", "2")
+        self.gitlab_jobs_json.extend(
+            [
+                self.failed_job2_run("5", "2019-03-31T19:39:39.927Z", status="success"),
+                self.failed_job2_run("6", "2019-03-31T19:38:39.927Z"),
+            ],
+        )
+        measurement = await self.collect_measurement(get_request_json_return_value=self.gitlab_jobs_json)
+        self.assert_measurement(measurement, value="0", entities=[], landing_url=self.LANDING_URL)
+
+    async def test_failed_runs_outside_the_lookback_period(self):
+        """Test that failed runs outside the look-back period do not count as failures."""
+        self.set_source_parameter("lookback_days", "20000")  # Look back to about 1971
+        self.set_source_parameter("minimum_number_of_failures", "2")
+        self.gitlab_jobs_json.append(self.failed_job2_run("5", "1970-03-31T19:39:39.927Z"))
+        measurement = await self.collect_measurement(get_request_json_return_value=self.gitlab_jobs_json)
+        self.assert_measurement(measurement, value="0", entities=[], landing_url=self.LANDING_URL)
 
     async def test_private_token(self):
         """Test that the private token is used."""

--- a/components/shared_code/src/shared_data_model/meta/unit.py
+++ b/components/shared_code/src/shared_data_model/meta/unit.py
@@ -27,6 +27,7 @@ class Unit(StrEnum):
     DOWNVOTES = auto()
     FAILED_DEPLOYMENT = "failed deployment"
     FAILED_DEPLOYMENTS = "failed deployments"
+    FAILURES = auto()
     ISSUE = auto()
     ISSUES = auto()
     LINE = auto()

--- a/components/shared_code/src/shared_data_model/sources/gitlab.py
+++ b/components/shared_code/src/shared_data_model/sources/gitlab.py
@@ -4,6 +4,7 @@ from pydantic import HttpUrl
 
 from shared_data_model.meta.entity import Color, Entity, EntityAttribute, EntityAttributeType
 from shared_data_model.meta.source import Source
+from shared_data_model.meta.unit import Unit
 from shared_data_model.parameters import (
     URL,
     Branch,
@@ -12,6 +13,7 @@ from shared_data_model.parameters import (
     BranchMergeStatus,
     Days,
     FailureType,
+    IntegerParameter,
     MergeRequestState,
     MultipleChoiceWithAdditionParameter,
     MultipleChoiceWithDefaultsParameter,
@@ -203,6 +205,15 @@ ref=<branch>`
             metrics=["unused_jobs"],
         ),
         "failure_type": FailureType(values=["canceled", "failed", "skipped"]),
+        "minimum_number_of_failures": IntegerParameter(
+            name="Minimum number of failures before considering a job as failed",
+            help="Only count jobs whose most recent runs failed at least this many times in a row. Runs outside the "
+            "look-back period are ignored.",
+            default_value="1",
+            min_value="1",
+            unit=Unit.FAILURES,
+            metrics=["failed_jobs"],
+        ),
         "result_type": ResultType(values=["canceled", "failed", "skipped", "success"]),
         "jobs_to_ignore": MultipleChoiceWithAdditionParameter(
             name="Jobs to ignore (regular expressions or job names)",
@@ -352,6 +363,11 @@ ref=<branch>`
                 ),
                 EntityAttribute(
                     name="Date of most recent failed build", key="build_date", type=EntityAttributeType.DATE
+                ),
+                EntityAttribute(
+                    name="Number of consecutive failures",
+                    key="failure_count",
+                    type=EntityAttributeType.INTEGER,
                 ),
             ],
         ),

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,6 +14,7 @@ If your currently installed *Quality-time* version is not the penultimate versio
 
 ### Added
 
+- When using GitLab as source for the 'Failed CI-jobs' metric, jobs that failed only incidentally can be ignored with the new parameter 'Minimum number of failures before considering a job as failed'. Closes [#11975](https://github.com/ICTU/quality-time/issues/11975).
 - The password of the LDAP lookup user can be read from a file, using the `LDAP_LOOKUP_USER_PASSWORD_FILE` environment variable, so that the password does not have to be passed to the API-server as an environment variable. See the [deployment instructions](deployment.md#ldap).
 
 ### Changed


### PR DESCRIPTION
When using GitLab as source for the 'Failed CI-jobs' metric, jobs that failed only incidentally can be ignored with the new parameter 'Minimum number of failures before considering a job as failed'.

Closes #11975.